### PR TITLE
Fix unescaped shell command construction in rastream.c (F-CL-18)

### DIFF
--- a/clients/rastream.c
+++ b/clients/rastream.c
@@ -204,7 +204,6 @@ RastreamProcessFileRetryList(void)
    FILE *pipe;
    struct RastreamFileMap *file = RastreamRetryListHead;
    char *cmd, path[PATH_MAX];
-   static const char * const fmt = "ra -X -Mlock -r %s -w %s";
    int rv = 1;
 
    cmd = ArgusMalloc(2*PATH_MAX);
@@ -218,7 +217,17 @@ RastreamProcessFileRetryList(void)
       if (file->filename == NULL)
          goto next;
 
-      slen = snprintf(cmd, 2*PATH_MAX, fmt, file->filename, file->filename_orig);
+      if ((strchr(file->filename, '\'') != NULL) ||
+          (strchr(file->filename_orig, '\'') != NULL)) {
+         ArgusLog(LOG_WARNING,
+                  "%s: filename contains a single quote, skipping: %s\n",
+                  __func__, file->filename);
+         file->nodelete = 1;
+         goto next;
+      }
+
+      slen = snprintf(cmd, 2*PATH_MAX, "ra -X -Mlock -r '%s' -w '%s'",
+                       file->filename, file->filename_orig);
       if (slen >= 2*PATH_MAX) {
          ArgusLog(LOG_WARNING, "%s command too long: skipping %s\n",
                   file->filename);
@@ -1767,7 +1776,17 @@ ArgusRunFileScript (struct ArgusParserStruct *parser, struct ArgusWfileStruct *f
       for (i = 0; i < 4; i++) {
          if (script->args[i] != NULL) {
             int slen = strlen(sbuf);
-            snprintf (&sbuf[slen], 1024 - slen, " %s", script->args[i]);
+            if (strchr(script->args[i], '\'') != NULL) {
+               ArgusLog(LOG_WARNING,
+                        "ArgusRunFileScript: argument contains a single "
+                        "quote, refusing to run script for file %s\n",
+                        file->filename);
+               free(script->filename);
+               free(script->script);
+               ArgusFree(script);
+               return (retn);
+            }
+            snprintf (&sbuf[slen], 1024 - slen, " '%s'", script->args[i]);
          }
       }
 


### PR DESCRIPTION
rastream.c has two places that build a shell command line by directly interpolating filenames (no escaping or quoting at all) and then execute it via popen()/system():

* RastreamProcessFileRetryList() (run at exit/signal-handling time) embeds the locked-file-retry temp filename and the original -w output filename into a "ra -X -Mlock -r %s -w %s" command run via popen().

* ArgusRunFileScript() (invoked when -F <script> is used) embeds the script path and the just-closed output filename into a "<script> -r <filename>" command run via system().

Both are live, reachable code paths through normal, documented rastream usage (-w with file locking enabled for the first; -F for the second) -- unlike most of the shell-injection-class findings from this review (F-CL-14, F-CL-15), which were confirmed unreachable dead code. The output filename in both cases can be influenced by a -w template's $field substitution, which pulls live flow-record content.

Verified with a standalone repro that an embedded backtick in a filename executes arbitrary commands via command substitution when interpolated unescaped into these command strings.

Fixed both sites by single-quoting each filename/argument in the constructed command and rejecting (with a logged warning, and no popen()/system() call) any filename/argument containing an embedded single quote, which would otherwise break out of the added quoting -- the same defense-in-depth pattern already used for F-CL-15. Also removed the now-unused fmt format-string variable in
RastreamProcessFileRetryList() and fixed a small memory leak in the new early-return path in ArgusRunFileScript() (freeing script->filename/ script->script before freeing the script struct itself).

Verified: standalone repro confirms the previous backtick-substitution payload is neutralized post-fix while normal filenames continue to work unchanged. Full clean rebuild (make clean && ./configure && make -j4): zero errors, zero new warnings (only the 29 pre-existing unrelated linker alignment warnings).

See argus-clients-security-review.2026.09.03/findings-log.md for the full F-CL-18 write-up.