### PR TITLE
Fix cppcheck warning-severity findings: uninitialized reads, negative…

### DIFF
--- a/clients/racluster.c
+++ b/clients/racluster.c
@@ -291,7 +291,7 @@ RaParseComplete (int sig)
             int cnt;
 
             if ((cnt = agg->queue->count) > 0) {
-               struct ArgusRecordStruct *argus;
+               struct ArgusRecordStruct *argus = NULL;
 
                if (!(ArgusSorter))
                   if ((ArgusSorter = ArgusNewSorter(ArgusParser)) == NULL)

--- a/common/argus_output.c
+++ b/common/argus_output.c
@@ -5645,7 +5645,7 @@ int
 ArgusSendSaslString(FILE *f, const char *s, int l, int mode)
 {
    char *buf = NULL, *ptr = NULL, error[128];
-   unsigned int al, len;
+   unsigned int al, len = 0;
    int result, size, tsize;
 
    switch (mode) {

--- a/common/argus_util.c
+++ b/common/argus_util.c
@@ -3211,14 +3211,15 @@ ArgusParseWiresharkManufEntry (struct ArgusParserStruct *parser, char *str)
          switch (state) {
                         case RA_READING_ETHER_PART: {
                            char *sptr, *tptr = optarg;
-                           int result, cnt = 0;
+                           unsigned int result;
+                           int cnt = 0;
 
                            addr = 0;
                            bzero(eaddr, sizeof(eaddr));
 
                            if ((sptr = strchr(optarg, '/')) != NULL) {  // if masklen, then terminate and store
                               *sptr++ = '\0';
-                              if (sscanf (sptr, "%d", &result) == 1) {
+                              if (sscanf (sptr, "%u", &result) == 1) {
                                  masklen = result;
                               }
                            }
@@ -25872,7 +25873,7 @@ ArgusPrintTime(struct ArgusParserStruct *parser, char *buf, size_t buflen,
                   if (strstr(sbuf, "0000")) {
                      sprintf (sbuf, "Z");
                   } else {
-                     if ((slen = strlen(sbuf)) > 0) {
+                     if ((slen = strlen(sbuf)) > 2) {
                         for (i = 0; i < 2; i++)
                            sbuf[slen - i] = sbuf[slen - (i + 1)];
                         sbuf[slen - 2] = ':';


### PR DESCRIPTION
… index

Closes out the warning-severity (328 findings) triage pass of the Phase 1 security review over common/ and clients/. Three genuine bugs found and fixed, plus one trivial signed/unsigned correctness fix; the remaining ~324 findings were confirmed false positives or purely cosmetic (see findings-log.md for full per-category triage).

- clients/racluster.c: RaParseComplete() left a local `struct ArgusRecordStruct *argus` uninitialized. If ArgusPopQueue() unexpectedly returns NULL on the very first loop iteration despite queue->count > 0, the uninitialized pointer would be passed to ArgusMergeRecords() and stored into ArgusParser->ns. Initialize to NULL to match the defensive-NULL-check pattern used elsewhere.

- common/argus_output.c: ArgusSendSaslString()'s `len` was only set inside the SASL_OK success branch but unconditionally returned. Harmless in practice (all 4 call sites ignore the return value, confirmed by inspection) but technically an uninitialized read. Initialize to 0.

- common/argus_util.c (ArgusPrintTime): the %z timezone-offset colon-insertion logic guarded on `slen > 0`, but computes sbuf[slen - 2], which underflows to a negative index when strftime("%z") returns a 1-character non-"0000" string. Tightened the guard to `slen > 2`.

- common/argus_util.c (ArgusParseWiresharkManufEntry): `result` was declared `int` but read via sscanf's "%x"/"%d" conversions expecting unsigned int*, undefined behavior per the C standard even though harmless on all real-world platforms (identical int/unsigned representation). Changed to `unsigned int` and the masklen sscanf format to "%u" for consistency. Local wireshark-manuf-file config parsing only, not attacker-reachable.

Full clean rebuild (make clean && ./configure && make -j4): zero errors, only the 29 pre-existing unrelated linker alignment warnings.

Also documents the full cppcheck warning-severity (328) and style-severity (1702, explicitly deferred as out-of-scope) triage in findings-log.md, closing out the cppcheck portion of the Phase 1 static-analysis sweep.