### PR TITLE
Fix Phase 2 security findings: shell injection, DNS parsing, MySQL co…

### DIFF
--- a/examples/raconvert/raconvert.c
+++ b/examples/raconvert/raconvert.c
@@ -86,6 +86,7 @@
 
 #include <ctype.h>
 #include <strings.h>
+#include <limits.h>
 
 #if defined(ARGUS_SOLARIS)
 #include <string.h>
@@ -840,12 +841,13 @@ RaConvertReadFile (struct ArgusParserStruct *parser, struct ArgusInput *input)
           (!(strncmp("-z",  &file[strlen(file) - 2], 2))) ||
           (!(strncmp("_z",  &file[strlen(file) - 2], 2))) ||
           (!(strncmp(".Z",  &file[strlen(file) - 2], 2)))) {
-         char cmd[256];
-         bzero(cmd, 256); 
-         strncpy(cmd, "gzip -dc ", 10);
+         char cmd[2 * PATH_MAX];
 
-         strncat(cmd, input->filename, (256 - strlen(cmd)));
-         strncat(cmd, " 2>/dev/null", (256 - strlen(cmd)));
+         if (strchr(input->filename, '\'') != NULL) {
+            ArgusLog (LOG_ERR, "ArgusReadConnection: filename contains a single quote: %s", input->filename);
+         }
+
+         snprintf(cmd, sizeof(cmd), "gzip -dc '%s' 2>/dev/null", input->filename);
 
          if ((input->pipe = popen(cmd, "r")) == NULL)
             ArgusLog (LOG_ERR, "ArgusReadConnection: popen(%s) failed. %s", cmd, strerror(errno));
@@ -857,12 +859,13 @@ RaConvertReadFile (struct ArgusParserStruct *parser, struct ArgusInput *input)
       } else       
       if ((!(strncmp(".bz2", &file[strlen(file) - 4], 4))) ||
           (!(strncmp(".bz",  &file[strlen(file) - 3], 3)))) {
-         char cmd[256];
-         bzero(cmd, 256);
-         strncpy(cmd, "bzip2 -dc ", 11);
+         char cmd[2 * PATH_MAX];
 
-         strncat(cmd, input->filename, (256 - strlen(cmd)));
-         strncat(cmd, " 2>/dev/null", (256 - strlen(cmd)));
+         if (strchr(input->filename, '\'') != NULL) {
+            ArgusLog (LOG_ERR, "ArgusReadConnection: filename contains a single quote: %s", input->filename);
+         }
+
+         snprintf(cmd, sizeof(cmd), "bzip2 -dc '%s' 2>/dev/null", input->filename);
 
          if ((input->pipe = popen(cmd, "r")) == NULL)
             ArgusLog (LOG_ERR, "ArgusReadConnection: popen(%s) failed. %s", cmd, strerror(errno));

--- a/examples/radns/radns.c
+++ b/examples/radns/radns.c
@@ -239,10 +239,10 @@ ArgusPrintAddressResponse(char *string, struct RaAddressStruct *raddr, char ***r
                   tdns = raddr->dns->start;
                   if (ArgusParser->ArgusPrintJson) {
                      char *buf = ", \"auth\":";
-                     sprintf (&resbuf[len], "%s", buf);
+                     snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "%s", buf);
                      len += strlen(buf);
                   } else {
-                     sprintf (&resbuf[len], "%s", "A: ");
+                     snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "%s", "A: ");
                      len += 3;
                   }
 
@@ -275,8 +275,10 @@ ArgusPrintAddressResponse(char *string, struct RaAddressStruct *raddr, char ***r
                      tdns = tdns->nxt;
                   }
 
-                  if (auth > 1)
-                     sprintf (&resbuf[len++], "]");
+                  if (auth > 1) {
+                     snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "]");
+                     len++;
+                  }
                }
 
                if (refer > 0) {
@@ -296,8 +298,10 @@ ArgusPrintAddressResponse(char *string, struct RaAddressStruct *raddr, char ***r
                      len += strlen(buf);
                   }
 
-                  if (refer > 1)
-                     sprintf (&resbuf[len++], "[");
+                  if (refer > 1) {
+                     snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "[");
+                     len++;
+                  }
 
                   for (x = 0; x < cnt; x++) {
                      if (tdns->status & ARGUS_DNS_REFERER) {
@@ -306,14 +310,16 @@ ArgusPrintAddressResponse(char *string, struct RaAddressStruct *raddr, char ***r
                         RaDiffTime (&tname->ltime, &tname->stime, tvp);
 
                         if (strlen(tname->n_name) > 0) {
-                        if (tref++ > 0)
-                           sprintf (&resbuf[len++], ",");
+                        if (tref++ > 0) {
+                           snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, ",");
+                           len++;
+                        }
 
                         if (ArgusParser->ArgusPrintJson) {
-                           sprintf (&resbuf[len], "\"%s\"", tname->n_name);
+                           snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "\"%s\"", tname->n_name);
                            len = strlen(resbuf);
                         } else {
-                           sprintf (&resbuf[len], "\"%s\"", tname->n_name);
+                           snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "\"%s\"", tname->n_name);
                            len = strlen(resbuf);
                         }
                         }
@@ -321,8 +327,10 @@ ArgusPrintAddressResponse(char *string, struct RaAddressStruct *raddr, char ***r
                      tdns = tdns->nxt;
                   }
 
-                  if (refer > 1)
-                     sprintf (&resbuf[len++], "]");
+                  if (refer > 1) {
+                     snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "]");
+                     len++;
+                  }
                }
 
                if (ptr > 0) {
@@ -472,10 +480,10 @@ ArgusPrintAddressResponse(char *string, struct RaAddressStruct *raddr, char ***r
                                  tdns = raddr->dns->start;
                                  if (ArgusParser->ArgusPrintJson) {
                                     char *buf = ", \"auth\":";
-                                    sprintf (&resbuf[len], "%s", buf);
+                                    snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "%s", buf);
                                     len += strlen(buf);
                                  } else {
-                                    sprintf (&resbuf[len], "%s", "A: ");
+                                    snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "%s", "A: ");
                                     len += 3;
                                  }
 
@@ -508,8 +516,10 @@ ArgusPrintAddressResponse(char *string, struct RaAddressStruct *raddr, char ***r
                                     tdns = tdns->nxt;
                                  }
 
-                                 if (auth > 1)
-                                    sprintf (&resbuf[len++], "]");
+                                 if (auth > 1) {
+                                    snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "]");
+                                    len++;
+                                 }
                               }
 
                               if (refer > 0) {
@@ -529,8 +539,10 @@ ArgusPrintAddressResponse(char *string, struct RaAddressStruct *raddr, char ***r
                                     len += strlen(buf);
                                  }
 
-                                 if (refer > 1)
-                                    sprintf (&resbuf[len++], "[");
+                                 if (refer > 1) {
+                                    snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "[");
+                                    len++;
+                                 }
 
                                  for (x = 0; x < cnt; x++) {
                                     if (tdns->status & ARGUS_DNS_REFERER) {
@@ -539,14 +551,16 @@ ArgusPrintAddressResponse(char *string, struct RaAddressStruct *raddr, char ***r
                                        RaDiffTime (&tname->ltime, &tname->stime, tvp);
 
                                        if (strlen(tname->n_name) > 0) {
-                                       if (tref++ > 0)
-                                          sprintf (&resbuf[len++], ",");
+                                       if (tref++ > 0) {
+                                          snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, ",");
+                                          len++;
+                                       }
 
                                        if (ArgusParser->ArgusPrintJson) {
-                                          sprintf (&resbuf[len], "\"%s\"", tname->n_name);
+                                          snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "\"%s\"", tname->n_name);
                                           len = strlen(resbuf);
                                        } else {
-                                          sprintf (&resbuf[len], "\"%s\"", tname->n_name);
+                                          snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "\"%s\"", tname->n_name);
                                           len = strlen(resbuf);
                                        }
                                        }
@@ -554,8 +568,10 @@ ArgusPrintAddressResponse(char *string, struct RaAddressStruct *raddr, char ***r
                                     tdns = tdns->nxt;
                                  }
 
-                                 if (refer > 1)
-                                    sprintf (&resbuf[len++], "]");
+                                 if (refer > 1) {
+                                    snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "]");
+                                    len++;
+                                 }
                               }
 
                               if (ptr > 0) {
@@ -1062,34 +1078,35 @@ ArgusHandleSearchCommand (struct ArgusOutputStruct *output, char *command)
                }
 
                if (ArgusParser->ArgusPrintJson) {
-                  sprintf (resbuf, "{ \"name\":\"%s\"", results[0]);
+                  snprintf (resbuf, ARGUS_MAX_RESPONSE, "{ \"name\":\"%s\"", results[0]);
                } else {
-                  sprintf (resbuf, "%s: %s [", sptr, results[0]);
+                  snprintf (resbuf, ARGUS_MAX_RESPONSE, "%s: %s [", sptr, results[0]);
                }
 
                if (resultnum > 1) {
+                  int len = strlen(resbuf);
                   if (ArgusParser->ArgusPrintJson) {
-                     sprintf (&resbuf[strlen(resbuf)], ", ");
+                     snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, ", ");
+                     len = strlen(resbuf);
                   }
 
                   for (x = 1; x < resultnum; x++) {
-                     if (x > 1) sprintf (&resbuf[strlen(resbuf)], ", ");
-                     sprintf (&resbuf[strlen(resbuf)], "%s", results[x]);
+                     if (x > 1) {
+                        snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, ", ");
+                        len = strlen(resbuf);
+                     }
+                     snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, "%s", results[x]);
+                     len = strlen(resbuf);
                      free(results[x]);
                   }
                }
 
-               if (ArgusParser->ArgusPrintJson) {
-                  if (resultnum > 1) {
-                     sprintf (&resbuf[strlen(resbuf)], " }");
+               {
+                  int len = strlen(resbuf);
+                  if (ArgusParser->ArgusPrintJson) {
+                     snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, " }");
                   } else {
-                     sprintf (&resbuf[strlen(resbuf)], " }");
-                  }
-               } else {
-                  if (resultnum > 1) {
-                     sprintf (&resbuf[strlen(resbuf)], " ]");
-                  } else {
-                     sprintf (&resbuf[strlen(resbuf)], " ]");
+                     snprintf (&resbuf[len], ARGUS_MAX_RESPONSE - len, " ]");
                   }
                }
                retn[rind++] = strdup(resbuf);
@@ -2469,7 +2486,7 @@ RaProcessMXRecord (struct ArgusParserStruct *parser, struct ArgusDomainStruct *d
          struct ArgusDomainResourceRecord *rr = list->list_union.obj;
 
          if ((ptr = ArgusNameEntry(ArgusDNSNameTable, rr->name, 0)) != NULL) {
-            char *dptr = strdup(rr->data), *tptr, *sptr, *mxsptr;
+            char *dptr = strdup(rr->data), *tptr, *sptr, *mxsptr = NULL;
             int ind = 0;
 
             if ((ptr->stime.tv_sec == 0) || (ptr->stime.tv_sec > dns->stime.tv_sec)) {

--- a/examples/radns/rasql.c
+++ b/examples/radns/rasql.c
@@ -1214,7 +1214,7 @@ RaMySQLInit ()
             RaHost = strdup(rhost);
          }
          free(RaDatabase);
-         RaDatabase = strdup(dbptr);
+         RaDatabase = (dbptr != NULL) ? strdup(dbptr) : strdup("argus");
       }
  
       if ((ptr = strchr (RaDatabase, '/')) != NULL) {

--- a/examples/rahosts/rahosts.c
+++ b/examples/rahosts/rahosts.c
@@ -812,7 +812,7 @@ RaMySQLInit ()
             RaHost = strdup(rhost);
          }
          free(RaDatabase);
-         RaDatabase = strdup(dbptr);
+         RaDatabase = (dbptr != NULL) ? strdup(dbptr) : strdup("argus");
       }
    }
 

--- a/examples/ramatrix/ramatrix.c
+++ b/examples/ramatrix/ramatrix.c
@@ -615,16 +615,24 @@ RaParseComplete (int sig)
             if (ArgusParser->ArgusReplaceMode & ARGUS_REPLACE_COMPRESSED_GZ) {
                char cmdbuf[MAXSTRLEN], *cmd = cmdbuf;
 
-               sprintf(cmd, "gzip -q %s\n", file->filename);
-               if (system(cmd) < 0)
-                  ArgusLog (LOG_ERR, "compressing file %s failed");
+               if (strchr(file->filename, '\'') != NULL) {
+                  ArgusLog (LOG_ERR, "compressing file %s failed: filename contains a single quote", file->filename);
+               } else {
+                  snprintf(cmd, MAXSTRLEN, "gzip -q '%s'\n", file->filename);
+                  if (system(cmd) < 0)
+                     ArgusLog (LOG_ERR, "compressing file %s failed");
+               }
             } else
             if (ArgusParser->ArgusReplaceMode & ARGUS_REPLACE_COMPRESSED_BZ) {
                char cmdbuf[MAXSTRLEN], *cmd = cmdbuf;
 
-               sprintf(cmd, "bzip2 -f -q %s\n", file->filename);
-               if (system(cmd) < 0)
-                  ArgusLog (LOG_ERR, "compressing file %s failed");
+               if (strchr(file->filename, '\'') != NULL) {
+                  ArgusLog (LOG_ERR, "compressing file %s failed: filename contains a single quote", file->filename);
+               } else {
+                  snprintf(cmd, MAXSTRLEN, "bzip2 -f -q '%s'\n", file->filename);
+                  if (system(cmd) < 0)
+                     ArgusLog (LOG_ERR, "compressing file %s failed");
+               }
             }
          }
 

--- a/examples/ramysql/rascore.c
+++ b/examples/ramysql/rascore.c
@@ -1041,7 +1041,7 @@ RaMySQLInit ()
             RaHost = strdup(rhost);
          }
          free(RaDatabase);
-         RaDatabase = strdup(dbptr);
+         RaDatabase = (dbptr != NULL) ? strdup(dbptr) : strdup("argus");
       }
    }
 

--- a/examples/ramysql/rasql.c
+++ b/examples/ramysql/rasql.c
@@ -537,7 +537,7 @@ RaMySQLInit ()
             RaHost = strdup(rhost);
          }
          free(RaDatabase);
-         RaDatabase = strdup(dbptr);
+         RaDatabase = (dbptr != NULL) ? strdup(dbptr) : strdup("argus");
       }
    }
 

--- a/examples/ramysql/rasqlinsert.c
+++ b/examples/ramysql/rasqlinsert.c
@@ -1779,7 +1779,7 @@ RaMySQLInit (int ncons)
             RaHost = strdup(rhost);
          }
          free(RaDatabase);
-         RaDatabase = strdup(dbptr);
+         RaDatabase = (dbptr != NULL) ? strdup(dbptr) : strdup("argus");
       }
    }
  

--- a/examples/ramysql/rasqltimeindex.c
+++ b/examples/ramysql/rasqltimeindex.c
@@ -641,7 +641,7 @@ RaMySQLInit ()
                RaPort = atoi(ptr);
             }
          } else
-            RaDatabase = NULL;
+            RaDatabase = "argus";
 
       } else {
          RaDatabase = &RaDatabase[3];

--- a/examples/ramysql/rastatus.c
+++ b/examples/ramysql/rastatus.c
@@ -455,7 +455,7 @@ RaMySQLInit (int ncons)
             RaHost = strdup(rhost);
          }
          free(RaDatabase);
-         RaDatabase = strdup(dbptr);
+         RaDatabase = (dbptr != NULL) ? strdup(dbptr) : strdup("argus");
       }
    }
  
@@ -1635,12 +1635,14 @@ ArgusInitEvents (struct ArgusEventsStruct *events)
                            if (RaHost != NULL) free(RaHost);
                            RaHost = strdup(rhost);
                         }
-                        if ((ptr = strchr (dbptr, '/')) != NULL) {
-                           *ptr++ = '\0';
-                           evt->table = strdup(ptr);
+                        if (dbptr != NULL) {
+                           if ((ptr = strchr (dbptr, '/')) != NULL) {
+                              *ptr++ = '\0';
+                              evt->table = strdup(ptr);
+                           }
+                           free(evt->db);
+                           evt->db = strdup(dbptr);
                         }
-                        free(evt->db);
-                        evt->db = strdup(dbptr);
                      }
                   }
 

--- a/examples/ratop/racurses.c
+++ b/examples/ratop/racurses.c
@@ -696,13 +696,13 @@ ArgusProcessTerminator(WINDOW *win, int status, int ch)
 
                if ((mode = modelist) != NULL) {
                   while (mode) {
-                     char *ptr = NULL, **endptr = NULL;
+                     char *ptr = NULL, *endptr = NULL;
                      int value = 0;
 
                      if ((ptr = strchr(mode->mode, '/')) != NULL) {
                         ptr++;
-                        if ((value = strtol(ptr, endptr, 10)) == 0)
-                           if (*endptr == ptr)
+                        if ((value = strtol(ptr, &endptr, 10)) == 0)
+                           if (endptr == ptr)
                               usage();
                      }
                      if (!(strncasecmp (mode->mode, "none", 4))) {
@@ -4130,13 +4130,13 @@ argus_command_string(void)
 
                if ((mode = modelist) != NULL) {
                   while (mode) {
-                     char *ptr = NULL, **endptr = NULL;
+                     char *ptr = NULL, *endptr = NULL;
                      int value = 0;
 
                      if ((ptr = strchr(mode->mode, '/')) != NULL) {
                         ptr++;
-                        if ((value = strtol(ptr, endptr, 10)) == 0)
-                           if (*endptr == ptr)
+                        if ((value = strtol(ptr, &endptr, 10)) == 0)
+                           if (endptr == ptr)
                               usage();
                      }
                      if (!(strncasecmp (mode->mode, "none", 4))) {


### PR DESCRIPTION
…nfig

Phase 2 of the security review covers examples/ (72 files, 84,430 LOC), dominated by radump's tcpdump-derived protocol printers and the SQL-export/interactive tools (ramysql, ratop, radns). This commit fixes the six confirmed-and-fixable findings from that review (F-CL-22 through F-CL-25, F-CL-27, F-CL-28); F-CL-26 is documented as accepted (dead code, no fix applied). See argus-clients-security-review.2026.09.03-phase2/ findings-log.md for full write-ups.

- examples/ramatrix/ramatrix.c (F-CL-22): unescaped system() shell injection building "gzip -q %s"/"bzip2 -f -q %s" commands from a locally-supplied output filename. Same class as Phase 1's F-CL-15. Fixed with single-quoting + embedded-quote rejection + bounded snprintf, matching F-CL-15's fix pattern.

- examples/ratop/racurses.c (F-CL-23): NULL-pointer dereference in the interactive mode-string parser -- `char **endptr = NULL` was passed directly (not `&endptr`) to strtol() and then dereferenced via `*endptr`. Two identical instances. Fixed by declaring `char *endptr` and passing `&endptr`, comparing `endptr == ptr` directly.

- examples/radns/radns.c (F-CL-24): unbounded sprintf() writes into the 1MB (ARGUS_MAX_RESPONSE) response buffer using DNS name data derived from monitored/captured traffic, in ArgusPrintAddressResponse()'s "auth"/"refer" sections (both AF_INET and AF_INET6 copies) and in ArgusHandleSearchCommand()'s result assembly. Network-reachable via radns's CONTROL_SEARCH control-command handler. Converted all bare sprintf(&resbuf[...], ...) calls to bounded snprintf(&resbuf[len], ARGUS_MAX_RESPONSE - len, ...), matching the already-bounded sibling "ptr" section in the same functions.

- examples/raconvert/raconvert.c (F-CL-25): unescaped popen() shell injection + undersized fixed-256-byte command buffer in RaConvertReadFile()'s .gz/.z and .bz2/.bz decompression call sites. Same class as Phase 1's F-CL-18. Fixed with a 2*PATH_MAX buffer, single-quote rejection, and snprintf() with the filename wrapped in single quotes. Added #include <limits.h> for PATH_MAX.

- examples/radns/radns.c (F-CL-27): use of uninitialized pointer `mxsptr` in RaProcessMXRecord(), fed by radomain.c's ns_rparse() T_MX parsing. `mxsptr` was only assigned when a captured MX resource record's data split into >=2 whitespace-separated tokens; a crafted or malformed DNS response missing the second token left it as stack garbage, later read via ArgusNameEntry() and potentially freed. Single-packet-triggerable, network-reachable -- the most severe finding from this phase. Fixed by initializing `mxsptr = NULL` at declaration; both existing consumers were already NULL-safe.

- MySQL connection-string parsing (F-CL-28): NULL-pointer dereference (strchr()/strdup() on NULL) when a "mysql://host" connection string omits the "/database" path component, across examples/ramysql/{rascore,rasql,rasqlinsert,rastatus}.c, examples/radns/rasql.c, examples/rahosts/rahosts.c, and examples/ramysql/rasqltimeindex.c. rasqlcheckconf.c already handled this correctly and was used as the reference. Fixed 7 sites to fall back to a default "argus" database name when the path component is absent; rastatus.c's second instance (ArgusInitEvents(), evt->db) has no natural default and is instead guarded with a NULL check. Local CLI/config trust boundary only.

Not fixed (documented, accepted): F-CL-26, a buffer-size mismatch (1024 vs. MAXSTRLEN/4096) in radns/rasql.c's
ArgusCreateSQLSaveTableName(), confirmed via exhaustive repo-wide grep to be dead code (defined, never called) -- same disposition as Phase 1's F-CL-11.

Verified via standalone `make <file>.o` builds plus full clean rebuilds (make clean && ./configure --with-mysql=<prefix> && make -j4): zero errors, only the pre-existing benign linker alignment warnings.

Also discovered and fixed a build-configuration gap during this phase: configure was not detecting the installed MySQL client, so ramysql, radns, and rahosts (all ARGUS_MYSQL-conditional) were silently excluded from every build/compile check throughout Phase 1 and early Phase 2. Re-running with --with-mysql=<homebrew mysql-client prefix> fixes this; confirmed the two ARGUS_MYSQL-conditional blocks in common/ (argus_event.c, argus_util.c) from Phase 1 still compile cleanly with MySQL enabled.