### PR TITLE
Fix integer overflow and format-string bugs in argus_filter.c

### DIFF
--- a/common/argus_filter.c
+++ b/common/argus_filter.c
@@ -1373,7 +1373,7 @@ find_closure(struct ablock *root)
     * Initialize sets to contain no nodes.
     */
    memset((char *)all_closure_sets, 0,
-         n_blocks * nodewords * sizeof(*all_closure_sets));
+         (size_t)n_blocks * (size_t)nodewords * sizeof(*all_closure_sets));
 
    /* root->level is the highest level no found. */
    for (i = root->level; i >= 0; --i) {
@@ -2885,8 +2885,8 @@ opt_init(struct ablock *root)
    nodewords = n_blocks / (8 * sizeof(nff_u_int32)) + 1;
 
    /* XXX */
-   space = (nff_u_int32 *)malloc(2 * n_blocks * nodewords * sizeof(*space)
-             + n_edges * edgewords * sizeof(*space));
+   space = (nff_u_int32 *)malloc((size_t)2 * (size_t)n_blocks * (size_t)nodewords * sizeof(*space)
+             + (size_t)n_edges * (size_t)edgewords * sizeof(*space));
    p = space;
    all_dom_sets = p;
    for (i = 0; i < n; ++i) {
@@ -3024,7 +3024,7 @@ convert_code_r(struct ablock *p)
 #endif
 
       if (!src->s.jt || !src->s.jf) {
-         ArgusLog(LOG_ERR, "no jmp destination %d, %d", ljerr, off);
+         ArgusLog(LOG_ERR, ljerr, "no jmp destination", off);
          /*NOTREACHED*/
       }
 
@@ -3032,7 +3032,7 @@ convert_code_r(struct ablock *p)
       for (i = 0; i < slen; i++) {
          if (offset[i] == src->s.jt) {
             if (jt) {
-               ArgusLog(LOG_ERR, "multiple matches %d, %d", ljerr, off);
+               ArgusLog(LOG_ERR, ljerr, "multiple matches", off);
                /*NOTREACHED*/
             }
 
@@ -3041,7 +3041,7 @@ convert_code_r(struct ablock *p)
          }
          if (offset[i] == src->s.jf) {
             if (jf) {
-               ArgusLog(LOG_ERR, "multiple matches %d, %d", ljerr, off);
+               ArgusLog(LOG_ERR, ljerr, "multiple matches", off);
                /*NOTREACHED*/
             }
             dst->jf = i - off - 1;
@@ -3049,7 +3049,7 @@ convert_code_r(struct ablock *p)
          }
       }
       if (!jt || !jf) {
-         ArgusLog(LOG_ERR, "no destination found %d, %d", ljerr, off);
+         ArgusLog(LOG_ERR, ljerr, "no destination found", off);
          /*NOTREACHED*/
       }
        }


### PR DESCRIPTION
Same two bug classes previously found and fixed in the sensor repo's copy of this file (openargus/argus, commit 99db891) -- this file shares direct lineage with that one but had diverged before the fix landed there.

1. Integer overflow before widening: n_blocks, nodewords, n_edges, edgewords are all 'int'. In find_closure() and opt_init(), size calculations like 'n_blocks * nodewords * sizeof(*space)' compute the multiplication in 32-bit int arithmetic first -- if the product overflows INT_MAX, it wraps before ever being widened to size_t for malloc()/memset(). Requires a pathologically complex compiled filter expression to trigger, since these counts are derived from filter-expression complexity, not attacker packet/record data -- but it's a real overflow-then-undersized-allocation risk given an adversarial filter string.

   Fixed by casting each operand to size_t before multiplying, so the full computation happens in (at least) size_t width throughout.

2. Wrong-type / misdirected format arguments in convert_code_r()'s block-local relative jump error handling (4 call sites):

   'ljerr' is a template string, "%s for block-local relative jump: off=%d", clearly designed to be used as the *format* argument to ArgusLog with a reason string and the offset substituted in. All 4 call sites instead used a literal message as the format string and passed ljerr itself (a char*) into a %d slot -- reinterpreting a pointer as an integer -- while the message's own %d showed the wrong value (ljerr's pointer, not off).

   Fixed all 4 sites to call ArgusLog(LOG_ERR, ljerr, "<reason>", off) as evidently intended.

Verified: clean configure/make rebuild, and a filter-compile smoke test across 7 filter expressions of varying complexity (simple single terms through nested boolean/parenthesized expressions covering tcp/udp/net/host/port), all compiling cleanly through Argusnff_optimize() (find_closure/opt_init/convert_code_r).