### PR TITLE
Fix label/auth buffer overflows, ramanage shell/TOCTOU issues, and de…

### DIFF
--- a/clients/rabins.c
+++ b/clients/rabins.c
@@ -1121,7 +1121,7 @@ ArgusPrintFormat(struct ArgusParserStruct *parser, char *buf, struct ArgusRecord
             double ltime = ArgusFetchLastuSecTime(argus)/1000;
             long long sdate = stime, ldate = ltime;
             char *rank, *node, *proto, *saddr, *daddr, *dport, *synack;
-            char buf[1024], str[256];
+            char buf[2048], str[256];
 
             ArgusPrintRank(parser, str, argus, 32);
             rank = strdup(ArgusTrimString(str));
@@ -1144,7 +1144,7 @@ ArgusPrintFormat(struct ArgusParserStruct *parser, char *buf, struct ArgusRecord
             ArgusPrintSourceID(parser, str, argus, 256);
             node = strdup(ArgusTrimString(str));
 
-            sprintf(buf, "{\"rank\":\"%s\",\"node\":\"%s\",\"stime\":new Date(%lld),\"ltime\":new Date(%lld),\"proto\":\"%s\",\"saddr\":\"%s\",\"daddr\":\"%s\",\"dport\":\"%s\",\"synack\":\"%s\"},", rank, node, sdate, ldate, proto, saddr, daddr, dport, synack);
+            snprintf(buf, sizeof(buf), "{\"rank\":\"%s\",\"node\":\"%s\",\"stime\":new Date(%lld),\"ltime\":new Date(%lld),\"proto\":\"%s\",\"saddr\":\"%s\",\"daddr\":\"%s\",\"dport\":\"%s\",\"synack\":\"%s\"},", rank, node, sdate, ldate, proto, saddr, daddr, dport, synack);
             fprintf(stdout, "%s", buf);
             fflush(stdout);
             break;

--- a/clients/racluster.c
+++ b/clients/racluster.c
@@ -381,16 +381,24 @@ RaParseComplete (int sig)
             if (ArgusParser->ArgusReplaceMode & ARGUS_REPLACE_COMPRESSED_GZ) {
                char cmdbuf[MAXSTRLEN], *cmd = cmdbuf;
 
-               sprintf(cmd, "gzip -q %s\n", file->filename);
-               if (system(cmd) < 0)
-                  ArgusLog (LOG_ERR, "compressing file %s failed");
+               if (strchr(file->filename, '\'') != NULL) {
+                  ArgusLog (LOG_ERR, "compressing file %s failed: filename contains a single quote", file->filename);
+               } else {
+                  snprintf(cmd, MAXSTRLEN, "gzip -q '%s'\n", file->filename);
+                  if (system(cmd) < 0)
+                     ArgusLog (LOG_ERR, "compressing file %s failed");
+               }
             } else
             if (ArgusParser->ArgusReplaceMode & ARGUS_REPLACE_COMPRESSED_BZ) {
                char cmdbuf[MAXSTRLEN], *cmd = cmdbuf;
 
-               sprintf(cmd, "bzip2 -f -q %s\n", file->filename);
-               if (system(cmd) < 0)
-                  ArgusLog (LOG_ERR, "compressing file %s failed");
+               if (strchr(file->filename, '\'') != NULL) {
+                  ArgusLog (LOG_ERR, "compressing file %s failed: filename contains a single quote", file->filename);
+               } else {
+                  snprintf(cmd, MAXSTRLEN, "bzip2 -f -q '%s'\n", file->filename);
+                  if (system(cmd) < 0)
+                     ArgusLog (LOG_ERR, "compressing file %s failed");
+               }
             }
          }
 

--- a/clients/ramanage.c
+++ b/clients/ramanage.c
@@ -42,6 +42,7 @@
 #include <utime.h>
 #include <libgen.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #ifdef HAVE_ZLIB_H
 #include <zlib.h>
@@ -652,6 +653,56 @@ __shell_escape(const char * const str)
 
    return newstr;
 }
+
+/* Escape characters that retain special meaning inside a double-quoted
+ * bourne shell string: backslash, double-quote, backtick (command
+ * substitution), and dollar sign (variable/command substitution). This is
+ * distinct from __shell_escape(), which is meant for use in an *unquoted*
+ * shell word and does not neutralize these characters when the resulting
+ * string is subsequently placed inside double quotes (e.g. "-T \"%s\"").
+ * Caller is responsible for freeing memory (with free(), not ArgusFree()).
+ */
+static int
+__is_dquote_metacharacter(char c)
+{
+   return (c == '\\' || c == '"' || c == '`' || c == '$');
+}
+
+static char *
+__shell_escape_dquote(const char * const str)
+{
+   size_t metacount = 0;
+   size_t orig_strlen = strlen(str);
+   size_t i = 0;
+   char *newstr;
+   char *tmp;
+
+   while (*(str+i) != 0) {
+      if (__is_dquote_metacharacter(*(str+i)))
+         metacount++;
+      i++;
+   }
+
+   if (metacount == 0) {
+      newstr = strdup(str);
+      if (newstr == NULL)
+         ArgusLog(LOG_ERR, "%s: failed to duplicate string\n", __func__);
+      return newstr;
+   }
+
+   newstr = malloc(orig_strlen + metacount + 1);
+   if (newstr == NULL)
+      ArgusLog(LOG_ERR, "%s: failed to allocate new string\n", __func__);
+
+   for (i = 0, tmp = newstr; i < orig_strlen; i++) {
+      if (__is_dquote_metacharacter(*(str+i)))
+         *tmp++ = '\\';
+      *tmp++ = *(str+i);
+   }
+   *tmp = 0;
+
+   return newstr;
+}
 #endif /* ARGUS_CURLEXE */
 
 static inline int
@@ -768,10 +819,19 @@ __parse_network_address(const char * const src, struct sockaddr_storage *dst)
 }
 
 #ifdef HAVE_ZLIB_H
-/* __gzip() returns 0 on success, -1 otherwise. */
+/* __gzip() returns 0 on success, -1 otherwise.
+ *
+ * The destination file is created here (rather than by the caller) using
+ * O_CREAT|O_EXCL|O_NOFOLLOW, and its ownership/permissions are set via
+ * fchown()/fchmod() on the open file descriptor before gzclose(), so that
+ * there is no window between file creation and permission/ownership
+ * assignment during which a symlink-swap or file-swap race could redirect
+ * later by-path chmod()/chown() calls to an attacker-controlled target.
+ */
 static int
 __gzip(const char * const filename, const char * const gzfilename,
-       off_t filesz, unsigned char *buf, size_t buflen)
+       off_t filesz, unsigned char *buf, size_t buflen,
+       mode_t mode, uid_t uid, gid_t gid)
 {
    gzFile gzfp;
    FILE *fp;
@@ -780,6 +840,7 @@ __gzip(const char * const filename, const char * const gzfilename,
    int gzerr;
    unsigned char hdr[3];
    int magicbytes;
+   int gzfd;
 
    fp = fopen(filename, "rb");
    if (fp == NULL) {
@@ -798,9 +859,24 @@ __gzip(const char * const filename, const char * const gzfilename,
    }
    rewind(fp);
 
-   gzfp = gzopen(gzfilename,"wb");
+   gzfd = open(gzfilename, O_CREAT|O_EXCL|O_NOFOLLOW|O_WRONLY, 0600);
+   if (gzfd < 0) {
+      ArgusLog(LOG_WARNING, "unable to open file %s\n", gzfilename);
+      fclose(fp);
+      return -1;
+   }
+
+   if (fchown(gzfd, uid, gid) < 0)
+      ArgusLog(LOG_WARNING, "failed to update ownership of file %s\n",
+               gzfilename);
+   if (fchmod(gzfd, mode) < 0)
+      ArgusLog(LOG_WARNING, "failed to update permissions on file %s\n",
+               gzfilename);
+
+   gzfp = gzdopen(gzfd, "wb");
    if (gzfp == NULL) {
       ArgusLog(LOG_WARNING, "unable to open file %s\n", gzfilename);
+      close(gzfd);
       fclose(fp);
       return -1;
    }
@@ -1198,7 +1274,7 @@ __upload(CURL *hnd, const char * const filename, off_t filesz,
    char *winpath = ArgusCygwinConvPath2Win(filename);
 # else
 #ifdef ARGUS_CURLEXE
-   char *escaped = __shell_escape(filename);
+   char *escaped = __shell_escape_dquote(filename);
 # else
    char *escaped = NULL;
 #endif
@@ -1525,7 +1601,8 @@ RamanageCompress(const struct ArgusParserStruct * const parser,
          DEBUGLOG(4, "compress file %s -> %s\n", file->filename, gzfilename);
 
          gzerr = __gzip(file->filename, gzfilename, file->statbuf.st_size,
-                        buf, buflen);
+                        buf, buflen, file->statbuf.st_mode,
+                        file->statbuf.st_uid, file->statbuf.st_gid);
 
          if (gzerr) {
             i++;
@@ -1535,8 +1612,10 @@ RamanageCompress(const struct ArgusParserStruct * const parser,
          compress_kb += file->statbuf.st_size / 1024;
 
          /* Make the new gzip file's attributes look like those of the
-          * original file.  Copy timestamps, ownerhip and permissions
-          * to the new file.  Then remove the original, uncompressed,
+          * original file.  Ownership and permissions were already applied,
+          * on the open file descriptor, inside __gzip() to avoid a
+          * TOCTOU race between file creation and attribute assignment.
+          * Copy timestamps here, then remove the original, uncompressed,
           * file and update the filename and attributes in the linked
           * list so that subsequent ramanage commands operate on the
           * gzip file.
@@ -1546,12 +1625,6 @@ RamanageCompress(const struct ArgusParserStruct * const parser,
          ut.modtime = file->statbuf.st_mtime;
          if (utime(gzfilename, &ut) < 0)
             ArgusLog(LOG_WARNING, "failed to update timestamp on file %s\n",
-                     gzfilename);
-         if (chmod(gzfilename, file->statbuf.st_mode) < 0)
-            ArgusLog(LOG_WARNING,
-                     "failed to update permissions on file %s\n", gzfilename);
-         if (chown(gzfilename, file->statbuf.st_uid, file->statbuf.st_gid) < 0)
-            ArgusLog(LOG_WARNING, "failed to update ownership of file %s\n",
                      gzfilename);
          origfilename = file->filename;
          file->filename = strdup(gzfilename);

--- a/clients/rasort.c
+++ b/clients/rasort.c
@@ -248,16 +248,24 @@ RaParseComplete (int sig)
          if (ArgusParser->ArgusReplaceMode & ARGUS_REPLACE_COMPRESSED_GZ) {
             char cmdbuf[MAXSTRLEN], *cmd = cmdbuf;
 
-            sprintf(cmd, "gzip -q %s\n", file->filename);
-            if (system(cmd) < 0)
-               ArgusLog (LOG_ERR, "compressing file %s failed");
+            if (strchr(file->filename, '\'') != NULL) {
+               ArgusLog (LOG_ERR, "compressing file %s failed: filename contains a single quote", file->filename);
+            } else {
+               snprintf(cmd, MAXSTRLEN, "gzip -q '%s'\n", file->filename);
+               if (system(cmd) < 0)
+                  ArgusLog (LOG_ERR, "compressing file %s failed");
+            }
          } else
          if (ArgusParser->ArgusReplaceMode & ARGUS_REPLACE_COMPRESSED_BZ) {
             char cmdbuf[MAXSTRLEN], *cmd = cmdbuf;
 
-            sprintf(cmd, "bzip2 -f -q %s\n", file->filename);
-            if (system(cmd) < 0)
-               ArgusLog (LOG_ERR, "compressing file %s failed");
+            if (strchr(file->filename, '\'') != NULL) {
+               ArgusLog (LOG_ERR, "compressing file %s failed: filename contains a single quote", file->filename);
+            } else {
+               snprintf(cmd, MAXSTRLEN, "bzip2 -f -q '%s'\n", file->filename);
+               if (system(cmd) < 0)
+                  ArgusLog (LOG_ERR, "compressing file %s failed");
+            }
          }
       }
 

--- a/common/argus_auth.c
+++ b/common/argus_auth.c
@@ -377,7 +377,7 @@ RaSimple(void *context __attribute__((unused)), int id, const char **result, uns
             if ((ptr = strchr(ArgusParser->ustr, '/')) != NULL)
                 *ptr = '\0';
           
-            sprintf (RaSimpleBuf, "%s", ArgusParser->ustr);
+            snprintf (RaSimpleBuf, sizeof(RaSimpleBuf), "%s", ArgusParser->ustr);
             if (ptr)
                *ptr = '/';
 #ifdef ARGUSDEBUG
@@ -399,7 +399,7 @@ RaSimple(void *context __attribute__((unused)), int id, const char **result, uns
             printf("Authname: ");
             ptr = fgets(RaSimpleBuf, sizeof RaSimpleBuf, stdin);
          } else 
-            sprintf (RaSimpleBuf, "%s", ptr);
+            snprintf (RaSimpleBuf, sizeof(RaSimpleBuf), "%s", ptr);
 #ifdef ARGUSDEBUG
          ArgusDebug (4, "RaSimple SASL_CB_AUTHNAME is %s", RaSimpleBuf);
 #endif
@@ -506,8 +506,10 @@ RaSaslNegotiate(struct ArgusInput *input)
 
    len = 0; data = "";
 
-   if (RaSaslMech)
-      strcpy(mechs, RaSaslMech);
+   if (RaSaslMech) {
+      strncpy(mechs, RaSaslMech, sizeof(mechs) - 1);
+      mechs[sizeof(mechs) - 1] = '\0';
+   }
 
    retn = sasl_client_start(conn, mechs, NULL, &data, &len, &chosenmech);
 

--- a/common/argus_label.c
+++ b/common/argus_label.c
@@ -3475,7 +3475,7 @@ RaReadPortConfig (struct ArgusParserStruct *parser, struct ArgusLabelerStruct *l
 
                                     if (!found) {
                                        snprintf (tbuf, MAXSTRLEN, "%s", tlabel);
-                                       sprintf(&tbuf[strlen(tbuf)], ":%s", plabel);
+                                       snprintf (&tbuf[strlen(tbuf)], MAXSTRLEN - strlen(tbuf), ":%s", plabel);
                                        port->label = strdup(tbuf);
                                     } else
                                        port->label = strdup(tlabel);


### PR DESCRIPTION
…fense-in-depth hardening

This addresses findings F-CL-12 through F-CL-17 from the Phase 1 security review (common/ + clients/), continuing on from the fixes merged in #21 (F-CL-1/2/3/4/5/6/7/10).

Confirmed, exploitable issues (verified with ASan repros):

* F-CL-12: common/argus_label.c, RaReadPortConfig() — unbounded sprintf() concatenating IANA port labels into a fixed 4096-byte buffer while parsing a RALABEL_IANA_PORT_FILE labeler config file. Two config lines assigning distinct multi-KB labels to the same port number overflow the buffer. Fixed with a properly bounded snprintf(). Local config-file trust boundary only.

* F-CL-13: common/argus_auth.c — unbounded sprintf()/strcpy() from CLI-controlled strings: RaSimple()'s two SASL_CB_USER/AUTHNAME callback sites copy ArgusParser->ustr (from a -U-style CLI arg) into a fixed RaSimpleBuf without a bound, and RaSaslNegotiate() strcpy()s RaSaslMech (from a saslmech= connection-string option) into a fixed mechs buffer. Fixed with snprintf()/strncpy()+NUL-termination, matching the pattern already applied to the adjacent SASL mechanism-list site fixed as F-CL-7 in #21. Local CLI trust boundary only.

* F-CL-17: clients/ramanage.c, RamanageCompress()/__gzip() — TOCTOU race between creating the compressed archive file and chmod()/chown()-ing it *by path* to match the original file's mode/owner. A local attacker with write access to the managed archive directory could swap the path for a symlink between file creation and the chmod/chown calls, causing ramanage's privileges to retarget an attacker-chosen file. Fixed by having __gzip() create the file itself with O_CREAT|O_EXCL|O_NOFOLLOW and set ownership/permissions via fchown()/fchmod() on the open descriptor before gzclose(), eliminating the race window entirely; removed the now-redundant by-path chmod/chown calls at the call site. Verified with a standalone repro (normal creation applies correct mode; pre-staged symlink at the target path correctly causes open() to fail with EEXIST rather than following it).

* F-CL-14: clients/ramanage.c, __shell_escape() — escaping bypass allowing shell injection via backtick or $(...)/${IFS} inside the double-quoted curl command line built by __upload(). __shell_escape() only escapes metacharacters that are dangerous in an *unquoted* shell word; it does not escape backtick or $, which remain dangerous inside double quotes. Added a new __shell_escape_dquote() (escapes \, ", `, $) and switched the filename call site to use it. Verified a working backtick/${IFS} injection payload pre-fix and confirmed neutralization post-fix. Only reachable when built with the non-default --with-curlexe option (confirmed via nm that the affected symbols aren't present in the default HAVE_LIBCURL build); local-file trust boundary regardless.

Defense-in-depth hardening for currently-unreachable dead code (no exploit demonstrated, fixed to pre-empt future reachability):

* F-CL-15: clients/racluster.c, clients/rasort.c — unbounded sprintf() and fully unescaped system() call building "gzip -q %s"/"bzip2 -f -q %s" from file->filename in the ARGUS_REPLACE_COMPRESSED_GZ/_BZ replace-mode branch. Confirmed via repo-wide grep that no CLI mode-string parsing ever sets these two ArgusReplaceMode bits today, so this branch is unreachable. Bounded the sprintf() with snprintf(), single-quoted the filename in the shell command, and added a check that rejects (logs and skips) any filename containing an embedded single quote rather than attempting full shell-escaping. examples/ramatrix.c has the identical pattern and is deferred to the Phase 2 review pass.

* F-CL-16: clients/rabins.c, ArgusPrintFormat() — the ARGUS_JSON_OUTPUT case builds a JSON string from six independently-256-byte-bounded fields (plus a 32-byte rank) into a 1024-byte buffer; worst case (~1708 bytes, e.g. long DNS-PTR-resolved hostnames in saddr/daddr/node) overflows it. Confirmed via ASan that this is a real overflow when triggered, but ArgusPrintFormat() is never called from anywhere in the codebase today. Increased the buffer to 2048 bytes and changed sprintf() to snprintf() as a hard backstop. Flagged because, unlike most other dead-code findings in this review, the overflow would be network-influenced (via DNS PTR records) if this function is ever wired up to a future CLI output option.

All changes verified with a full clean rebuild (make clean && ./configure && make -j4): zero errors, zero new warnings (only the 29 pre-existing unrelated linker alignment warnings).

See argus-clients-security-review.2026.09.03/findings-log.md for full write-ups (F-CL-12 through F-CL-17).