### PR TITLE
Fix critical memory-safety bugs in legacy v2 protocol and SASL handling

### DIFF
--- a/common/argus_auth.c
+++ b/common/argus_auth.c
@@ -488,7 +488,8 @@ RaSaslNegotiate(struct ArgusInput *input)
    if ((len = RaGetSaslString(in, buf, sizeof(buf))) == 0)
       ArgusLog (LOG_ERR, "RaSaslNegotiate: RaGetSaslString(0x%x, 0x%x, %d) error %s\n", in, buf, sizeof(buf), strerror(errno));
 
-   strcpy(mechs, buf);
+   strncpy(mechs, buf, sizeof(mechs) - 1);
+   mechs[sizeof(mechs) - 1] = '\0';
 
    if (RaSaslMech) {
    /* make sure that 'RaSaslMech' appears in 'buf' */

--- a/common/argus_client.c
+++ b/common/argus_client.c
@@ -1431,10 +1431,10 @@ ArgusGetServerSocket (struct ArgusInput *input, int timeout)
          if ((s = socket (AF_UNIX, SOCK_STREAM, 0)) >= 0) {
             server.sun_family = AF_UNIX;
            
-            if (input->filename != NULL) 
-               strcpy(server.sun_path, input->filename);
+            if (input->filename != NULL)
+               strncpy(server.sun_path, input->filename, sizeof(server.sun_path) - 1);
             else
-               strcpy(server.sun_path, ARGUS_SOCKET_PATH);
+               strncpy(server.sun_path, ARGUS_SOCKET_PATH, sizeof(server.sun_path) - 1);
 
             if ((retn = connect (s, (struct sockaddr *)&server, sizeof(struct sockaddr_un))) < 0) {
                close(s);

--- a/common/argus_code.c
+++ b/common/argus_code.c
@@ -821,8 +821,8 @@ Argusgen_dns(int v, int value, int dir)
    struct ArgusDnsQueryStruct *sdns = (struct ArgusDnsQueryStruct *) &argus.srate;
    struct ArgusDnsQueryStruct *ddns = (struct ArgusDnsQueryStruct *) &argus.drate;
 
-   int soffset = ((char *)&sdns - (char *)&argus);
-   int doffset = ((char *)&ddns - (char *)&argus);
+   int soffset = ((char *)sdns - (char *)&argus);
+   int doffset = ((char *)ddns - (char *)&argus);
 
    switch (dir) {
       case Q_SRC: {

--- a/common/argus_event.c
+++ b/common/argus_event.c
@@ -514,7 +514,7 @@ ArgusProcessSQLEvent (struct ArgusParserStruct *parser, struct ArgusEventObject 
    char *sptr, *hptr; 
    struct ArgusRecord *argus = NULL;
    char stim[128], etim[128];
-   struct timeval stvp, etvp;
+   struct timeval stvp = {0, 0}, etvp = {0, 0};
    extern char version[];
    int retn = 0, i, x, len;
    MYSQL_RES *mysqlRes;

--- a/common/argus_util.c
+++ b/common/argus_util.c
@@ -30374,7 +30374,7 @@ ArgusGenerateCanonRecord (struct ArgusRecordStruct *argus)
       bcopy ((char *)&argus->hdr, (char *)&canon->hdr, sizeof(canon->hdr));
    
       for (i = 0; i < ARGUSMAXDSRTYPE; i++) {
-         ind = (1 << i);
+         ind = (1U << i);
          switch (ind) {
             case ARGUS_FLOW_INDEX:
                if (argus->dsrindex & (0x1 << ARGUS_FLOW_INDEX))
@@ -30483,7 +30483,7 @@ ArgusConvertRecord (struct ArgusInput *input, char *ptr)
             dsr++;
 
             for (i = 0; i < 32; i++) {
-               ind = (1 << i);
+               ind = (1U << i);
                if (ArgusThisFarStatus & ind) {
                   switch (ind) {
                      case ARGUS_V2_FAR_DSR_STATUS: {
@@ -31516,8 +31516,16 @@ ArgusReadConnection (struct ArgusParserStruct *parser, struct ArgusInput *input,
 #endif
                               input->type = ARGUS_V2_DATA_SOURCE;
                               if ((argusid == ARGUS_V2_COOKIE) && (sequence == 0)) {
+                                 if (length < sizeof(argus2->ahdr) || length > sizeof(*argus2)) {
+                                    ArgusLog (LOG_ALERT, "ArgusReadConnection: invalid Argus-2.0 MAR length %d.", length);
+                                    close (input->fd);
+                                    input->fd = -1;
+                                    goto out;
+                                 }
+
+                                 {
                                  int size = length - sizeof(argus2->ahdr);
-                  
+
                                  if ((cnt = read (input->fd, &argus2->argus_mar, size)) != size) {
 #ifdef ARGUSDEBUG
                                     ArgusDebug (1, "ArgusReadConnection() read failed for ARGUS_START Mar %s.\n", strerror(errno));
@@ -31530,6 +31538,7 @@ ArgusReadConnection (struct ArgusParserStruct *parser, struct ArgusInput *input,
                                  input->offset += cnt;
                                  ptr = ArgusConvertRecord(input, (char *)argus2);
                                  bcopy ((char *) ptr, (char *)&input->ArgusInitCon, sizeof (*argus2));
+                                 }
 
                                  fstat(input->fd, &input->statbuf);
 #ifdef _LITTLE_ENDIAN
@@ -31755,8 +31764,16 @@ ArgusReadConnection (struct ArgusParserStruct *parser, struct ArgusInput *input,
 #endif
                                           input->type = ARGUS_V2_DATA_SOURCE;
                                           if ((argusid == ARGUS_V2_COOKIE) && (sequence == 0)) {
+                                             if (length < sizeof(argus2->ahdr) || length > sizeof(*argus2)) {
+                                                ArgusLog (LOG_ALERT, "ArgusReadConnection: invalid Argus-2.0 MAR length %d.", length);
+                                                close (input->fd);
+                                                input->fd = -1;
+                                                goto out;
+                                             }
+
+                                             {
                                              int size = length - sizeof(argus2->ahdr);
-                              
+
                                              if ((cnt = read (input->fd, &argus2->argus_mar, size)) != size) {
 #ifdef ARGUSDEBUG
                                                 ArgusDebug (1, "ArgusReadConnection() read failed for ARGUS_START Mar %s.\n", strerror(errno));
@@ -31769,6 +31786,7 @@ ArgusReadConnection (struct ArgusParserStruct *parser, struct ArgusInput *input,
                                              input->offset += cnt;
                                              ptr = ArgusConvertRecord(input, (char *)argus2);
                                              bcopy ((char *) ptr, (char *)&input->ArgusInitCon, sizeof (*argus2));
+                                             }
 
                                              fstat(input->fd, &input->statbuf);
 #ifdef _LITTLE_ENDIAN
@@ -33345,7 +33363,13 @@ setArgusID(struct ArgusAddrStruct *srcid, void *ptr, int len, unsigned int type)
       int offset                   = 0;
 
       switch (type & ~ARGUS_TYPE_INTERFACE) {
-         case ARGUS_TYPE_STRING: bcopy((char *)ptr, &srcid->a_un.str, 4); break;
+         case ARGUS_TYPE_STRING: {
+            int slen = (len < 4) ? len : 4;
+            bzero(&srcid->a_un.str, sizeof(srcid->a_un.str));
+            if (slen > 0)
+               bcopy((char *)ptr, &srcid->a_un.str, slen);
+            break;
+         }
          case ARGUS_TYPE_INT:    srcid->a_un.value = atoi((char *)ptr); offset = sizeof(unsigned int); break;
          case ARGUS_TYPE_IPV4:   srcid->a_un.ipv4 = ntohl(*(unsigned int *)ptr); offset = sizeof(unsigned int); break;
          case ARGUS_TYPE_IPV6:   bcopy((char *)ptr, &srcid->a_un.ipv6, 16); offset = sizeof(srcid->a_un.ipv6); break;
@@ -34265,10 +34289,15 @@ ArgusIndexV2Record (struct ArgusV2Record *argus, struct ArgusV2FarHeaderStruct *
 {
    unsigned int retn = 0;
    struct ArgusV2FarHeaderStruct *far = (struct ArgusV2FarHeaderStruct *) &argus->argus_far;
-   unsigned int length = argus->ahdr.length - sizeof(argus->ahdr);
+   unsigned int length;
    unsigned int farlen;
- 
+
    bzero ((char *) hdrs, 32 * sizeof(struct ArgusFarHeaderStruct *));
+
+   if (argus->ahdr.length < sizeof(argus->ahdr))
+      return (retn);
+
+   length = argus->ahdr.length - sizeof(argus->ahdr);
 
    if (argus->ahdr.type & ARGUS_V2_FAR) {
       while ((length > 0) && (far->length > 0) && (length >= far->length)) {


### PR DESCRIPTION
Fixes several security issues found during a manual security review of the common/ and clients/ directories (Phase 1), verified with static analysis (cppcheck, flawfinder, semgrep) plus manual reachability tracing and live exploitation tests.

Critical, remotely-reachable findings (F-CL-1, F-CL-2, F-CL-7):

- ArgusReadConnection() (argus_util.c, two call sites): the legacy Argus v2 MAR/START handshake read the attacker-controlled 16-bit `length` field with no lower-bound check before computing `size = length - sizeof(ahdr)`. A remote peer sending length < 16 underflows `size` to a negative int, which is then passed to read() as an implicitly-converted, enormous size_t with no upper bound at all -- a remotely-triggerable stack buffer overflow on the very first bytes exchanged with a peer. Fixed by validating `length >= sizeof(ahdr) && length <= sizeof(*argus2)` before the subtraction, closing the connection and logging an alert if invalid. Verified via a live crafted-TCP-server test: pre-fix, the malformed handshake reaches the unguarded read(); post-fix, the client logs "invalid Argus-2.0 MAR length N" and exits cleanly.

- ArgusIndexV2Record() (argus_util.c): same underlying bug -- v2 FAR (flow) records also read `ahdr.length` with no lower bound, but the subtraction result is stored in an *unsigned* int, wrapping to ~4 billion and causing the FAR-header-walking loop to advance a pointer arbitrarily far out of bounds on every malformed FAR record (i.e. ongoing, not just at handshake time). Fixed by returning early if `ahdr.length < sizeof(ahdr)`. Verified end-to-end: a crafted FAR record with length=5 sent after a valid handshake is now safely ignored (empty/placeholder record printed) instead of walking off the end of the buffer.

- RaSaslNegotiate() (argus_auth.c): the server's SASL mechanism list is read into an 8192-byte buffer, then strcpy()'d unbounded into a 1024-byte destination -- a remotely-triggerable stack overflow reachable during unauthenticated SASL capability negotiation, before any credentials are exchanged. Fixed with a bounded strncpy() plus explicit null-termination. Verified with a standalone AddressSanitizer repro: the original strcpy reliably reports stack-buffer-overflow when the source is filled to its 8191-byte max; the fixed version is ASan-clean.

Lower-severity / local-only / dead-code findings, fixed for defense-in-depth:

- argus_client.c: unbounded strcpy() into sockaddr_un.sun_path changed to bounded strncpy() (operator/CLI-controlled path, not remote-reachable, but no length check existed at all).
- argus_util.c: two `1 << 31` undefined-behavior left-shifts (for ARGUS_V2_AGR_DSR_STATUS = 0x80000000) changed to `1U << i`.
- argus_util.c: setArgusID() ignored the caller-supplied `len` for ARGUS_TYPE_STRING, always copying 4 bytes regardless of the actual source buffer size; now honors `len` and zero-pads. Currently dead code repo-wide (no callers), fixed as defense-in-depth for future callers.
- argus_code.c: Argusgen_dns() (dead code, no current callers) took the address of local pointer variables instead of using the pointer values themselves in an offset calculation, producing meaningless results; fixed for correctness.
- argus_event.c: ArgusProcessSQLEvent()'s stvp/etvp struct timeval locals had tv_usec left uninitialized on one code path before being formatted for a log/debug string; now zero-initialized at declaration.

All fixes verified with a full clean rebuild (./configure && make -j4, zero new warnings) plus targeted live/ASan tests described above.