### PR TITLE
Fix Phase 2 radump/radns hardening findings: F-CL-29 through F-CL-32

### DIFF
--- a/common/argus_main.c
+++ b/common/argus_main.c
@@ -237,7 +237,7 @@ main (int argc, char **argv)
       struct ArgusFileInput *file;
 
       while (ArgusParser->ArgusPassNum) {
-         if ((input = ArgusMalloc(sizeof(*input))) == NULL)
+         if ((input = ArgusCalloc(1, sizeof(*input))) == NULL)
             ArgusLog(LOG_ERR, "unable to allocate input structure\n");
 
          file = ArgusParser->ArgusInputFileList;

--- a/common/argus_util.c
+++ b/common/argus_util.c
@@ -21749,9 +21749,17 @@ ArgusPrintSrcUserDataLabel (struct ArgusParserStruct *parser, char *buf, int len
       }
  
       if (len > 10) slen++;
-      sprintf (buf, "%*ssrcUdata%*s ", (slen)/2, " ", (slen)/2, " ");
+
+      /* buf is a MAXSTRLEN-sized buffer (see ArgusGenerateLabel()); clamp
+       * slen so that the padding plus "srcUdata"/trailer text below cannot
+       * exceed that buffer, and use snprintf/bounds checks throughout.
+       */
+      if (slen > (MAXSTRLEN - 16))
+         slen = MAXSTRLEN - 16;
+
+      snprintf (buf, MAXSTRLEN, "%*ssrcUdata%*s ", (slen)/2, " ", (slen)/2, " ");
       if (slen & 0x01)
-         sprintf (&buf[strlen(buf)], " ");
+         snprintf (&buf[strlen(buf)], MAXSTRLEN - strlen(buf), " ");
    }
 }
 
@@ -21775,9 +21783,17 @@ ArgusPrintDstUserDataLabel (struct ArgusParserStruct *parser, char *buf, int len
       }
 
       if (len > 10) slen++;
-      sprintf (buf, "%*sdstUdata%*s ", (slen)/2, " ", (slen)/2, " ");
+
+      /* buf is a MAXSTRLEN-sized buffer (see ArgusGenerateLabel()); clamp
+       * slen so that the padding plus "dstUdata"/trailer text below cannot
+       * exceed that buffer, and use snprintf/bounds checks throughout.
+       */
+      if (slen > (MAXSTRLEN - 16))
+         slen = MAXSTRLEN - 16;
+
+      snprintf (buf, MAXSTRLEN, "%*sdstUdata%*s ", (slen)/2, " ", (slen)/2, " ");
       if (slen & 0x01)
-         sprintf (&buf[strlen(buf)], " ");
+         snprintf (&buf[strlen(buf)], MAXSTRLEN - strlen(buf), " ");
    }
 }
 
@@ -34158,6 +34174,15 @@ ArgusProcessSOptions(struct ArgusParserStruct *parser)
 
                if (RaNewLength < 1)
                   ArgusLog (LOG_ERR, "-s %s:%d length must be greater than 0\n", soption, RaNewLength);
+
+               /* Field-print routines (e.g. ArgusPrintSrcUserData()) use
+                * this length directly against fixed-size internal buffers
+                * (MAXSTRLEN-sized).  Clamp it here, at the single point
+                * where it comes in from user/CLI input, so it can never
+                * drive an out-of-bounds write downstream.
+                */
+               if (RaNewLength > MAXSTRLEN)
+                  RaNewLength = MAXSTRLEN;
             }
 
             if ((sptr = strchr(ptr, ':')) != NULL) {

--- a/examples/raconvert/raconvert.c
+++ b/examples/raconvert/raconvert.c
@@ -298,7 +298,7 @@ main (int argc, char **argv) {
       struct ArgusFileInput *file;
 
       while (ArgusParser->ArgusPassNum) {
-         if ((input = ArgusMalloc(sizeof(*input))) == NULL)
+         if ((input = ArgusCalloc(1, sizeof(*input))) == NULL)
             ArgusLog(LOG_ERR, "unable to allocate input structure\n");
 
          file = ArgusParser->ArgusInputFileList;

--- a/examples/radns/interface.h
+++ b/examples/radns/interface.h
@@ -121,6 +121,34 @@
 /* Bail if "var" was not captured */
 #define TCHECK(var) TCHECK2(var, sizeof(var))
 
+/*
+ * Size of the global ArgusBuf[] protocol-decode text buffer (declared in
+ * radns.c). Kept as a named constant so ARGUSBUF_APPEND() below can bound
+ * its writes without requiring a complete array type in every file that
+ * references the buffer via "extern char ArgusBuf[];".
+ */
+#define ARGUSBUF_SIZE 0x8000
+
+/*
+ * Bounded-append helper for the global ArgusBuf[ARGUSBUF_SIZE] protocol-
+ * decode text buffer. Protocol printers build up their output by
+ * repeatedly appending formatted text to ArgusBuf; several of those append
+ * calls sit inside loops whose iteration count comes directly from a field
+ * carried in the record being decoded, so the total number of appends made
+ * while decoding a single record is not bounded by the code itself.
+ * ARGUSBUF_APPEND() closes that gap: it always appends via snprintf() with
+ * the buffer's *actual remaining* capacity, so a decode pass can never
+ * write past the end of ArgusBuf no matter how many times it is called or
+ * how large the appended values are. Once ArgusBuf is full, remaining
+ * appends become silent (safe) no-ops rather than writes past the buffer.
+ */
+#define ARGUSBUF_APPEND(...) \
+   do { \
+      size_t __argusbuf_len = strlen(ArgusBuf); \
+      if (__argusbuf_len < ARGUSBUF_SIZE) \
+         snprintf(&ArgusBuf[__argusbuf_len], ARGUSBUF_SIZE - __argusbuf_len, __VA_ARGS__); \
+   } while (0)
+
 void safeputchar(int);
 
 extern const char *tok2strbuf(const struct tok *, const char *, int, char *, size_t);

--- a/examples/radns/radomain.c
+++ b/examples/radns/radomain.c
@@ -417,33 +417,33 @@ struct ArgusDomainResourceRecord {
             break;
 
          case T_MX:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+            ARGUSBUF_APPEND("%c", ' ');
             if (!TTEST2(*cp, 2))
                return(NULL);
             if (ns_nprint(cp + 2, bp, &ArgusBuf[strlen(ArgusBuf)]) == NULL)
                return(NULL);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %d", EXTRACT_16BITS(cp));
+            ARGUSBUF_APPEND(" %d", EXTRACT_16BITS(cp));
             rr->data = strdup(ArgusBuf);
             break;
 
          case T_TXT:
             while (cp < rp) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)]," \"");
+               ARGUSBUF_APPEND(" \"");
                cp = ns_cprint(cp);
                if (cp == NULL)
                   return(NULL);
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+               ARGUSBUF_APPEND("%c", '"');
             }
             rr->data = strdup(ArgusBuf);
             break;
 
          case T_SRV:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+            ARGUSBUF_APPEND("%c", ' ');
             if (!TTEST2(*cp, 6))
                return(NULL);
             if (ns_nprint(cp + 6, bp, &ArgusBuf[strlen(ArgusBuf)]) == NULL)
                return(NULL);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":%d %d %d", EXTRACT_16BITS(cp + 4),
+            ARGUSBUF_APPEND(":%d %d %d", EXTRACT_16BITS(cp + 4),
                EXTRACT_16BITS(cp), EXTRACT_16BITS(cp + 2));
             rr->data = strdup(ArgusBuf);
             break;
@@ -452,7 +452,7 @@ struct ArgusDomainResourceRecord {
             bzero(ArgusBuf, 0x4000);
             if (!TTEST2(*cp, sizeof(struct in6_addr)))
                return(NULL);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ArgusGetV6Name(ArgusParser, (unsigned char *)cp));
+            ARGUSBUF_APPEND("%s", ArgusGetV6Name(ArgusParser, (unsigned char *)cp));
             rr->data = strdup(ArgusBuf);
             break;
 
@@ -465,17 +465,17 @@ struct ArgusDomainResourceRecord {
             pbit = *cp;
             pbyte = (pbit & ~7) / 8;
             if (pbit > 128) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u(bad plen)", pbit);
+               ARGUSBUF_APPEND(" %u(bad plen)", pbit);
                break;
             } else if (pbit < 128) {
                if (!TTEST2(*(cp + 1), sizeof(a) - pbyte))
                   return(NULL);
                memset(&a, 0, sizeof(a));
                memcpy(&a.s6_addr[pbyte], cp + 1, sizeof(a) - pbyte);
-               sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u %s", pbit, ArgusGetV6Name(ArgusParser, (unsigned char *)&a));
+               ARGUSBUF_APPEND(" %u %s", pbit, ArgusGetV6Name(ArgusParser, (unsigned char *)&a));
             }
             if (pbit > 0) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+               ARGUSBUF_APPEND("%c", ' ');
                if (ns_nprint(cp + 1 + sizeof(a) - pbyte, bp, &ArgusBuf[strlen(ArgusBuf)]) == NULL)
                   return(NULL);
             }
@@ -484,14 +484,14 @@ struct ArgusDomainResourceRecord {
          }
 
          case T_OPT:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," UDPsize=%u", rr->class);
+            ARGUSBUF_APPEND(" UDPsize=%u", rr->class);
             rr->data = strdup(ArgusBuf);
             break;
 
          case T_UNSPECA:      
             if (!TTEST2(*cp, len))
                return(NULL);
-            if (fn_printn(cp, len, snapend, ArgusBuf) == NULL)
+            if (fn_printn(cp, len, snapend, ArgusBuf, ARGUSBUF_SIZE - strlen(ArgusBuf)) == NULL)
                return(NULL);
             rr->data = strdup(ArgusBuf);
             break;
@@ -501,29 +501,29 @@ struct ArgusDomainResourceRecord {
                return(NULL);
             if (!ArgusParser->vflag)
                break;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+            ARGUSBUF_APPEND("%c", ' ');
             if ((cp = ns_nprint(cp, bp, &ArgusBuf[strlen(ArgusBuf)])) == NULL)
                return(NULL);
             cp += 6;
             if (!TTEST2(*cp, 2))
                return(NULL);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," fudge=%u", EXTRACT_16BITS(cp));
+            ARGUSBUF_APPEND(" fudge=%u", EXTRACT_16BITS(cp));
             cp += 2;
             if (!TTEST2(*cp, 2))
                return(NULL);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," maclen=%u", EXTRACT_16BITS(cp));
+            ARGUSBUF_APPEND(" maclen=%u", EXTRACT_16BITS(cp));
             cp += 2 + EXTRACT_16BITS(cp);
             if (!TTEST2(*cp, 2))
                return(NULL);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," origid=%u", EXTRACT_16BITS(cp));
+            ARGUSBUF_APPEND(" origid=%u", EXTRACT_16BITS(cp));
             cp += 2;
             if (!TTEST2(*cp, 2))
                return(NULL);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," error=%u", EXTRACT_16BITS(cp));
+            ARGUSBUF_APPEND(" error=%u", EXTRACT_16BITS(cp));
             cp += 2;
             if (!TTEST2(*cp, 2))
                return(NULL);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," otherlen=%u", EXTRACT_16BITS(cp));
+            ARGUSBUF_APPEND(" otherlen=%u", EXTRACT_16BITS(cp));
             cp += 2;
             rr->data = strdup(ArgusBuf);
          }
@@ -670,24 +670,24 @@ blabel_print(const u_char *cp)
    lim = cp + 1 + slen;
 
    /* print the bit string as a hex string */
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"\\[x");
+   ARGUSBUF_APPEND("\\[x");
    for (bitp = cp + 1, b = bitlen; bitp < lim && b > 7; b -= 8, bitp++) {
       TCHECK(*bitp);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02x", *bitp);
+      ARGUSBUF_APPEND("%02x", *bitp);
    }
    if (b > 4) {
       TCHECK(*bitp);
       tc = *bitp++;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02x", tc & (0xff << (8 - b)));
+      ARGUSBUF_APPEND("%02x", tc & (0xff << (8 - b)));
    } else if (b > 0) {
       TCHECK(*bitp);
       tc = *bitp++;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%1x", ((tc >> 4) & 0x0f) & (0x0f << (4 - b)));
+      ARGUSBUF_APPEND("%1x", ((tc >> 4) & 0x0f) & (0x0f << (4 - b)));
    }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"/%d]", bitlen);
+   ARGUSBUF_APPEND("/%d]", bitlen);
    return lim;
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],".../%d]", bitlen);
+   ARGUSBUF_APPEND(".../%d]", bitlen);
    return NULL;
 }
 
@@ -702,7 +702,7 @@ labellen(const u_char *cp)
    if ((i & INDIR_MASK) == EDNS0_MASK) {
       int bitlen, elt;
       if ((elt = (i & ~INDIR_MASK)) != EDNS0_ELT_BITLABEL) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"<ELT %d>", elt);
+         ARGUSBUF_APPEND("<ELT %d>", elt);
          return(-1);
       }
       if (!TTEST2(*(cp + 1), 1))
@@ -722,6 +722,7 @@ ns_nprint(register const u_char *cp, register const u_char *bp, char *buf)
    register int compress = 0;
    int elt;
    u_int offset, max_offset;
+   char *bufend = ArgusBuf + ARGUSBUF_SIZE;
 
    if ((l = labellen(cp)) == (u_int) -1)
       return(NULL);
@@ -760,6 +761,9 @@ ns_nprint(register const u_char *cp, register const u_char *bp, char *buf)
             continue;
          }
 
+         if (buf >= bufend - 1)
+            return(NULL);         /* out of room */
+
          if ((i & INDIR_MASK) == EDNS0_MASK) {
             elt = (i & ~INDIR_MASK);
             switch(elt) {
@@ -769,16 +773,18 @@ ns_nprint(register const u_char *cp, register const u_char *bp, char *buf)
                break;
             default:
                /* unknown ELT */
-               sprintf(buf,"<ELT %d>", elt);
+               snprintf(buf, bufend - buf, "<ELT %d>", elt);
                return(NULL);
             }
          } else {
-            if ((buf = fn_printn(cp, l, snapend, buf)) == NULL)
+            if ((buf = fn_printn(cp, l, snapend, buf, bufend - buf)) == NULL)
                return(NULL);
          }
 
          cp += l;
 
+         if (buf >= bufend - 1)
+            return(NULL);         /* out of room */
          *buf++ = '.';
          if ((l = labellen(cp)) == (u_int)-1)
             return(NULL);
@@ -788,8 +794,11 @@ ns_nprint(register const u_char *cp, register const u_char *bp, char *buf)
          if (!compress)
             rp += l + 1;
       }
-   } else
+   } else {
+      if (buf >= bufend - 1)
+         return(NULL);            /* out of room */
       sprintf(buf++, "%c", '.');
+   }
 
    return (rp);
 }
@@ -804,7 +813,7 @@ ns_cprint(register const u_char *cp)
    if (!TTEST2(*cp, 1))
       return (NULL);
    i = *cp++;
-   if (fn_printn(cp, i, snapend, buf) == NULL)
+   if (fn_printn(cp, i, snapend, buf, ARGUSBUF_SIZE - strlen(ArgusBuf)) == NULL)
       return (NULL);
    return (cp + i);
 }
@@ -824,7 +833,7 @@ ns_qprint(register const u_char *cp, register const u_char *bp, int is_mdns)
    /* print the qtype and qclass (if it's not IN) */
    i = EXTRACT_16BITS(cp);
    cp += 2;
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", tok2str(ns_type2str, "Type%d", i));
+   ARGUSBUF_APPEND(" %s", tok2str(ns_type2str, "Type%d", i));
 
    /* print the qclass (if it's not IN) */
    i = EXTRACT_16BITS(cp);
@@ -836,12 +845,12 @@ ns_qprint(register const u_char *cp, register const u_char *bp, int is_mdns)
       class = i;
 
    if (class != C_IN)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", tok2str(ns_class2str, "(Class %d)", i));
+      ARGUSBUF_APPEND(" %s", tok2str(ns_class2str, "(Class %d)", i));
 
    if (is_mdns) 
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], (i & C_QU) ? " (QU)" : " (QM)");
+      ARGUSBUF_APPEND((i & C_QU) ? " (QU)" : " (QM)");
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"? ");
+   ARGUSBUF_APPEND("? ");
    cp = ns_nprint(np, bp, &ArgusBuf[strlen(ArgusBuf)]);
    return(cp ? cp + 4 : NULL);
 }
@@ -855,7 +864,7 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
    register const u_char *rp;
 
    if (ArgusParser->vflag) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if ((cp = ns_nprint(cp, bp, &ArgusBuf[strlen(ArgusBuf)])) == NULL)
          return NULL;
    } else
@@ -874,10 +883,10 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
       class &= ~C_CACHE_FLUSH;
 
    if ((class != C_IN) && (typ != T_OPT))
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", tok2str(ns_class2str, "(Class %d)", class));
+      ARGUSBUF_APPEND(" %s", tok2str(ns_class2str, "(Class %d)", class));
 
    if (is_mdns && (class & C_CACHE_FLUSH))
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," (Cache flush)");
+      ARGUSBUF_APPEND(" (Cache flush)");
 
    if (typ == T_OPT) {
       /* get opt flags */
@@ -887,9 +896,9 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
       cp += 2;
    } else if (ArgusParser->vflag > 2) {
       /* print ttl */
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], " [");
+      ARGUSBUF_APPEND(" [");
       relts_print(ArgusBuf, EXTRACT_32BITS(cp));
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "]");
+      ARGUSBUF_APPEND("]");
       cp += 4;
    } else {
       /* ignore ttl */
@@ -901,7 +910,7 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
 
    rp = cp + len;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", tok2str(ns_type2str, "Type%d", typ));
+   ARGUSBUF_APPEND(" %s", tok2str(ns_type2str, "Type%d", typ));
    if (rp > snapend)
       return(NULL);
 
@@ -911,7 +920,7 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
          return(NULL);
       {
          unsigned int addr = htonl(EXTRACT_32BITS(cp));
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", ipaddr_string(&addr));
+         ARGUSBUF_APPEND(" %s", ipaddr_string(&addr));
       }
       break;
    }
@@ -922,7 +931,7 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
 #ifdef T_DNAME
    case T_DNAME:
 #endif
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if (ns_nprint(cp, bp, &ArgusBuf[strlen(ArgusBuf)]) == NULL)
          return(NULL);
       break;
@@ -930,51 +939,51 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
    case T_SOA:
       if (!ArgusParser->vflag)
          break;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if ((cp = ns_nprint(cp, bp, &ArgusBuf[strlen(ArgusBuf)])) == NULL)
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if ((cp = ns_nprint(cp, bp, &ArgusBuf[strlen(ArgusBuf)])) == NULL)
          return(NULL);
       if (!TTEST2(*cp, 5 * 4))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u", EXTRACT_32BITS(cp));
+      ARGUSBUF_APPEND(" %u", EXTRACT_32BITS(cp));
       cp += 4;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u", EXTRACT_32BITS(cp));
+      ARGUSBUF_APPEND(" %u", EXTRACT_32BITS(cp));
       cp += 4;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u", EXTRACT_32BITS(cp));
+      ARGUSBUF_APPEND(" %u", EXTRACT_32BITS(cp));
       cp += 4;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u", EXTRACT_32BITS(cp));
+      ARGUSBUF_APPEND(" %u", EXTRACT_32BITS(cp));
       cp += 4;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u", EXTRACT_32BITS(cp));
+      ARGUSBUF_APPEND(" %u", EXTRACT_32BITS(cp));
       cp += 4;
       break;
    case T_MX:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if (!TTEST2(*cp, 2))
          return(NULL);
       if (ns_nprint(cp + 2, bp, &ArgusBuf[strlen(ArgusBuf)]) == NULL)
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %d", EXTRACT_16BITS(cp));
+      ARGUSBUF_APPEND(" %d", EXTRACT_16BITS(cp));
       break;
 
    case T_TXT:
       while (cp < rp) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," \"");
+         ARGUSBUF_APPEND(" \"");
          cp = ns_cprint(cp);
          if (cp == NULL)
             return(NULL);
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+         ARGUSBUF_APPEND("%c", '"');
       }
       break;
 
    case T_SRV:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if (!TTEST2(*cp, 6))
          return(NULL);
       if (ns_nprint(cp + 6, bp, &ArgusBuf[strlen(ArgusBuf)]) == NULL)
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],":%d %d %d", EXTRACT_16BITS(cp + 4),
+      ARGUSBUF_APPEND(":%d %d %d", EXTRACT_16BITS(cp + 4),
          EXTRACT_16BITS(cp), EXTRACT_16BITS(cp + 2));
       break;
 
@@ -982,7 +991,7 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
    case T_AAAA:
       if (!TTEST2(*cp, sizeof(struct in6_addr)))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", ArgusGetV6Name(ArgusParser, cp));
+      ARGUSBUF_APPEND(" %s", ArgusGetV6Name(ArgusParser, cp));
       break;
 
    case T_A6:
@@ -995,17 +1004,17 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
       pbit = *cp;
       pbyte = (pbit & ~7) / 8;
       if (pbit > 128) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u(bad plen)", pbit);
+         ARGUSBUF_APPEND(" %u(bad plen)", pbit);
          break;
       } else if (pbit < 128) {
          if (!TTEST2(*(cp + 1), sizeof(a) - pbyte))
             return(NULL);
          memset(&a, 0, sizeof(a));
          memcpy(&a.s6_addr[pbyte], cp + 1, sizeof(a) - pbyte);
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u %s", pbit, ArgusGetV6Name(ArgusParser, &a));
+         ARGUSBUF_APPEND(" %u %s", pbit, ArgusGetV6Name(ArgusParser, &a));
       }
       if (pbit > 0) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+         ARGUSBUF_APPEND("%c", ' ');
          if (ns_nprint(cp + 1 + sizeof(a) - pbyte, bp, &ArgusBuf[strlen(ArgusBuf)]) == NULL)
             return(NULL);
       }
@@ -1014,15 +1023,15 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
 #endif /*INET6*/
 
    case T_OPT:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," UDPsize=%u", class);
+      ARGUSBUF_APPEND(" UDPsize=%u", class);
       if (opt_flags & 0x8000)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," DO");
+         ARGUSBUF_APPEND(" DO");
       break;
 
    case T_UNSPECA:      /* One long string */
       if (!TTEST2(*cp, len))
          return(NULL);
-      if (fn_printn(cp, len, snapend, &ArgusBuf[strlen(ArgusBuf)]) == NULL)
+      if (fn_printn(cp, len, snapend, &ArgusBuf[strlen(ArgusBuf)], ARGUSBUF_SIZE - strlen(ArgusBuf)) == NULL)
          return(NULL);
       break;
 
@@ -1032,29 +1041,29 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
          return(NULL);
       if (!ArgusParser->vflag)
          break;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if ((cp = ns_nprint(cp, bp, &ArgusBuf[strlen(ArgusBuf)])) == NULL)
          return(NULL);
       cp += 6;
       if (!TTEST2(*cp, 2))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," fudge=%u", EXTRACT_16BITS(cp));
+      ARGUSBUF_APPEND(" fudge=%u", EXTRACT_16BITS(cp));
       cp += 2;
       if (!TTEST2(*cp, 2))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," maclen=%u", EXTRACT_16BITS(cp));
+      ARGUSBUF_APPEND(" maclen=%u", EXTRACT_16BITS(cp));
       cp += 2 + EXTRACT_16BITS(cp);
       if (!TTEST2(*cp, 2))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," origid=%u", EXTRACT_16BITS(cp));
+      ARGUSBUF_APPEND(" origid=%u", EXTRACT_16BITS(cp));
       cp += 2;
       if (!TTEST2(*cp, 2))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," error=%u", EXTRACT_16BITS(cp));
+      ARGUSBUF_APPEND(" error=%u", EXTRACT_16BITS(cp));
       cp += 2;
       if (!TTEST2(*cp, 2))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," otherlen=%u", EXTRACT_16BITS(cp));
+      ARGUSBUF_APPEND(" otherlen=%u", EXTRACT_16BITS(cp));
       cp += 2;
        }
    }
@@ -1079,7 +1088,7 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
 
    if (DNS_QR(np)) {
       /* this is a response */
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d%s%s%s%s%s%s",
+      ARGUSBUF_APPEND("%d%s%s%s%s%s%s",
          EXTRACT_16BITS(&np->id),
          ns_ops[DNS_OPCODE(np)],
          ns_resp[DNS_RCODE(np)],
@@ -1089,15 +1098,15 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
          DNS_AD(np)? "$" : "");
 
       if (qdcount != 1)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," [%dq]", qdcount);
+         ARGUSBUF_APPEND(" [%dq]", qdcount);
 
       /* Print QUESTION section on -vv */
       cp = (const u_char *)(np + 1);
       while (qdcount--) {
          if (qdcount < EXTRACT_16BITS(&np->qdcount) - 1)
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+            ARGUSBUF_APPEND("%c", ',');
          if (ArgusParser->vflag > 1) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," q:");
+            ARGUSBUF_APPEND(" q:");
             if ((cp = ns_qprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
          } else {
@@ -1106,12 +1115,12 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
             cp += 4;   /* skip QTYPE and QCLASS */
          }
       }
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %d/%d/%d", ancount, nscount, arcount);
+      ARGUSBUF_APPEND(" %d/%d/%d", ancount, nscount, arcount);
       if (ancount--) {
          if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
             goto trunc;
          while (cp < snapend && ancount--) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+            ARGUSBUF_APPEND("%c", ',');
             if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
          }
@@ -1121,11 +1130,11 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
       /* Print NS and AR sections on -vv */
       if (ArgusParser->vflag > 1) {
          if (cp < snapend && nscount--) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," ns:");
+            ARGUSBUF_APPEND(" ns:");
             if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
             while (cp < snapend && nscount--) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
                if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                   goto trunc;
             }
@@ -1133,11 +1142,11 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
          if (nscount > 0)
             goto trunc;
          if (cp < snapend && arcount--) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," ar:");
+            ARGUSBUF_APPEND(" ar:");
             if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
             while (cp < snapend && arcount--) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
                if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                   goto trunc;
             }
@@ -1151,7 +1160,7 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
       bzero(tbuf, sizeof(tbuf));
 
       /* this is a request */
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d%s%s%s", EXTRACT_16BITS(&np->id), ns_ops[DNS_OPCODE(np)],
+      ARGUSBUF_APPEND("%d%s%s%s", EXTRACT_16BITS(&np->id), ns_ops[DNS_OPCODE(np)],
           DNS_RD(np) ? "+" : "",
           DNS_CD(np) ? "%" : "");
 
@@ -1178,9 +1187,9 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
          sprintf(&tbuf[strlen(tbuf)]," [%dau]", arcount);
 
       if (strlen(tbuf) > 0) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", tbuf);
+         ARGUSBUF_APPEND(" %s", tbuf);
       } else {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," [_]");
+         ARGUSBUF_APPEND(" [_]");
       }
 
       cp = (const u_char *)(np + 1);
@@ -1205,7 +1214,7 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
             if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
             while (cp < snapend && ancount--) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
                if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                   goto trunc;
             }
@@ -1213,11 +1222,11 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
          if (ancount > 0)
             goto trunc;
          if (cp < snapend && nscount--) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," ns:");
+            ARGUSBUF_APPEND(" ns:");
             if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
             while (nscount-- && cp < snapend) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
                if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                   goto trunc;
             }
@@ -1225,11 +1234,11 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
          if (nscount > 0)
             goto trunc;
          if (cp < snapend && arcount--) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," ar:");
+            ARGUSBUF_APPEND(" ar:");
             if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
             while (cp < snapend && arcount--) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
                if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                   goto trunc;
             }
@@ -1238,11 +1247,11 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
             goto trunc;
       }
    }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," (%d)", length);
+   ARGUSBUF_APPEND(" (%d)", length);
    return ArgusBuf;
 
   trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|domain]");
+   ARGUSBUF_APPEND("[|domain]");
    return ArgusBuf;
 }
 
@@ -1251,13 +1260,20 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
 /*
  * Print out a null-terminated filename (or other ascii string).
  * If ep is NULL, assume no truncation check is needed.
- * Return true if truncated.
+ * "buflen" is the number of bytes remaining in "buf" (not including a
+ * terminating NUL) that this call is allowed to write, so a caller
+ * appending to a shared buffer (e.g. &ArgusBuf[strlen(ArgusBuf)]) can pass
+ * the buffer's actual remaining capacity and this function will never
+ * write past it, regardless of how many bytes the record being decoded
+ * claims to contain.
+ * Return true if truncated (either by "ep" or by running out of "buflen").
  */
 int
-fn_print(register const u_char *s, register const u_char *ep, char *buf)
+fn_print(register const u_char *s, register const u_char *ep, char *buf, size_t buflen)
 {
    register int ret;
    register u_char c;
+   char *lim = buf + buflen;
 
    ret = 1;                        /* assume truncated */
    while (ep == NULL || s < ep) {
@@ -1266,6 +1282,8 @@ fn_print(register const u_char *s, register const u_char *ep, char *buf)
          ret = 0;
          break;
       }
+      if ((buf + strlen(buf) + 4) >= lim)
+         break;                    /* out of room; report truncated */
       if (!isascii(c)) {
          c = toascii(c);
          sprintf(&buf[strlen(buf)], "%c", 'M');
@@ -1283,18 +1301,24 @@ fn_print(register const u_char *s, register const u_char *ep, char *buf)
 /*                      
  * Print out a counted filename (or other ascii string).
  * If ep is NULL, assume no truncation check is needed.
- * Return true if truncated.
+ * "buflen" is the number of bytes remaining in "buf" (not including a
+ * terminating NUL); see fn_print() above for why this matters.
+ * Returns a pointer to the NUL terminator on success, or NULL if
+ * truncated by "ep" or by running out of "buflen".
  */                     
 
 char *
 fn_printn(register const u_char *s, register u_int n,
-          register const u_char *ep, char *buf)
+          register const u_char *ep, char *buf, size_t buflen)
 {
    register u_char c;
    int len = strlen(buf);
    char *ebuf = &buf[len];
+   char *lim = buf + buflen;
 
    while ((n > 0) && (ep == NULL || s < ep)) {
+      if ((ebuf + 4) >= lim)
+         return (NULL);            /* out of room */
       n--;
       c = *s++;
       if (!isascii(c)) {
@@ -1308,6 +1332,7 @@ fn_printn(register const u_char *s, register u_int n,
       }
       *ebuf++ = c;
    }
+   *ebuf = '\0';
    return (n == 0) ? ebuf : NULL;
 }
 

--- a/examples/radump/interface.h
+++ b/examples/radump/interface.h
@@ -122,6 +122,27 @@
 /* Bail if "var" was not captured */
 #define TCHECK(var) TCHECK2(var, sizeof(var))
 
+/*
+ * Bounded-append helper for the global ArgusBuf[MAXSTRLEN] protocol-decode
+ * text buffer. Every protocol printer in this directory builds up its
+ * output by repeatedly appending formatted text to ArgusBuf; several of
+ * those append calls sit inside loops whose iteration count comes directly
+ * from a field carried in the record being decoded, so the total number of
+ * appends made while decoding a single record is not bounded by the code
+ * itself. ARGUSBUF_APPEND() closes that gap: it always appends via
+ * snprintf() with the buffer's *actual remaining* capacity, so a decode
+ * pass can never write past the end of ArgusBuf no matter how many times
+ * it is called or how large the appended values are. Once ArgusBuf is
+ * full, remaining appends become silent (safe) no-ops rather than writes
+ * past the buffer.
+ */
+#define ARGUSBUF_APPEND(...) \
+   do { \
+      size_t __argusbuf_len = strlen(ArgusBuf); \
+      if (__argusbuf_len < MAXSTRLEN) \
+         snprintf(&ArgusBuf[__argusbuf_len], MAXSTRLEN - __argusbuf_len, __VA_ARGS__); \
+   } while (0)
+
 void safeputchar(int);
 
 extern const char *tok2strbuf(const struct tok *, const char *, int, char *, size_t);

--- a/examples/radump/print-aodv.c
+++ b/examples/radump/print-aodv.c
@@ -65,22 +65,22 @@ aodv_extension(const struct aodv_ext *ep, u_int length)
    switch (ep->type) {
    case AODV_EXT_HELLO:
       if (snapend < (u_char *) ep) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|hello]");
+         ARGUSBUF_APPEND(" [|hello]");
          return;
       }
       i = min(length, (u_int)(snapend - (u_char *)ep));
       if (i < sizeof(struct aodv_hello)) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|hello]");
+         ARGUSBUF_APPEND(" [|hello]");
          return;
       }
       i -= sizeof(struct aodv_hello);
       ah = (void *)ep;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\text HELLO %ld ms",
+      ARGUSBUF_APPEND("\n\text HELLO %ld ms",
           (unsigned long)EXTRACT_32BITS(&ah->interval));
       break;
 
    default:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\text %u %u", ep->type, ep->length);
+      ARGUSBUF_APPEND("\n\text %u %u", ep->type, ep->length);
       break;
    }
 }
@@ -91,16 +91,16 @@ aodv_rreq(const union aodv *ap, const u_char *dat, u_int length)
    u_int i;
 
    if (snapend < dat) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|aodv]");
+      ARGUSBUF_APPEND(" [|aodv]");
       return;
    }
    i = min(length, (u_int)(snapend - dat));
    if (i < sizeof(ap->rreq)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|rreq]");
+      ARGUSBUF_APPEND(" [|rreq]");
       return;
    }
    i -= sizeof(ap->rreq);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rreq %u %s%s%s%s%shops %u id 0x%08lx\n"
+   ARGUSBUF_APPEND(" rreq %u %s%s%s%s%shops %u id 0x%08lx\n"
        "\tdst %s seq %lu src %s seq %lu", length,
        ap->rreq.rreq_type & RREQ_JOIN ? "[J]" : "",
        ap->rreq.rreq_type & RREQ_REPAIR ? "[R]" : "",
@@ -123,16 +123,16 @@ aodv_rrep(const union aodv *ap, const u_char *dat, u_int length)
    u_int i;
 
    if (snapend < dat) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|aodv]");
+      ARGUSBUF_APPEND(" [|aodv]");
       return;
    }
    i = min(length, (u_int)(snapend - dat));
    if (i < sizeof(ap->rrep)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|rrep]");
+      ARGUSBUF_APPEND(" [|rrep]");
       return;
    }
    i -= sizeof(ap->rrep);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rrep %u %s%sprefix %u hops %u\n"
+   ARGUSBUF_APPEND(" rrep %u %s%sprefix %u hops %u\n"
        "\tdst %s dseq %lu src %s %lu ms", length,
        ap->rrep.rrep_type & RREP_REPAIR ? "[R]" : "",
        ap->rrep.rrep_type & RREP_ACK ? "[A] " : " ",
@@ -154,28 +154,28 @@ aodv_rerr(const union aodv *ap, const u_char *dat, u_int length)
    int n, trunc;
 
    if (snapend < dat) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|aodv]");
+      ARGUSBUF_APPEND(" [|aodv]");
       return;
    }
    i = min(length, (u_int)(snapend - dat));
    if (i < offsetof(struct aodv_rerr, r)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|rerr]");
+      ARGUSBUF_APPEND(" [|rerr]");
       return;
    }
    i -= offsetof(struct aodv_rerr, r);
    dp = &ap->rerr.r.dest[0];
    n = ap->rerr.rerr_dc * sizeof(ap->rerr.r.dest[0]);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rerr %s [items %u] [%u]:",
+   ARGUSBUF_APPEND(" rerr %s [items %u] [%u]:",
        ap->rerr.rerr_flags & RERR_NODELETE ? "[D]" : "",
        ap->rerr.rerr_dc, length);
    trunc = n - (i/sizeof(ap->rerr.r.dest[0]));
    for (; i >= sizeof(ap->rerr.r.dest[0]);
        ++dp, i -= sizeof(ap->rerr.r.dest[0])) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," {%s}(%ld)", ipaddr_string(&dp->u_da),
+      ARGUSBUF_APPEND(" {%s}(%ld)", ipaddr_string(&dp->u_da),
           (unsigned long)EXTRACT_32BITS(&dp->u_ds));
    }
    if (trunc)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|rerr]");
+      ARGUSBUF_APPEND("[|rerr]");
 }
 
 static void
@@ -189,16 +189,16 @@ aodv_v6_rreq(const union aodv *ap, const u_char *dat, u_int length)
    u_int i;
 
    if (snapend < dat) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|aodv]");
+      ARGUSBUF_APPEND(" [|aodv]");
       return;
    }
    i = min(length, (u_int)(snapend - dat));
    if (i < sizeof(ap->rreq6)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|rreq6]");
+      ARGUSBUF_APPEND(" [|rreq6]");
       return;
    }
    i -= sizeof(ap->rreq6);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," v6 rreq %u %s%s%s%s%shops %u id 0x%08lx\n"
+   ARGUSBUF_APPEND(" v6 rreq %u %s%s%s%s%shops %u id 0x%08lx\n"
        "\tdst %s seq %lu src %s seq %lu", length,
        ap->rreq6.rreq_type & RREQ_JOIN ? "[J]" : "",
        ap->rreq6.rreq_type & RREQ_REPAIR ? "[R]" : "",
@@ -214,7 +214,7 @@ aodv_v6_rreq(const union aodv *ap, const u_char *dat, u_int length)
    if (i >= sizeof(struct aodv_ext))
       aodv_extension((void *)(&ap->rreq6 + 1), i);
 #else
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," v6 rreq %u", length);
+   ARGUSBUF_APPEND(" v6 rreq %u", length);
 #endif
 }
 
@@ -229,16 +229,16 @@ aodv_v6_rrep(const union aodv *ap, const u_char *dat, u_int length)
    u_int i;
 
    if (snapend < dat) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|aodv]");
+      ARGUSBUF_APPEND(" [|aodv]");
       return;
    }
    i = min(length, (u_int)(snapend - dat));
    if (i < sizeof(ap->rrep6)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|rrep6]");
+      ARGUSBUF_APPEND(" [|rrep6]");
       return;
    }
    i -= sizeof(ap->rrep6);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rrep %u %s%sprefix %u hops %u\n"
+   ARGUSBUF_APPEND(" rrep %u %s%sprefix %u hops %u\n"
       "\tdst %s dseq %lu src %s %lu ms", length,
        ap->rrep6.rrep_type & RREP_REPAIR ? "[R]" : "",
        ap->rrep6.rrep_type & RREP_ACK ? "[A] " : " ",
@@ -251,7 +251,7 @@ aodv_v6_rrep(const union aodv *ap, const u_char *dat, u_int length)
    if (i >= sizeof(struct aodv_ext))
       aodv_extension((void *)(&ap->rrep6 + 1), i);
 #else
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rrep %u", length);
+   ARGUSBUF_APPEND(" rrep %u", length);
 #endif
 }
 
@@ -270,18 +270,18 @@ aodv_v6_rerr(const union aodv *ap, u_int length)
    j = sizeof(ap->rerr.r.dest6[0]);
    dp6 = &ap->rerr.r.dest6[0];
    n = ap->rerr.rerr_dc * j;
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rerr %s [items %u] [%u]:",
+   ARGUSBUF_APPEND(" rerr %s [items %u] [%u]:",
        ap->rerr.rerr_flags & RERR_NODELETE ? "[D]" : "",
        ap->rerr.rerr_dc, length);
    trunc = n - (i/j);
    for (; i -= j >= 0; ++dp6) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," {%s}(%ld)", ip6addr_string(&dp6->u_da),
+      ARGUSBUF_APPEND(" {%s}(%ld)", ip6addr_string(&dp6->u_da),
           (unsigned long)EXTRACT_32BITS(&dp6->u_ds));
    }
    if (trunc)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|rerr]");
+      ARGUSBUF_APPEND("[|rerr]");
 #else
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rerr %u", length);
+   ARGUSBUF_APPEND(" rerr %u", length);
 #endif
 }
 
@@ -296,16 +296,16 @@ aodv_v6_draft_01_rreq(const union aodv *ap, const u_char *dat, u_int length)
    u_int i;
 
    if (snapend < dat) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|aodv]");
+      ARGUSBUF_APPEND(" [|aodv]");
       return;
    }
    i = min(length, (u_int)(snapend - dat));
    if (i < sizeof(ap->rreq6_draft_01)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|rreq6]");
+      ARGUSBUF_APPEND(" [|rreq6]");
       return;
    }
    i -= sizeof(ap->rreq6_draft_01);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rreq %u %s%s%s%s%shops %u id 0x%08lx\n"
+   ARGUSBUF_APPEND(" rreq %u %s%s%s%s%shops %u id 0x%08lx\n"
        "\tdst %s seq %lu src %s seq %lu", length,
        ap->rreq6_draft_01.rreq_type & RREQ_JOIN ? "[J]" : "",
        ap->rreq6_draft_01.rreq_type & RREQ_REPAIR ? "[R]" : "",
@@ -321,7 +321,7 @@ aodv_v6_draft_01_rreq(const union aodv *ap, const u_char *dat, u_int length)
    if (i >= sizeof(struct aodv_ext))
       aodv_extension((void *)(&ap->rreq6_draft_01 + 1), i);
 #else
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rreq %u", length);
+   ARGUSBUF_APPEND(" rreq %u", length);
 #endif
 }
 
@@ -336,16 +336,16 @@ aodv_v6_draft_01_rrep(const union aodv *ap, const u_char *dat, u_int length)
    u_int i;
 
    if (snapend < dat) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|aodv]");
+      ARGUSBUF_APPEND(" [|aodv]");
       return;
    }
    i = min(length, (u_int)(snapend - dat));
    if (i < sizeof(ap->rrep6_draft_01)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|rrep6]");
+      ARGUSBUF_APPEND(" [|rrep6]");
       return;
    }
    i -= sizeof(ap->rrep6_draft_01);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rrep %u %s%sprefix %u hops %u\n"
+   ARGUSBUF_APPEND(" rrep %u %s%sprefix %u hops %u\n"
       "\tdst %s dseq %lu src %s %lu ms", length,
        ap->rrep6_draft_01.rrep_type & RREP_REPAIR ? "[R]" : "",
        ap->rrep6_draft_01.rrep_type & RREP_ACK ? "[A] " : " ",
@@ -358,7 +358,7 @@ aodv_v6_draft_01_rrep(const union aodv *ap, const u_char *dat, u_int length)
    if (i >= sizeof(struct aodv_ext))
       aodv_extension((void *)(&ap->rrep6_draft_01 + 1), i);
 #else
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rrep %u", length);
+   ARGUSBUF_APPEND(" rrep %u", length);
 #endif
 }
 
@@ -377,18 +377,18 @@ aodv_v6_draft_01_rerr(const union aodv *ap, u_int length)
    j = sizeof(ap->rerr.r.dest6_draft_01[0]);
    dp6 = &ap->rerr.r.dest6_draft_01[0];
    n = ap->rerr.rerr_dc * j;
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rerr %s [items %u] [%u]:",
+   ARGUSBUF_APPEND(" rerr %s [items %u] [%u]:",
        ap->rerr.rerr_flags & RERR_NODELETE ? "[D]" : "",
        ap->rerr.rerr_dc, length);
    trunc = n - (i/j);
    for (; i -= j >= 0; ++dp6) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," {%s}(%ld)", ip6addr_string(&dp6->u_da),
+      ARGUSBUF_APPEND(" {%s}(%ld)", ip6addr_string(&dp6->u_da),
           (unsigned long)EXTRACT_32BITS(&dp6->u_ds));
    }
    if (trunc)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|rerr]");
+      ARGUSBUF_APPEND("[|rerr]");
 #else
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," rerr %u", length);
+   ARGUSBUF_APPEND(" rerr %u", length);
 #endif
 }
 
@@ -399,14 +399,14 @@ aodv_print(const u_char *dat, u_int length, int is_ip6)
 
    ap = (union aodv *)dat;
    if (snapend < dat) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|aodv]");
+      ARGUSBUF_APPEND(" [|aodv]");
       return ArgusBuf;
    }
    if (min(length, (u_int)(snapend - dat)) < sizeof(ap->rrep_ack)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|aodv]");
+      ARGUSBUF_APPEND(" [|aodv]");
       return ArgusBuf;
    }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," aodv");
+   ARGUSBUF_APPEND(" aodv");
 
    switch (ap->rerr.rerr_type) {
 
@@ -432,7 +432,7 @@ aodv_print(const u_char *dat, u_int length, int is_ip6)
       break;
 
    case AODV_RREP_ACK:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," rrep-ack %u", length);
+      ARGUSBUF_APPEND(" rrep-ack %u", length);
       break;
 
    case AODV_V6_DRAFT_01_RREQ:
@@ -448,11 +448,11 @@ aodv_print(const u_char *dat, u_int length, int is_ip6)
       break;
 
    case AODV_V6_DRAFT_01_RREP_ACK:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," rrep-ack %u", length);
+      ARGUSBUF_APPEND(" rrep-ack %u", length);
       break;
 
    default:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u %u", ap->rreq.rreq_type, length);
+      ARGUSBUF_APPEND(" %u %u", ap->rreq.rreq_type, length);
    }
 
    return ArgusBuf;

--- a/examples/radump/print-arp.c
+++ b/examples/radump/print-arp.c
@@ -174,11 +174,11 @@ static void
 atmarp_addr_print(const u_char *ha, u_int ha_len, const u_char *srca, u_int srca_len)
 {
    if (ha_len == 0)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"<No address>");
+      ARGUSBUF_APPEND("<No address>");
    else {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", linkaddr_string(ArgusParser, ha, ha_len));
+      ARGUSBUF_APPEND("%s", linkaddr_string(ArgusParser, ha, ha_len));
       if (srca_len != 0) 
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],",%s", linkaddr_string(ArgusParser, srca, srca_len));
+         ARGUSBUF_APPEND(",%s", linkaddr_string(ArgusParser, srca, srca_len));
    }
 }
 
@@ -196,60 +196,60 @@ atmarp_print(const u_char *bp, u_int length, u_int caplen)
    op = ATMOP(ap);
 
    if (!TTEST2(*aar_tpa(ap), ATMTPLN(ap))) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"truncated-atmarp");
+      ARGUSBUF_APPEND("truncated-atmarp");
       return;
    }
 
    if ((pro != ETHERTYPE_IP && pro != ETHERTYPE_TRAIL) ||
        ATMSPLN(ap) != 4 || ATMTPLN(ap) != 4) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"atmarp-#%d for proto #%d (%d/%d) hardware #%d",
+      ARGUSBUF_APPEND("atmarp-#%d for proto #%d (%d/%d) hardware #%d",
            op, pro, ATMSPLN(ap), ATMTPLN(ap), hrd);
       return;
    }
    if (pro == ETHERTYPE_TRAIL)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"trailer-");
+      ARGUSBUF_APPEND("trailer-");
    switch (op) {
 
    case ARPOP_REQUEST:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"arp who-has %s", ipaddr_string(ATMTPA(ap)));
+      ARGUSBUF_APPEND("arp who-has %s", ipaddr_string(ATMTPA(ap)));
       if (ATMTHLN(ap) != 0) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," (");
+         ARGUSBUF_APPEND(" (");
          atmarp_addr_print(ATMTHA(ap), ATMTHLN(ap), ATMTSA(ap), ATMTSLN(ap));
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+         ARGUSBUF_APPEND(")");
       }
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," tell %s", ipaddr_string(ATMSPA(ap)));
+      ARGUSBUF_APPEND(" tell %s", ipaddr_string(ATMSPA(ap)));
       break;
 
    case ARPOP_REPLY:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"arp reply %s", ipaddr_string(ATMSPA(ap)));
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," is-at ");
+      ARGUSBUF_APPEND("arp reply %s", ipaddr_string(ATMSPA(ap)));
+      ARGUSBUF_APPEND(" is-at ");
       atmarp_addr_print(ATMSHA(ap), ATMSHLN(ap), ATMSSA(ap), ATMSSLN(ap));
       break;
 
    case ARPOP_INVREQUEST:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"invarp who-is ");
+      ARGUSBUF_APPEND("invarp who-is ");
       atmarp_addr_print(ATMTHA(ap), ATMTHLN(ap), ATMTSA(ap), ATMTSLN(ap));
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," tell ");
+      ARGUSBUF_APPEND(" tell ");
       atmarp_addr_print(ATMSHA(ap), ATMSHLN(ap), ATMSSA(ap), ATMSSLN(ap));
       break;
 
    case ARPOP_INVREPLY:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"invarp reply ");
+      ARGUSBUF_APPEND("invarp reply ");
       atmarp_addr_print(ATMSHA(ap), ATMSHLN(ap), ATMSSA(ap), ATMSSLN(ap));
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," at %s", ipaddr_string(ATMSPA(ap)));
+      ARGUSBUF_APPEND(" at %s", ipaddr_string(ATMSPA(ap)));
       break;
 
    case ATMARPOP_NAK:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"nak reply for %s", ipaddr_string(ATMSPA(ap)));
+      ARGUSBUF_APPEND("nak reply for %s", ipaddr_string(ATMSPA(ap)));
       break;
 
    default:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"atmarp-#%d", op);
+      ARGUSBUF_APPEND("atmarp-#%d", op);
       return;
    }
    return;
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|atmarp]");
+   ARGUSBUF_APPEND("[|atmarp]");
 }
 */
 
@@ -266,7 +266,7 @@ arp_src_print(struct ArgusParserStruct *parser, struct ArgusRecordStruct *argus)
    if ((metric != NULL) && metric->src.pkts) {
       switch (flow->hdr.argus_dsrvl8.qual & 0x1F) {
          case ARGUS_TYPE_ARP:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"who-has %s tell %s", ArgusGetName(parser, (unsigned char *)&arp->arp_tpa),
+            ARGUSBUF_APPEND("who-has %s tell %s", ArgusGetName(parser, (unsigned char *)&arp->arp_tpa),
                                          ArgusGetName(parser, (unsigned char *)&arp->arp_spa));
             break;
       }
@@ -295,7 +295,7 @@ arp_dst_print(struct ArgusParserStruct *parser, struct ArgusRecordStruct *argus)
       if (net != NULL) {
          switch (net->hdr.subtype & 0x1F) {
             case ARGUS_NETWORK_SUBTYPE_ARP:
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s is-at %s", ArgusGetName(parser, (unsigned char *)&arp->arp_tpa), 
+               ARGUSBUF_APPEND("%s is-at %s", ArgusGetName(parser, (unsigned char *)&arp->arp_tpa), 
                            etheraddr_string(parser, (unsigned char *)&net->net_union.arp.respaddr));
                break;
          }

--- a/examples/radump/print-beep.c
+++ b/examples/radump/print-beep.c
@@ -55,21 +55,21 @@ beep_print(const u_char *bp, u_int length)
 {
 
    if (l_strnstart("MSG", 4, (const char *)bp, length)) /* A REQuest */
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," BEEP MSG");
+      ARGUSBUF_APPEND(" BEEP MSG");
    else if (l_strnstart("RPY ", 4, (const char *)bp, length))
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," BEEP RPY");
+      ARGUSBUF_APPEND(" BEEP RPY");
    else if (l_strnstart("ERR ", 4, (const char *)bp, length))
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," BEEP ERR");
+      ARGUSBUF_APPEND(" BEEP ERR");
    else if (l_strnstart("ANS ", 4, (const char *)bp, length))
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," BEEP ANS");
+      ARGUSBUF_APPEND(" BEEP ANS");
    else if (l_strnstart("NUL ", 4, (const char *)bp, length))
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," BEEP NUL");
+      ARGUSBUF_APPEND(" BEEP NUL");
    else if (l_strnstart("SEQ ", 4, (const char *)bp, length))
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," BEEP SEQ");
+      ARGUSBUF_APPEND(" BEEP SEQ");
    else if (l_strnstart("END", 4, (const char *)bp, length))
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," BEEP END");
+      ARGUSBUF_APPEND(" BEEP END");
    else
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," BEEP (payload or undecoded)");
+      ARGUSBUF_APPEND(" BEEP (payload or undecoded)");
 
    return(ArgusBuf);
 }

--- a/examples/radump/print-bfd.c
+++ b/examples/radump/print-bfd.c
@@ -184,7 +184,7 @@ bfd_print(register const u_char *pptr, register u_int len, register u_int port)
        /* BFDv0 */
    case (BFD_CONTROL_PORT << 8):
        if (ArgusParser->vflag < 1 ) {
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],"BFDv%u, %s, Flags: [%s], length: %u",
+           ARGUSBUF_APPEND("BFDv%u, %s, Flags: [%s], length: %u",
                   version,
                   tok2str(bfd_port_values, "unknown (%u)", port),
                   bittok2str(bfd_v0_flag_values, "none", bfd_header->flags),
@@ -192,7 +192,7 @@ bfd_print(register const u_char *pptr, register u_int len, register u_int port)
            return ArgusBuf;
        }
        
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"BFDv%u, length: %u %s, Flags: [%s], Diagnostic: %s (0x%02x)",
+       ARGUSBUF_APPEND("BFDv%u, length: %u %s, Flags: [%s], Diagnostic: %s (0x%02x)",
               version,
               len,
               tok2str(bfd_port_values, "unknown (%u)", port),
@@ -200,23 +200,23 @@ bfd_print(register const u_char *pptr, register u_int len, register u_int port)
               tok2str(bfd_diag_values,"unknown",BFD_EXTRACT_DIAG(bfd_header->version_diag)),
               BFD_EXTRACT_DIAG(bfd_header->version_diag));
        
-       sprintf(&ArgusBuf[strlen(ArgusBuf)]," Detection Timer Multiplier: %u (%u ms Detection time), BFD Length: %u",
+       ARGUSBUF_APPEND(" Detection Timer Multiplier: %u (%u ms Detection time), BFD Length: %u",
               bfd_header->detect_time_multiplier,
               bfd_header->detect_time_multiplier * EXTRACT_32BITS(bfd_header->desired_min_tx_interval)/1000,
               bfd_header->length);
 
 
-       sprintf(&ArgusBuf[strlen(ArgusBuf)]," My Discriminator: 0x%08x", EXTRACT_32BITS(bfd_header->my_discriminator));
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],", Your Discriminator: 0x%08x", EXTRACT_32BITS(bfd_header->your_discriminator));
-       sprintf(&ArgusBuf[strlen(ArgusBuf)]," Desired min Tx Interval:    %4u ms", EXTRACT_32BITS(bfd_header->desired_min_tx_interval)/1000);
-       sprintf(&ArgusBuf[strlen(ArgusBuf)]," Required min Rx Interval:   %4u ms", EXTRACT_32BITS(bfd_header->required_min_rx_interval)/1000);
-       sprintf(&ArgusBuf[strlen(ArgusBuf)]," Required min Echo Interval: %4u ms", EXTRACT_32BITS(bfd_header->required_min_echo_interval)/1000);
+       ARGUSBUF_APPEND(" My Discriminator: 0x%08x", EXTRACT_32BITS(bfd_header->my_discriminator));
+       ARGUSBUF_APPEND(", Your Discriminator: 0x%08x", EXTRACT_32BITS(bfd_header->your_discriminator));
+       ARGUSBUF_APPEND(" Desired min Tx Interval:    %4u ms", EXTRACT_32BITS(bfd_header->desired_min_tx_interval)/1000);
+       ARGUSBUF_APPEND(" Required min Rx Interval:   %4u ms", EXTRACT_32BITS(bfd_header->required_min_rx_interval)/1000);
+       ARGUSBUF_APPEND(" Required min Echo Interval: %4u ms", EXTRACT_32BITS(bfd_header->required_min_echo_interval)/1000);
        break;
 
        /* BFDv1 */
    case (BFD_CONTROL_PORT << 8 | 1):
        if (ArgusParser->vflag < 1 ) {
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],"BFDv%u, %s, State %s, Flags: [%s], length: %u",
+           ARGUSBUF_APPEND("BFDv%u, %s, State %s, Flags: [%s], length: %u",
                   version,
                   tok2str(bfd_port_values, "unknown (%u)", port),
                   tok2str(bfd_v1_state_values, "unknown (%u)", bfd_header->flags & 0xc0),
@@ -225,7 +225,7 @@ bfd_print(register const u_char *pptr, register u_int len, register u_int port)
            return ArgusBuf;
        }
        
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"BFDv%u, length: %u %s, State %s, Flags: [%s], Diagnostic: %s (0x%02x)",
+       ARGUSBUF_APPEND("BFDv%u, length: %u %s, State %s, Flags: [%s], Diagnostic: %s (0x%02x)",
               version,
               len,
               tok2str(bfd_port_values, "unknown (%u)", port),
@@ -234,23 +234,23 @@ bfd_print(register const u_char *pptr, register u_int len, register u_int port)
               tok2str(bfd_diag_values,"unknown",BFD_EXTRACT_DIAG(bfd_header->version_diag)),
               BFD_EXTRACT_DIAG(bfd_header->version_diag));
        
-       sprintf(&ArgusBuf[strlen(ArgusBuf)]," Detection Timer Multiplier: %u (%u ms Detection time), BFD Length: %u",
+       ARGUSBUF_APPEND(" Detection Timer Multiplier: %u (%u ms Detection time), BFD Length: %u",
               bfd_header->detect_time_multiplier,
               bfd_header->detect_time_multiplier * EXTRACT_32BITS(bfd_header->desired_min_tx_interval)/1000,
               bfd_header->length);
 
 
-       sprintf(&ArgusBuf[strlen(ArgusBuf)]," My Discriminator: 0x%08x", EXTRACT_32BITS(bfd_header->my_discriminator));
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],", Your Discriminator: 0x%08x", EXTRACT_32BITS(bfd_header->your_discriminator));
-       sprintf(&ArgusBuf[strlen(ArgusBuf)]," Desired min Tx Interval:    %4u ms", EXTRACT_32BITS(bfd_header->desired_min_tx_interval)/1000);
-       sprintf(&ArgusBuf[strlen(ArgusBuf)]," Required min Rx Interval:   %4u ms", EXTRACT_32BITS(bfd_header->required_min_rx_interval)/1000);
-       sprintf(&ArgusBuf[strlen(ArgusBuf)]," Required min Echo Interval: %4u ms", EXTRACT_32BITS(bfd_header->required_min_echo_interval)/1000);
+       ARGUSBUF_APPEND(" My Discriminator: 0x%08x", EXTRACT_32BITS(bfd_header->my_discriminator));
+       ARGUSBUF_APPEND(", Your Discriminator: 0x%08x", EXTRACT_32BITS(bfd_header->your_discriminator));
+       ARGUSBUF_APPEND(" Desired min Tx Interval:    %4u ms", EXTRACT_32BITS(bfd_header->desired_min_tx_interval)/1000);
+       ARGUSBUF_APPEND(" Required min Rx Interval:   %4u ms", EXTRACT_32BITS(bfd_header->required_min_rx_interval)/1000);
+       ARGUSBUF_APPEND(" Required min Echo Interval: %4u ms", EXTRACT_32BITS(bfd_header->required_min_echo_interval)/1000);
 
        if (bfd_header->flags & BFD_FLAG_AUTH) {
            pptr += sizeof (const struct bfd_header_t);
            bfd_auth_header = (const struct bfd_auth_header_t *)pptr;
            TCHECK2(*bfd_auth_header, sizeof(const struct bfd_auth_header_t));
-           sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s (%u) Authentication, length %u present",
+           ARGUSBUF_APPEND(" %s (%u) Authentication, length %u present",
                   tok2str(bfd_v1_authentication_values,"Unknown",bfd_auth_header->auth_type),
                   bfd_auth_header->auth_type,
                   bfd_auth_header->auth_len);
@@ -263,7 +263,7 @@ bfd_print(register const u_char *pptr, register u_int len, register u_int port)
    case (BFD_ECHO_PORT << 8 | 1):
 
    default:
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"BFD, %s, length: %u",
+       ARGUSBUF_APPEND("BFD, %s, length: %u",
               tok2str(bfd_port_values, "unknown (%u)", port),
               len);
        if (ArgusParser->vflag >= 1) {
@@ -275,7 +275,7 @@ bfd_print(register const u_char *pptr, register u_int len, register u_int port)
    return ArgusBuf;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|BFD]");
+   ARGUSBUF_APPEND("[|BFD]");
 
    return ArgusBuf;
 }

--- a/examples/radump/print-bgp.c
+++ b/examples/radump/print-bgp.c
@@ -865,10 +865,10 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
    switch (attr->bgpa_type) {
    case BGPTYPE_ORIGIN:
       if (len != 1)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+         ARGUSBUF_APPEND("invalid len");
       else {
          TCHECK(*tptr);
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tok2strbuf(bgp_origin_values,
+         ARGUSBUF_APPEND("%s", tok2strbuf(bgp_origin_values,
                   "Unknown Origin Typecode",
                   tptr[0],
                   tokbuf, sizeof(tokbuf)));
@@ -877,25 +877,25 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
 
    case BGPTYPE_AS_PATH:
       if (len % 2) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+         ARGUSBUF_APPEND("invalid len");
          break;
       }
                 if (!len) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"empty");
+         ARGUSBUF_APPEND("empty");
          break;
                 }
 
       while (tptr < pptr + len) {
          TCHECK(tptr[0]);
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tok2strbuf(bgp_as_path_segment_open_values,
+                        ARGUSBUF_APPEND("%s", tok2strbuf(bgp_as_path_segment_open_values,
                   "?", tptr[0],
                   tokbuf, sizeof(tokbuf)));
                         for (i = 0; i < tptr[1] * 2; i += 2) {
                             TCHECK2(tptr[2 + i], 2);
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u ", EXTRACT_16BITS(&tptr[2 + i]));
+                            ARGUSBUF_APPEND("%u ", EXTRACT_16BITS(&tptr[2 + i]));
                         }
          TCHECK(tptr[0]);
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tok2strbuf(bgp_as_path_segment_close_values,
+                        ARGUSBUF_APPEND("%s", tok2strbuf(bgp_as_path_segment_close_values,
                   "?", tptr[0],
                   tokbuf, sizeof(tokbuf)));
                         TCHECK(tptr[1]);
@@ -904,37 +904,37 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
       break;
    case BGPTYPE_NEXT_HOP:
       if (len != 4)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+         ARGUSBUF_APPEND("invalid len");
       else {
          TCHECK2(tptr[0], 4);
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ArgusGetName(ArgusParser, (u_char *)tptr));
+         ARGUSBUF_APPEND("%s", ArgusGetName(ArgusParser, (u_char *)tptr));
       }
       break;
    case BGPTYPE_MULTI_EXIT_DISC:
    case BGPTYPE_LOCAL_PREF:
       if (len != 4)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+         ARGUSBUF_APPEND("invalid len");
       else {
          TCHECK2(tptr[0], 4);
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", EXTRACT_32BITS(tptr));
+         ARGUSBUF_APPEND("%u", EXTRACT_32BITS(tptr));
       }
       break;
    case BGPTYPE_ATOMIC_AGGREGATE:
       if (len != 0)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+         ARGUSBUF_APPEND("invalid len");
       break;
    case BGPTYPE_AGGREGATOR:
       if (len != 6) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+         ARGUSBUF_APPEND("invalid len");
          break;
       }
       TCHECK2(tptr[0], 6);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," AS #%u, origin %s", EXTRACT_16BITS(tptr),
+      ARGUSBUF_APPEND(" AS #%u, origin %s", EXTRACT_16BITS(tptr),
          ArgusGetName(ArgusParser, (u_char *)tptr + 2));
       break;
    case BGPTYPE_COMMUNITIES:
       if (len % 4) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+         ARGUSBUF_APPEND("invalid len");
          break;
       }
       while (tlen>0) {
@@ -943,16 +943,16 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
          comm = EXTRACT_32BITS(tptr);
          switch (comm) {
          case BGP_COMMUNITY_NO_EXPORT:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," NO_EXPORT");
+            ARGUSBUF_APPEND(" NO_EXPORT");
             break;
          case BGP_COMMUNITY_NO_ADVERT:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," NO_ADVERTISE");
+            ARGUSBUF_APPEND(" NO_ADVERTISE");
             break;
          case BGP_COMMUNITY_NO_EXPORT_SUBCONFED:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," NO_EXPORT_SUBCONFED");
+            ARGUSBUF_APPEND(" NO_EXPORT_SUBCONFED");
             break;
          default:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u:%u%s",
+            ARGUSBUF_APPEND("%u:%u%s",
                                        (comm >> 16) & 0xffff,
                                        comm & 0xffff,
                                        (tlen>4) ? ", " : "");
@@ -964,20 +964,20 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
       break;
         case BGPTYPE_ORIGINATOR_ID:
       if (len != 4) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+         ARGUSBUF_APPEND("invalid len");
          break;
       }
       TCHECK2(tptr[0], 4);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s",ArgusGetName(ArgusParser, (u_char *)tptr));
+                ARGUSBUF_APPEND("%s",ArgusGetName(ArgusParser, (u_char *)tptr));
                 break;
         case BGPTYPE_CLUSTER_LIST:
       if (len % 4) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+         ARGUSBUF_APPEND("invalid len");
          break;
       }
                 while (tlen>0) {
          TCHECK2(tptr[0], 4);
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s%s",
+                        ARGUSBUF_APPEND("%s%s",
                                ArgusGetName(ArgusParser, (u_char *)tptr),
                                 (tlen>4) ? ", " : "");
                         tlen -=4;
@@ -989,7 +989,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
       af = EXTRACT_16BITS(tptr);
       safi = tptr[2];
    
-                sprintf(&ArgusBuf[strlen(ArgusBuf)]," AFI: %s (%u), %sSAFI: %s (%u)",
+                ARGUSBUF_APPEND(" AFI: %s (%u), %sSAFI: %s (%u)",
                        tok2strbuf(bgp_afi_values, "Unknown AFI", af,
               tokbuf, sizeof(tokbuf)),
                        af,
@@ -1029,7 +1029,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                     break;
                 default:
                     TCHECK2(tptr[0], tlen);
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)]," no AFI %u / SAFI %u decoder",af,safi);
+                    ARGUSBUF_APPEND(" no AFI %u / SAFI %u decoder",af,safi);
                     if (ArgusParser->vflag <= 1)
                         print_unknown_data(tptr," ",tlen);
                     goto done;
@@ -1044,7 +1044,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                 tptr++;
 
       if (tlen) {
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)]," nexthop: ");
+                    ARGUSBUF_APPEND(" nexthop: ");
                     while (tlen > 0) {
                         switch(af<<8 | safi) {
                         case (AFNUM_INET<<8 | SAFNUM_UNICAST):
@@ -1053,11 +1053,11 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                         case (AFNUM_INET<<8 | SAFNUM_LABUNICAST):
                         case (AFNUM_INET<<8 | SAFNUM_RT_ROUTING_INFO):
                             if (tlen < (int)sizeof(struct in_addr)) {
-                                sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+                                ARGUSBUF_APPEND("invalid len");
                                 tlen = 0;
                             } else {
                                 TCHECK2(tptr[0], sizeof(struct in_addr));
-                                sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s",ArgusGetName(ArgusParser, (u_char *)tptr));
+                                ARGUSBUF_APPEND("%s",ArgusGetName(ArgusParser, (u_char *)tptr));
                                 tlen -= sizeof(struct in_addr);
                                 tptr += sizeof(struct in_addr);
                             }
@@ -1066,11 +1066,11 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                         case (AFNUM_INET<<8 | SAFNUM_VPNMULTICAST):
                         case (AFNUM_INET<<8 | SAFNUM_VPNUNIMULTICAST):
                             if (tlen < (int)(sizeof(struct in_addr)+BGP_VPN_RD_LEN)) {
-                                sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+                                ARGUSBUF_APPEND("invalid len");
                                 tlen = 0;
                             } else {
                                 TCHECK2(tptr[0], sizeof(struct in_addr)+BGP_VPN_RD_LEN);
-                                sprintf(&ArgusBuf[strlen(ArgusBuf)],"RD: %s, %s",
+                                ARGUSBUF_APPEND("RD: %s, %s",
                                        bgp_vpn_rd_print(tptr),
                                        ArgusGetName(ArgusParser, (u_char *)tptr+BGP_VPN_RD_LEN));
                                 tlen -= (sizeof(struct in_addr)+BGP_VPN_RD_LEN);
@@ -1084,11 +1084,11 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                         case (AFNUM_INET6<<8 | SAFNUM_LABUNICAST):
                         case (AFNUM_INET6<<8 | SAFNUM_RT_ROUTING_INFO):
                             if (tlen < (int)sizeof(struct in6_addr)) {
-                                sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+                                ARGUSBUF_APPEND("invalid len");
                                 tlen = 0;
                             } else {
                                 TCHECK2(tptr[0], sizeof(struct in6_addr));
-                                sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ArgusGetName(ArgusParser, (u_char *)tptr));
+                                ARGUSBUF_APPEND("%s", ArgusGetName(ArgusParser, (u_char *)tptr));
                                 tlen -= sizeof(struct in6_addr);
                                 tptr += sizeof(struct in6_addr);
                             }
@@ -1097,11 +1097,11 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                         case (AFNUM_INET6<<8 | SAFNUM_VPNMULTICAST):
                         case (AFNUM_INET6<<8 | SAFNUM_VPNUNIMULTICAST):
                             if (tlen < (int)(sizeof(struct in6_addr)+BGP_VPN_RD_LEN)) {
-                                sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+                                ARGUSBUF_APPEND("invalid len");
                                 tlen = 0;
                             } else {
                                 TCHECK2(tptr[0], sizeof(struct in6_addr)+BGP_VPN_RD_LEN);
-                                sprintf(&ArgusBuf[strlen(ArgusBuf)],"RD: %s, %s",
+                                ARGUSBUF_APPEND("RD: %s, %s",
                                        bgp_vpn_rd_print(tptr),
                                        ArgusGetName(ArgusParser, (u_char *)tptr+BGP_VPN_RD_LEN));
                                 tlen -= (sizeof(struct in6_addr)+BGP_VPN_RD_LEN);
@@ -1113,11 +1113,11 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                         case (AFNUM_L2VPN<<8 | SAFNUM_VPNMULTICAST):
                         case (AFNUM_L2VPN<<8 | SAFNUM_VPNUNIMULTICAST):
                             if (tlen < (int)sizeof(struct in_addr)) {
-                                sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+                                ARGUSBUF_APPEND("invalid len");
                                 tlen = 0;
                             } else {
                                 TCHECK2(tptr[0], sizeof(struct in_addr));
-                                sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ArgusGetName(ArgusParser, (u_char *)tptr));
+                                ARGUSBUF_APPEND("%s", ArgusGetName(ArgusParser, (u_char *)tptr));
                                 tlen -= (sizeof(struct in_addr));
                                 tptr += (sizeof(struct in_addr));
                             }
@@ -1126,7 +1126,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                         case (AFNUM_NSAP<<8 | SAFNUM_MULTICAST):
                         case (AFNUM_NSAP<<8 | SAFNUM_UNIMULTICAST):
                             TCHECK2(tptr[0], tlen);
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s",isonsap_string(tptr,tlen));
+                            ARGUSBUF_APPEND("%s",isonsap_string(tptr,tlen));
                             tptr += tlen;
                             tlen = 0;
                             break;
@@ -1135,20 +1135,20 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                         case (AFNUM_NSAP<<8 | SAFNUM_VPNMULTICAST):
                         case (AFNUM_NSAP<<8 | SAFNUM_VPNUNIMULTICAST):
                             if (tlen < BGP_VPN_RD_LEN+1) {
-                                sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+                                ARGUSBUF_APPEND("invalid len");
                                 tlen = 0;
                             } else {
                                 TCHECK2(tptr[0], tlen);
-                                sprintf(&ArgusBuf[strlen(ArgusBuf)],"RD: %s, %s",
+                                ARGUSBUF_APPEND("RD: %s, %s",
                                        bgp_vpn_rd_print(tptr),
                                        isonsap_string(tptr+BGP_VPN_RD_LEN,tlen-BGP_VPN_RD_LEN));
                                 /* rfc986 mapped IPv4 address ? */
                                 if (EXTRACT_32BITS(tptr+BGP_VPN_RD_LEN) ==  0x47000601)
-                                    sprintf(&ArgusBuf[strlen(ArgusBuf)]," = %s", ArgusGetName(ArgusParser, (u_char *)tptr+BGP_VPN_RD_LEN+4));
+                                    ARGUSBUF_APPEND(" = %s", ArgusGetName(ArgusParser, (u_char *)tptr+BGP_VPN_RD_LEN+4));
 #ifdef INET6
                                 /* rfc1888 mapped IPv6 address ? */
                                 else if (EXTRACT_24BITS(tptr+BGP_VPN_RD_LEN) ==  0x350000)
-                                    sprintf(&ArgusBuf[strlen(ArgusBuf)]," = %s", ArgusGetName(ArgusParser, (u_char *)tptr+BGP_VPN_RD_LEN+3));
+                                    ARGUSBUF_APPEND(" = %s", ArgusGetName(ArgusParser, (u_char *)tptr+BGP_VPN_RD_LEN+3));
 #endif
                                 tptr += tlen;
                                 tlen = 0;
@@ -1156,7 +1156,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                             break;
                         default:
                             TCHECK2(tptr[0], tlen);
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)],"no AFI %u/SAFI %u decoder",af,safi);
+                            ARGUSBUF_APPEND("no AFI %u/SAFI %u decoder",af,safi);
                             if (ArgusParser->vflag <= 1)
                                 print_unknown_data(tptr," ",tlen);
                             tptr += tlen;
@@ -1166,7 +1166,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                         }
                     }
       }
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],", nh-length: %u", nhlen);
+                ARGUSBUF_APPEND(", nh-length: %u", nhlen);
       tptr += tlen;
 
       TCHECK(tptr[0]);
@@ -1174,14 +1174,14 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
       tptr++;
 
       if (snpa) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u SNPA", snpa);
+         ARGUSBUF_APPEND(" %u SNPA", snpa);
          for (/*nothing*/; snpa > 0; snpa--) {
             TCHECK(tptr[0]);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %d bytes", tptr[0]);
+            ARGUSBUF_APPEND(" %d bytes", tptr[0]);
             tptr += tptr[0] + 1;
          }
       } else {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],", no SNPA");
+         ARGUSBUF_APPEND(", no SNPA");
                 }
 
       while (len - (tptr - pptr) > 0) {
@@ -1191,40 +1191,40 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                     case (AFNUM_INET<<8 | SAFNUM_UNIMULTICAST):
                         advance = decode_prefix4(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
                     case (AFNUM_INET<<8 | SAFNUM_LABUNICAST):
                         advance = decode_labeled_prefix4(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
                     case (AFNUM_INET<<8 | SAFNUM_VPNUNICAST):
                     case (AFNUM_INET<<8 | SAFNUM_VPNMULTICAST):
                     case (AFNUM_INET<<8 | SAFNUM_VPNUNIMULTICAST):
                         advance = decode_labeled_vpn_prefix4(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
                     case (AFNUM_INET<<8 | SAFNUM_RT_ROUTING_INFO):
                         advance = decode_rt_routing_info(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
 #ifdef INET6
                     case (AFNUM_INET6<<8 | SAFNUM_UNICAST):
@@ -1232,40 +1232,40 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                     case (AFNUM_INET6<<8 | SAFNUM_UNIMULTICAST):
                         advance = decode_prefix6(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
                     case (AFNUM_INET6<<8 | SAFNUM_LABUNICAST):
                         advance = decode_labeled_prefix6(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
                     case (AFNUM_INET6<<8 | SAFNUM_VPNUNICAST):
                     case (AFNUM_INET6<<8 | SAFNUM_VPNMULTICAST):
                     case (AFNUM_INET6<<8 | SAFNUM_VPNUNIMULTICAST):
                         advance = decode_labeled_vpn_prefix6(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
                     case (AFNUM_INET6<<8 | SAFNUM_RT_ROUTING_INFO):
                         advance = decode_rt_routing_info(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
 #endif
                     case (AFNUM_L2VPN<<8 | SAFNUM_VPNUNICAST):
@@ -1273,37 +1273,37 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                     case (AFNUM_L2VPN<<8 | SAFNUM_VPNUNIMULTICAST):
                         advance = decode_labeled_vpn_l2(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal length)");
+                            ARGUSBUF_APPEND(" (illegal length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);         
+                            ARGUSBUF_APPEND(" %s", buf);         
                         break;
                     case (AFNUM_NSAP<<8 | SAFNUM_UNICAST):
                     case (AFNUM_NSAP<<8 | SAFNUM_MULTICAST):
                     case (AFNUM_NSAP<<8 | SAFNUM_UNIMULTICAST):
                         advance = decode_clnp_prefix(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
                     case (AFNUM_NSAP<<8 | SAFNUM_VPNUNICAST):
                     case (AFNUM_NSAP<<8 | SAFNUM_VPNMULTICAST):
                     case (AFNUM_NSAP<<8 | SAFNUM_VPNUNIMULTICAST):
                         advance = decode_labeled_vpn_clnp_prefix(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;                                   
                     default:
                         TCHECK2(*tptr,tlen);
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)]," no AFI %u / SAFI %u decoder",af,safi);
+                        ARGUSBUF_APPEND(" no AFI %u / SAFI %u decoder",af,safi);
                         if (ArgusParser->vflag <= 1)
                             print_unknown_data(tptr," ",tlen);
                         advance = 0;
@@ -1322,7 +1322,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
       af = EXTRACT_16BITS(tptr);
       safi = tptr[2];
 
-                sprintf(&ArgusBuf[strlen(ArgusBuf)]," AFI: %s (%u), %sSAFI: %s (%u)",
+                ARGUSBUF_APPEND(" AFI: %s (%u), %sSAFI: %s (%u)",
                        tok2strbuf(bgp_afi_values, "Unknown AFI", af,
               tokbuf, sizeof(tokbuf)),
                        af,
@@ -1332,7 +1332,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                        safi);
 
                 if (len == BGP_MP_NLRI_MINSIZE)
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)]," End-of-Rib Marker (empty NLRI)");
+                    ARGUSBUF_APPEND(" End-of-Rib Marker (empty NLRI)");
 
       tptr += 3;
                 
@@ -1343,31 +1343,31 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                     case (AFNUM_INET<<8 | SAFNUM_UNIMULTICAST):
                         advance = decode_prefix4(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
                     case (AFNUM_INET<<8 | SAFNUM_LABUNICAST):
                         advance = decode_labeled_prefix4(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
                     case (AFNUM_INET<<8 | SAFNUM_VPNUNICAST):
                     case (AFNUM_INET<<8 | SAFNUM_VPNMULTICAST):
                     case (AFNUM_INET<<8 | SAFNUM_VPNUNIMULTICAST):
                         advance = decode_labeled_vpn_prefix4(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
 #ifdef INET6
                     case (AFNUM_INET6<<8 | SAFNUM_UNICAST):
@@ -1375,31 +1375,31 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                     case (AFNUM_INET6<<8 | SAFNUM_UNIMULTICAST):
                         advance = decode_prefix6(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
                     case (AFNUM_INET6<<8 | SAFNUM_LABUNICAST):
                         advance = decode_labeled_prefix6(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
                     case (AFNUM_INET6<<8 | SAFNUM_VPNUNICAST):
                     case (AFNUM_INET6<<8 | SAFNUM_VPNMULTICAST):
                     case (AFNUM_INET6<<8 | SAFNUM_VPNUNIMULTICAST):
                         advance = decode_labeled_vpn_prefix6(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
 #endif
                     case (AFNUM_L2VPN<<8 | SAFNUM_VPNUNICAST):
@@ -1407,37 +1407,37 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                     case (AFNUM_L2VPN<<8 | SAFNUM_VPNUNIMULTICAST):
                         advance = decode_labeled_vpn_l2(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal length)");
+                            ARGUSBUF_APPEND(" (illegal length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);         
+                            ARGUSBUF_APPEND(" %s", buf);         
                         break;
                     case (AFNUM_NSAP<<8 | SAFNUM_UNICAST):
                     case (AFNUM_NSAP<<8 | SAFNUM_MULTICAST):
                     case (AFNUM_NSAP<<8 | SAFNUM_UNIMULTICAST):
                         advance = decode_clnp_prefix(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;
                     case (AFNUM_NSAP<<8 | SAFNUM_VPNUNICAST):
                     case (AFNUM_NSAP<<8 | SAFNUM_VPNMULTICAST):
                     case (AFNUM_NSAP<<8 | SAFNUM_VPNUNIMULTICAST):
                         advance = decode_labeled_vpn_clnp_prefix(tptr, buf, sizeof(buf));
                         if (advance == -1)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+                            ARGUSBUF_APPEND(" (illegal prefix length)");
                         else if (advance == -2)
                             goto trunc;
                         else
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+                            ARGUSBUF_APPEND(" %s", buf);
                         break;                                   
                     default:
                         TCHECK2(*(tptr-3),tlen);
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],"no AFI %u / SAFI %u decoder",af,safi);
+                        ARGUSBUF_APPEND("no AFI %u / SAFI %u decoder",af,safi);
                         if (ArgusParser->vflag <= 1)
                             print_unknown_data(tptr-3," ",tlen);                                        
                         advance = 0;
@@ -1451,7 +1451,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
       break;
         case BGPTYPE_EXTD_COMMUNITIES:
       if (len % 8) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"invalid len");
+         ARGUSBUF_APPEND("invalid len");
          break;
       }
                 while (tlen>0) {
@@ -1460,7 +1460,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                     TCHECK2(tptr[0], 2);
                     extd_comm=EXTRACT_16BITS(tptr);
 
-          sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s (0x%04x), Flags [%s]",
+          ARGUSBUF_APPEND(" %s (0x%04x), Flags [%s]",
             tok2strbuf(bgp_extd_comm_subtype_values,
                   "unknown extd community typecode",
                   extd_comm, tokbuf, sizeof(tokbuf)),
@@ -1471,29 +1471,29 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                     switch(extd_comm) {
                     case BGP_EXT_COM_RT_0:
                     case BGP_EXT_COM_RO_0:
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],": %u:%s",
+                        ARGUSBUF_APPEND(": %u:%s",
                                EXTRACT_16BITS(tptr+2),
                                ArgusGetName(ArgusParser, (u_char *)tptr+4));
                         break;
                     case BGP_EXT_COM_RT_1:
                     case BGP_EXT_COM_RO_1:
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],": %s:%u",
+                        ARGUSBUF_APPEND(": %s:%u",
                                ArgusGetName(ArgusParser, (u_char *)tptr+2),
                                EXTRACT_16BITS(tptr+6));
                         break;
                     case BGP_EXT_COM_RT_2:
                     case BGP_EXT_COM_RO_2:
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],": %u:%u",
+                        ARGUSBUF_APPEND(": %u:%u",
                                EXTRACT_32BITS(tptr+2),
                                EXTRACT_16BITS(tptr+6));
                         break;
                     case BGP_EXT_COM_LINKBAND:
               bw.i = EXTRACT_32BITS(tptr+2);
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],": bandwidth: %.3f Mbps",
+                        ARGUSBUF_APPEND(": bandwidth: %.3f Mbps",
                                bw.f*8/1000000);
                         break;
                     case BGP_EXT_COM_CISCO_MCAST:
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],": AS %u, group %s",
+                        ARGUSBUF_APPEND(": AS %u, group %s",
                                EXTRACT_16BITS(tptr+2),
                                ArgusGetName(ArgusParser, (u_char *)tptr+4));
                         break;
@@ -1503,11 +1503,11 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                     case BGP_EXT_COM_VPN_ORIGIN4:
                     case BGP_EXT_COM_OSPF_RID:
                     case BGP_EXT_COM_OSPF_RID2:
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ArgusGetName(ArgusParser, (u_char *)tptr+2));
+                        ARGUSBUF_APPEND("%s", ArgusGetName(ArgusParser, (u_char *)tptr+2));
                         break;
                     case BGP_EXT_COM_OSPF_RTYPE:
                     case BGP_EXT_COM_OSPF_RTYPE2: 
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],": area:%s, router-type:%s, metric-type:%s%s",
+                        ARGUSBUF_APPEND(": area:%s, router-type:%s, metric-type:%s%s",
                                ArgusGetName(ArgusParser, (u_char *)tptr+2),
                                tok2strbuf(bgp_extd_comm_ospf_rtype_values,
                  "unknown (0x%02x)",
@@ -1517,7 +1517,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                                (*(tptr+6) == (BGP_OSPF_RTYPE_EXT ||BGP_OSPF_RTYPE_NSSA )) ? "E1" : "");
                         break;
                     case BGP_EXT_COM_L2INFO:
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],": %s Control Flags [0x%02x]:MTU %u",
+                        ARGUSBUF_APPEND(": %s Control Flags [0x%02x]:MTU %u",
                                tok2strbuf(l2vpn_encaps_values,
                  "unknown encaps",
                  *(tptr+2),
@@ -1537,7 +1537,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
 
         case BGPTYPE_ATTR_SET:
                 TCHECK2(tptr[0], 4);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)]," Origin AS: %u", EXTRACT_32BITS(tptr));
+                ARGUSBUF_APPEND(" Origin AS: %u", EXTRACT_32BITS(tptr));
                 tptr+=4;
                 len -=4;
 
@@ -1551,7 +1551,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                     tptr += bgp_attr_off(&bgpa);
                     len -= bgp_attr_off(&bgpa);
                     
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s (%u), length: %u",
+                    ARGUSBUF_APPEND(" %s (%u), length: %u",
                            tok2strbuf(bgp_attr_values,
                   "Unknown Attribute", bgpa.bgpa_type,
                   tokbuf, sizeof(tokbuf)),
@@ -1559,14 +1559,14 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
                            alen);
                     
                     if (bgpa.bgpa_flags) {
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],", Flags [%s%s%s%s",
+                        ARGUSBUF_APPEND(", Flags [%s%s%s%s",
                                bgpa.bgpa_flags & 0x80 ? "O" : "",
                                bgpa.bgpa_flags & 0x40 ? "T" : "",
                                bgpa.bgpa_flags & 0x20 ? "P" : "",
                                bgpa.bgpa_flags & 0x10 ? "E" : "");
                         if (bgpa.bgpa_flags & 0xf)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)],"+%x", bgpa.bgpa_flags & 0xf);
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],"]: ");
+                            ARGUSBUF_APPEND("+%x", bgpa.bgpa_flags & 0xf);
+                        ARGUSBUF_APPEND("]: ");
                     }
                     /* FIXME check for recursion */
                     if (!bgp_attr_print(&bgpa, tptr, alen))
@@ -1579,7 +1579,7 @@ bgp_attr_print(const struct bgp_attr *attr, const u_char *pptr, int len)
 
    default:
        TCHECK2(*pptr,len);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," no Attribute %u decoder",attr->bgpa_type); /* we have no decoder for the attribute */
+            ARGUSBUF_APPEND(" no Attribute %u decoder",attr->bgpa_type); /* we have no decoder for the attribute */
             if (ArgusParser->vflag <= 1)
                 print_unknown_data(pptr," ",len);
             break;
@@ -1607,11 +1607,11 @@ bgp_open_print(const u_char *dat, int length)
    TCHECK2(dat[0], BGP_OPEN_SIZE);
    memcpy(&bgpo, dat, BGP_OPEN_SIZE);
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," Version %d, ", bgpo.bgpo_version);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"my AS %u, ", ntohs(bgpo.bgpo_myas));
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"Holdtime %us, ", ntohs(bgpo.bgpo_holdtime));
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"ID %s", ArgusGetName(ArgusParser, (u_char *)&bgpo.bgpo_id));
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," Optional parameters, length: %u", bgpo.bgpo_optlen);
+   ARGUSBUF_APPEND(" Version %d, ", bgpo.bgpo_version);
+   ARGUSBUF_APPEND("my AS %u, ", ntohs(bgpo.bgpo_myas));
+   ARGUSBUF_APPEND("Holdtime %us, ", ntohs(bgpo.bgpo_holdtime));
+   ARGUSBUF_APPEND("ID %s", ArgusGetName(ArgusParser, (u_char *)&bgpo.bgpo_id));
+   ARGUSBUF_APPEND(" Optional parameters, length: %u", bgpo.bgpo_optlen);
 
         /* some little sanity checking */
         if (length < bgpo.bgpo_optlen+BGP_OPEN_SIZE) 
@@ -1626,11 +1626,11 @@ bgp_open_print(const u_char *dat, int length)
       TCHECK2(opt[i], BGP_OPT_SIZE);
       memcpy(&bgpopt, &opt[i], BGP_OPT_SIZE);
       if (i + 2 + bgpopt.bgpopt_len > bgpo.bgpo_optlen) {
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)]," Option %d, length: %u", bgpopt.bgpopt_type, bgpopt.bgpopt_len);
+                        ARGUSBUF_APPEND(" Option %d, length: %u", bgpopt.bgpopt_type, bgpopt.bgpopt_len);
          break;
       }
 
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Option %s (%u), length: %u",
+      ARGUSBUF_APPEND(" Option %s (%u), length: %u",
                        tok2strbuf(bgp_opt_values,"Unknown",
               bgpopt.bgpopt_type,
               tokbuf, sizeof(tokbuf)),
@@ -1643,14 +1643,14 @@ bgp_open_print(const u_char *dat, int length)
                     cap_type=opt[i+BGP_OPT_SIZE];
                     cap_len=opt[i+BGP_OPT_SIZE+1];
                     tcap_len=cap_len;
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s (%u), length: %u",
+                    ARGUSBUF_APPEND(" %s (%u), length: %u",
                            tok2strbuf(bgp_capcode_values, "Unknown",
                   cap_type, tokbuf, sizeof(tokbuf)),
                            cap_type,
                            cap_len);
                     switch(cap_type) {
                     case BGP_CAPCODE_MP:
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)]," AFI %s (%u), SAFI %s (%u)",
+                        ARGUSBUF_APPEND(" AFI %s (%u), SAFI %s (%u)",
                                tok2strbuf(bgp_afi_values, "Unknown",
                  EXTRACT_16BITS(opt+i+BGP_OPT_SIZE+2),
                  tokbuf, sizeof(tokbuf)),
@@ -1661,13 +1661,13 @@ bgp_open_print(const u_char *dat, int length)
                                opt[i+BGP_OPT_SIZE+5]);
                         break;
                     case BGP_CAPCODE_RESTART:
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)]," Restart Flags: [%s], Restart Time %us",
+                        ARGUSBUF_APPEND(" Restart Flags: [%s], Restart Time %us",
                                ((opt[i+BGP_OPT_SIZE+2])&0x80) ? "R" : "none",
                                EXTRACT_16BITS(opt+i+BGP_OPT_SIZE+2)&0xfff);
                         tcap_len-=2;
                         cap_offset=4;
                         while(tcap_len>=4) {
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," AFI %s (%u), SAFI %s (%u), Forwarding state preserved: %s",
+                            ARGUSBUF_APPEND(" AFI %s (%u), SAFI %s (%u), Forwarding state preserved: %s",
                                    tok2strbuf(bgp_afi_values,"Unknown",
                      EXTRACT_16BITS(opt+i+BGP_OPT_SIZE+cap_offset),
                      tokbuf, sizeof(tokbuf)),
@@ -1686,7 +1686,7 @@ bgp_open_print(const u_char *dat, int length)
                         break;
                     default:
                         TCHECK2(opt[i+BGP_OPT_SIZE+2],cap_len);
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)]," no decoder for Capability %u",
+                        ARGUSBUF_APPEND(" no decoder for Capability %u",
                                cap_type);
                         if (ArgusParser->vflag <= 1)
                             print_unknown_data(&opt[i+BGP_OPT_SIZE+2]," ",cap_len);
@@ -1699,7 +1699,7 @@ bgp_open_print(const u_char *dat, int length)
                     break;
                 case BGP_OPT_AUTH:
                 default:
-                       sprintf(&ArgusBuf[strlen(ArgusBuf)]," no decoder for option %u",
+                       ARGUSBUF_APPEND(" no decoder for option %u",
                            bgpopt.bgpopt_type);
                        break;
                 }
@@ -1708,7 +1708,7 @@ bgp_open_print(const u_char *dat, int length)
    }
    return;
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|BGP]");
+   ARGUSBUF_APPEND("[|BGP]");
 }
 
 static void
@@ -1734,7 +1734,7 @@ bgp_update_print(const u_char *dat, int length)
        * so only try to decode it if we're not v6 enabled.
             */
 #ifdef INET6
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Withdrawn routes: %d bytes", len);
+      ARGUSBUF_APPEND(" Withdrawn routes: %d bytes", len);
 #else
       char buf[MAXHOSTNAMELEN + 100];
       int wpfx;
@@ -1742,18 +1742,18 @@ bgp_update_print(const u_char *dat, int length)
       TCHECK2(p[2], len);
       i = 2;
 
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Withdrawn routes:");
+      ARGUSBUF_APPEND(" Withdrawn routes:");
 
       while(i < 2 + len) {
          wpfx = decode_prefix4(&p[i], buf, sizeof(buf));
          if (wpfx == -1) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+            ARGUSBUF_APPEND(" (illegal prefix length)");
             break;
          } else if (wpfx == -2)
             goto trunc;
          else {
             i += wpfx;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+            ARGUSBUF_APPEND(" %s", buf);
          }
       }
 #endif
@@ -1764,7 +1764,7 @@ bgp_update_print(const u_char *dat, int length)
    len = EXTRACT_16BITS(p);
 
         if (len == 0 && length == BGP_UPDATE_MINSIZE) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," End-of-Rib Marker (empty NLRI)");
+            ARGUSBUF_APPEND(" End-of-Rib Marker (empty NLRI)");
             return;
         }
 
@@ -1779,7 +1779,7 @@ bgp_update_print(const u_char *dat, int length)
          alen = bgp_attr_len(&bgpa);
          aoff = bgp_attr_off(&bgpa);
 
-             sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s (%u), length: %u",
+             ARGUSBUF_APPEND(" %s (%u), length: %u",
                               tok2strbuf(bgp_attr_values, "Unknown Attribute",
                 bgpa.bgpa_type,
                 tokbuf, sizeof(tokbuf)),
@@ -1787,14 +1787,14 @@ bgp_update_print(const u_char *dat, int length)
                               alen);
 
          if (bgpa.bgpa_flags) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],", Flags [%s%s%s%s",
+            ARGUSBUF_APPEND(", Flags [%s%s%s%s",
                bgpa.bgpa_flags & 0x80 ? "O" : "",
                bgpa.bgpa_flags & 0x40 ? "T" : "",
                bgpa.bgpa_flags & 0x20 ? "P" : "",
                bgpa.bgpa_flags & 0x10 ? "E" : "");
             if (bgpa.bgpa_flags & 0xf)
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"+%x", bgpa.bgpa_flags & 0xf);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"]: ");
+               ARGUSBUF_APPEND("+%x", bgpa.bgpa_flags & 0xf);
+            ARGUSBUF_APPEND("]: ");
          }
          if (!bgp_attr_print(&bgpa, &p[i + aoff], alen))
             goto trunc;
@@ -1804,24 +1804,24 @@ bgp_update_print(const u_char *dat, int length)
    p += 2 + len;
 
    if (dat + length > p) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Updated routes:");
+      ARGUSBUF_APPEND(" Updated routes:");
       while (dat + length > p) {
          char buf[MAXHOSTNAMELEN + 100];
          i = decode_prefix4(p, buf, sizeof(buf));
          if (i == -1) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (illegal prefix length)");
+            ARGUSBUF_APPEND(" (illegal prefix length)");
             break;
          } else if (i == -2)
             goto trunc;
          else {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", buf);
+            ARGUSBUF_APPEND(" %s", buf);
             p += i;
          }
       }
    }
    return;
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|BGP]");
+   ARGUSBUF_APPEND("[|BGP]");
 }
 
 static void
@@ -1839,7 +1839,7 @@ bgp_notification_print(const u_char *dat, int length)
         if (length<BGP_NOTIFICATION_SIZE)
             return;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],", %s (%u)",
+   ARGUSBUF_APPEND(", %s (%u)",
           tok2strbuf(bgp_notify_major_values, "Unknown Error",
            bgpn.bgpn_major, tokbuf, sizeof(tokbuf)),
           bgpn.bgpn_major);
@@ -1847,30 +1847,30 @@ bgp_notification_print(const u_char *dat, int length)
         switch (bgpn.bgpn_major) {
 
         case BGP_NOTIFY_MAJOR_MSG:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],", subcode %s (%u)",
+            ARGUSBUF_APPEND(", subcode %s (%u)",
          tok2strbuf(bgp_notify_minor_msg_values, "Unknown",
                bgpn.bgpn_minor, tokbuf, sizeof(tokbuf)),
          bgpn.bgpn_minor);
             break;
         case BGP_NOTIFY_MAJOR_OPEN:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],", subcode %s (%u)",
+            ARGUSBUF_APPEND(", subcode %s (%u)",
          tok2strbuf(bgp_notify_minor_open_values, "Unknown",
                bgpn.bgpn_minor, tokbuf, sizeof(tokbuf)),
          bgpn.bgpn_minor);
             break;
         case BGP_NOTIFY_MAJOR_UPDATE:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],", subcode %s (%u)",
+            ARGUSBUF_APPEND(", subcode %s (%u)",
          tok2strbuf(bgp_notify_minor_update_values, "Unknown",
                bgpn.bgpn_minor, tokbuf, sizeof(tokbuf)),
          bgpn.bgpn_minor);
             break;
         case BGP_NOTIFY_MAJOR_CAP:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," subcode %s (%u)",
+            ARGUSBUF_APPEND(" subcode %s (%u)",
          tok2strbuf(bgp_notify_minor_cap_values, "Unknown",
                bgpn.bgpn_minor, tokbuf, sizeof(tokbuf)),
          bgpn.bgpn_minor);
         case BGP_NOTIFY_MAJOR_CEASE:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],", subcode %s (%u)",
+            ARGUSBUF_APPEND(", subcode %s (%u)",
          tok2strbuf(bgp_notify_minor_cease_values, "Unknown",
                bgpn.bgpn_minor, tokbuf, sizeof(tokbuf)),
          bgpn.bgpn_minor);
@@ -1881,7 +1881,7 @@ bgp_notification_print(const u_char *dat, int length)
        if(bgpn.bgpn_minor == BGP_NOTIFY_MINOR_CEASE_MAXPRFX && length >= BGP_NOTIFICATION_SIZE + 7) {
       tptr = dat + BGP_NOTIFICATION_SIZE;
       TCHECK2(*tptr, 7);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", AFI %s (%u), SAFI %s (%u), Max Prefixes: %u",
+      ARGUSBUF_APPEND(", AFI %s (%u), SAFI %s (%u), Max Prefixes: %u",
              tok2strbuf(bgp_afi_values, "Unknown",
               EXTRACT_16BITS(tptr), tokbuf, sizeof(tokbuf)),
              EXTRACT_16BITS(tptr),
@@ -1897,7 +1897,7 @@ bgp_notification_print(const u_char *dat, int length)
 
    return;
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|BGP]");
+   ARGUSBUF_APPEND("[|BGP]");
 }
 
 static void
@@ -1915,7 +1915,7 @@ bgp_route_refresh_print(const u_char *pptr, int len) {
 
         bgp_route_refresh_header = (const struct bgp_route_refresh *)pptr;
 
-        sprintf(&ArgusBuf[strlen(ArgusBuf)]," AFI %s (%u), SAFI %s (%u)",
+        ARGUSBUF_APPEND(" AFI %s (%u), SAFI %s (%u)",
                tok2strbuf(bgp_afi_values,"Unknown",
            /* this stinks but the compiler pads the structure
             * weird */
@@ -1934,7 +1934,7 @@ bgp_route_refresh_print(const u_char *pptr, int len) {
         
         return;
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|BGP]");
+   ARGUSBUF_APPEND("[|BGP]");
 }
 
 static int
@@ -1945,7 +1945,7 @@ bgp_header_print(const u_char *dat, int length)
 
    TCHECK2(dat[0], BGP_SIZE);
    memcpy(&bgp, dat, BGP_SIZE);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s Message (%u), length: %u",
+   ARGUSBUF_APPEND(" %s Message (%u), length: %u",
                tok2strbuf(bgp_msg_values, "Unknown", bgp.bgp_type,
            tokbuf, sizeof(tokbuf)),
                bgp.bgp_type,
@@ -1969,13 +1969,13 @@ bgp_header_print(const u_char *dat, int length)
         default:
                 /* we have no decoder for the BGP message */
                 TCHECK2(*dat, length);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)]," no Message %u decoder",bgp.bgp_type);
+                ARGUSBUF_APPEND(" no Message %u decoder",bgp.bgp_type);
                 print_unknown_data(dat," ",length);
                 break;
    }
    return 1;
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|BGP]");
+   ARGUSBUF_APPEND("[|BGP]");
    return 0;
 }
 
@@ -1997,7 +1997,7 @@ bgp_print(const u_char *dat, int length)
    if (snapend < dat + length)
       ep = snapend;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],": BGP, length: %u",length);
+   ARGUSBUF_APPEND(": BGP, length: %u",length);
 
         if (ArgusParser->vflag < 1) /* lets be less chatty */
                 return ArgusBuf;
@@ -2024,11 +2024,11 @@ bgp_print(const u_char *dat, int length)
       memcpy(&bgp, p, BGP_SIZE);
 
       if (start != p)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|BGP]");
+         ARGUSBUF_APPEND(" [|BGP]");
 
       hlen = ntohs(bgp.bgp_len);
       if (hlen < BGP_SIZE) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|BGP Bogus header length %u < %u]", hlen, BGP_SIZE);
+         ARGUSBUF_APPEND(" [|BGP Bogus header length %u < %u]", hlen, BGP_SIZE);
          break;
       }
 
@@ -2038,7 +2038,7 @@ bgp_print(const u_char *dat, int length)
          p += hlen;
          start = p;
       } else {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|BGP %s]", tok2strbuf(bgp_msg_values,
+         ARGUSBUF_APPEND(" [|BGP %s]", tok2strbuf(bgp_msg_values,
                  "Unknown Message Type", bgp.bgp_type,
                  tokbuf, sizeof(tokbuf)));
          break;
@@ -2048,7 +2048,7 @@ bgp_print(const u_char *dat, int length)
    return ArgusBuf;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|BGP]");
+   ARGUSBUF_APPEND(" [|BGP]");
 
    return ArgusBuf;
 }

--- a/examples/radump/print-bootp.c
+++ b/examples/radump/print-bootp.c
@@ -76,15 +76,15 @@ bootp_print(register const u_char *cp, u_int length)
    bp = (struct bootp *)cp;
    TCHECK(bp->bp_op);
 
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"BOOTP/DHCP, %s",
+        ARGUSBUF_APPEND("BOOTP/DHCP, %s",
           tok2str(bootp_op_values, "unknown (0x%02x)", bp->bp_op));
 
    if (bp->bp_htype == 1 && bp->bp_hlen == 6 && bp->bp_op == BOOTPREQUEST) {
       TCHECK2(bp->bp_chaddr[0], 6);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," from %s", etheraddr_string(ArgusParser, (u_char *)bp->bp_chaddr));
+      ARGUSBUF_APPEND(" from %s", etheraddr_string(ArgusParser, (u_char *)bp->bp_chaddr));
    }
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],", length: %u", length);
+   ARGUSBUF_APPEND(", length: %u", length);
 
    if (!ArgusParser->vflag)
       return ArgusBuf;
@@ -93,78 +93,78 @@ bootp_print(register const u_char *cp, u_int length)
 
    /* The usual hardware address type is 1 (10Mb Ethernet) */
    if (bp->bp_htype != 1)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", htype-#%d", bp->bp_htype);
+      ARGUSBUF_APPEND(", htype-#%d", bp->bp_htype);
 
    /* The usual length for 10Mb Ethernet address is 6 bytes */
    if (bp->bp_htype != 1 || bp->bp_hlen != 6)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", hlen:%d", bp->bp_hlen);
+      ARGUSBUF_APPEND(", hlen:%d", bp->bp_hlen);
 
    /* Only print interesting fields */
    if (bp->bp_hops)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", hops:%d", bp->bp_hops);
+      ARGUSBUF_APPEND(", hops:%d", bp->bp_hops);
    if (bp->bp_xid)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", xid:0x%x", EXTRACT_32BITS(&bp->bp_xid));
+      ARGUSBUF_APPEND(", xid:0x%x", EXTRACT_32BITS(&bp->bp_xid));
    if (bp->bp_secs)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", secs:%d", EXTRACT_16BITS(&bp->bp_secs));
+      ARGUSBUF_APPEND(", secs:%d", EXTRACT_16BITS(&bp->bp_secs));
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],", flags: [%s]",
+   ARGUSBUF_APPEND(", flags: [%s]",
           bittok2str(bootp_flag_values, "none", EXTRACT_16BITS(&bp->bp_flags)));
    if (ArgusParser->vflag>1)
-     sprintf(&ArgusBuf[strlen(ArgusBuf)], " (0x%04x)", EXTRACT_16BITS(&bp->bp_flags));
+     ARGUSBUF_APPEND(" (0x%04x)", EXTRACT_16BITS(&bp->bp_flags));
 
    /* Client's ip address */
    TCHECK(bp->bp_ciaddr);
    if (bp->bp_ciaddr.s_addr) {
       iaddr = ntohl(bp->bp_ciaddr.s_addr);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Client IP: %s", ipaddr_string(&iaddr));
+      ARGUSBUF_APPEND(" Client IP: %s", ipaddr_string(&iaddr));
    }
 
    /* 'your' ip address (bootp client) */
    TCHECK(bp->bp_yiaddr);
    if (bp->bp_yiaddr.s_addr) {
       iaddr = ntohl(bp->bp_yiaddr.s_addr);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Your IP: %s", ipaddr_string(&iaddr));
+      ARGUSBUF_APPEND(" Your IP: %s", ipaddr_string(&iaddr));
    }
 
    /* Server's ip address */
    TCHECK(bp->bp_siaddr);
    if (bp->bp_siaddr.s_addr) {
       iaddr = ntohl(bp->bp_siaddr.s_addr);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Server IP: %s", ipaddr_string(&iaddr));
+      ARGUSBUF_APPEND(" Server IP: %s", ipaddr_string(&iaddr));
    }
 
    /* Gateway's ip address */
    TCHECK(bp->bp_giaddr);
    if (bp->bp_giaddr.s_addr) {
       iaddr = ntohl(bp->bp_giaddr.s_addr);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Gateway IP: %s", ipaddr_string(&iaddr));
+      ARGUSBUF_APPEND(" Gateway IP: %s", ipaddr_string(&iaddr));
    }
 
    /* Client's Ethernet address */
    if (bp->bp_htype == 1 && bp->bp_hlen == 6) {
       TCHECK2(bp->bp_chaddr[0], 6);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Client Ethernet Address: %s", etheraddr_string(ArgusParser, (u_char *)bp->bp_chaddr));
+      ARGUSBUF_APPEND(" Client Ethernet Address: %s", etheraddr_string(ArgusParser, (u_char *)bp->bp_chaddr));
    }
 
    TCHECK2(bp->bp_sname[0], 1);      /* check first char only */
    if (*bp->bp_sname) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," sname \"");
-      if (fn_print(bp->bp_sname, snapend, ArgusBuf)) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%s", tstr + 1);
+      ARGUSBUF_APPEND(" sname \"");
+      if (fn_print(bp->bp_sname, snapend, ArgusBuf, MAXSTRLEN - strlen(ArgusBuf))) {
+         ARGUSBUF_APPEND("%c", '"');
+         ARGUSBUF_APPEND("%s", tstr + 1);
          return ArgusBuf;
       }
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+      ARGUSBUF_APPEND("%c", '"');
    }
    TCHECK2(bp->bp_file[0], 1);      /* check first char only */
    if (*bp->bp_file) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," file \"");
-      if (fn_print(bp->bp_file, snapend, ArgusBuf)) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%s", tstr + 1);
+      ARGUSBUF_APPEND(" file \"");
+      if (fn_print(bp->bp_file, snapend, ArgusBuf, MAXSTRLEN - strlen(ArgusBuf))) {
+         ARGUSBUF_APPEND("%c", '"');
+         ARGUSBUF_APPEND("%s", tstr + 1);
          return ArgusBuf;
       }
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+      ARGUSBUF_APPEND("%c", '"');
    }
 
    /* Decode the vendor buffer */
@@ -180,12 +180,12 @@ bootp_print(register const u_char *cp, u_int length)
 
       ul = EXTRACT_32BITS(&bp->bp_vend);
       if (ul != 0)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," Vendor-#0x%x", ul);
+         ARGUSBUF_APPEND(" Vendor-#0x%x", ul);
    }
 
    return ArgusBuf;
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 
    return ArgusBuf;
 }
@@ -365,10 +365,10 @@ rfc1048_print(register const u_char *bp)
    u_int16_t us;
    u_int8_t uc;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," Vendor-rfc1048:");
+   ARGUSBUF_APPEND(" Vendor-rfc1048:");
 
    /* Step over magic cookie */
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], " MAGIC:0x%08x", EXTRACT_32BITS(bp));
+   ARGUSBUF_APPEND(" MAGIC:0x%08x", EXTRACT_32BITS(bp));
    bp += sizeof(int32_t);
 
    /* Loop while we there is a tag left in the buffer */
@@ -389,31 +389,31 @@ rfc1048_print(register const u_char *bp)
       } else
          cp = tok2str(tag2str, "?T%u", tag);
       c = *cp++;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s:", cp);
+      ARGUSBUF_APPEND(" %s:", cp);
 
       /* Get the length; check for truncation */
       if (bp + 1 >= snapend) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%s", tstr);
+         ARGUSBUF_APPEND("%s", tstr);
          return;
       }
       len = *bp++;
       if (bp + len >= snapend) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|bootp %u]", len);
+         ARGUSBUF_APPEND("[|bootp %u]", len);
          return;
       }
 
       if (tag == TAG_DHCP_MESSAGE && len == 1) {
          uc = *bp++;
          switch (uc) {
-         case DHCPDISCOVER:   sprintf(&ArgusBuf[strlen(ArgusBuf)],"DISCOVER");   break;
-         case DHCPOFFER:      sprintf(&ArgusBuf[strlen(ArgusBuf)],"OFFER");   break;
-         case DHCPREQUEST:   sprintf(&ArgusBuf[strlen(ArgusBuf)],"REQUEST");   break;
-         case DHCPDECLINE:   sprintf(&ArgusBuf[strlen(ArgusBuf)],"DECLINE");   break;
-         case DHCPACK:      sprintf(&ArgusBuf[strlen(ArgusBuf)],"ACK");      break;
-         case DHCPNAK:      sprintf(&ArgusBuf[strlen(ArgusBuf)],"NACK");      break;
-         case DHCPRELEASE:   sprintf(&ArgusBuf[strlen(ArgusBuf)],"RELEASE");   break;
-         case DHCPINFORM:   sprintf(&ArgusBuf[strlen(ArgusBuf)],"INFORM");   break;
-         default:      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", uc);   break;
+         case DHCPDISCOVER:   ARGUSBUF_APPEND("DISCOVER");   break;
+         case DHCPOFFER:      ARGUSBUF_APPEND("OFFER");   break;
+         case DHCPREQUEST:   ARGUSBUF_APPEND("REQUEST");   break;
+         case DHCPDECLINE:   ARGUSBUF_APPEND("DECLINE");   break;
+         case DHCPACK:      ARGUSBUF_APPEND("ACK");      break;
+         case DHCPNAK:      ARGUSBUF_APPEND("NACK");      break;
+         case DHCPRELEASE:   ARGUSBUF_APPEND("RELEASE");   break;
+         case DHCPINFORM:   ARGUSBUF_APPEND("INFORM");   break;
+         default:      ARGUSBUF_APPEND("%u", uc);   break;
          }
          continue;
       }
@@ -424,8 +424,8 @@ rfc1048_print(register const u_char *bp)
             uc = *bp++;
             cp = tok2str(tag2str, "?T%u", uc);
             if (!first)
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '+');
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", cp + 1);
+               ARGUSBUF_APPEND("%c", '+');
+            ARGUSBUF_APPEND("%s", cp + 1);
             first = 0;
          }
          continue;
@@ -438,8 +438,8 @@ rfc1048_print(register const u_char *bp)
             bp += 2;
             cp = tok2str(xtag2str, "?xT%u", us);
             if (!first)
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '+');
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", cp + 1);
+               ARGUSBUF_APPEND("%c", '+');
+            ARGUSBUF_APPEND("%s", cp + 1);
             first = 0;
          }
          continue;
@@ -461,12 +461,12 @@ rfc1048_print(register const u_char *bp)
 
       case 'a':
          /* ascii strings */
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
-         if (fn_printn(bp, size, snapend, &ArgusBuf[strlen(ArgusBuf)]) == NULL) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+         ARGUSBUF_APPEND("%c", '"');
+               if (fn_printn(bp, size, snapend, &ArgusBuf[strlen(ArgusBuf)], MAXSTRLEN - strlen(ArgusBuf)) == NULL) {
+            ARGUSBUF_APPEND("%c", '"');
             goto trunc;
          }
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+         ARGUSBUF_APPEND("%c", '"');
          bp += size;
          size = 0;
          break;
@@ -477,15 +477,15 @@ rfc1048_print(register const u_char *bp)
          /* ip addresses/32-bit words */
          while (size >= sizeof(ul)) {
             if (!first)
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
             ul = EXTRACT_32BITS(bp);
             if (c == 'i') {
 //             ul = htonl(ul);
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ipaddr_string(&ul));
+               ARGUSBUF_APPEND("%s", ipaddr_string(&ul));
             } else if (c == 'L')
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d", ul);
+               ARGUSBUF_APPEND("%d", ul);
             else
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", ul);
+               ARGUSBUF_APPEND("%u", ul);
             bp += sizeof(ul);
             size -= sizeof(ul);
             first = 0;
@@ -496,12 +496,12 @@ rfc1048_print(register const u_char *bp)
          /* IP address pairs */
          while (size >= 2*sizeof(ul)) {
             if (!first)
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
             memcpy((char *)&ul, (const char *)bp, sizeof(ul));
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"(%s:", ipaddr_string(&ul));
+            ARGUSBUF_APPEND("(%s:", ipaddr_string(&ul));
             bp += sizeof(ul);
             memcpy((char *)&ul, (const char *)bp, sizeof(ul));
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s)", ipaddr_string(&ul));
+            ARGUSBUF_APPEND("%s)", ipaddr_string(&ul));
             bp += sizeof(ul);
             size -= 2*sizeof(ul);
             first = 0;
@@ -512,9 +512,9 @@ rfc1048_print(register const u_char *bp)
          /* shorts */
          while (size >= sizeof(us)) {
             if (!first)
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
             us = EXTRACT_16BITS(bp);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", us);
+            ARGUSBUF_APPEND("%u", us);
             bp += sizeof(us);
             size -= sizeof(us);
             first = 0;
@@ -525,16 +525,16 @@ rfc1048_print(register const u_char *bp)
          /* boolean */
          while (size > 0) {
             if (!first)
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
             switch (*bp) {
             case 0:
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", 'N');
+               ARGUSBUF_APPEND("%c", 'N');
                break;
             case 1:
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", 'Y');
+               ARGUSBUF_APPEND("%c", 'Y');
                break;
             default:
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u?", *bp);
+               ARGUSBUF_APPEND("%u?", *bp);
                break;
             }
             ++bp;
@@ -549,11 +549,11 @@ rfc1048_print(register const u_char *bp)
          /* Bytes */
          while (size > 0) {
             if (!first)
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", c == 'x' ? ':' : '.');
+               ARGUSBUF_APPEND("%c", c == 'x' ? ':' : '.');
             if (c == 'x')
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02x", *bp);
+               ARGUSBUF_APPEND("%02x", *bp);
             else
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", *bp);
+               ARGUSBUF_APPEND("%u", *bp);
             ++bp;
             --size;
             first = 0;
@@ -567,32 +567,32 @@ rfc1048_print(register const u_char *bp)
          case TAG_NETBIOS_NODE:
             tag = *bp++;
             --size;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%s", tok2str(nbo2str, NULL, tag));
+            ARGUSBUF_APPEND("%s", tok2str(nbo2str, NULL, tag));
             break;
 
          case TAG_OPT_OVERLOAD:
             tag = *bp++;
             --size;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%s", tok2str(oo2str, NULL, tag));
+            ARGUSBUF_APPEND("%s", tok2str(oo2str, NULL, tag));
             break;
 
          case TAG_CLIENT_FQDN:
             /* option 81 should be at least 4 bytes long */
             if (len < 4)  {
-                                        sprintf(&ArgusBuf[strlen(ArgusBuf)],"ERROR: options 81 len %u < 4 bytes", len);
+                                        ARGUSBUF_APPEND("ERROR: options 81 len %u < 4 bytes", len);
                break;
             }
             if (*bp++)
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"[svrreg]");
+               ARGUSBUF_APPEND("[svrreg]");
             if (*bp)
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u/%u/", *bp, *(bp+1));
+               ARGUSBUF_APPEND("%u/%u/", *bp, *(bp+1));
             bp += 2;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
-            if (fn_printn(bp, size - 3, snapend, &ArgusBuf[strlen(ArgusBuf)]) == NULL) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+            ARGUSBUF_APPEND("%c", '"');
+            if (fn_printn(bp, size - 3, snapend, &ArgusBuf[strlen(ArgusBuf)], MAXSTRLEN - strlen(ArgusBuf)) == NULL) {
+               ARGUSBUF_APPEND("%c", '"');
                goto trunc;
             }
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+            ARGUSBUF_APPEND("%c", '"');
             bp += size - 3;
             size = 0;
             break;
@@ -601,22 +601,22 @@ rfc1048_print(register const u_char *bp)
              {   int type = *bp++;
             size--;
             if (type == 0) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
-               if (fn_printn(bp, size, snapend, &ArgusBuf[strlen(ArgusBuf)]) == NULL) {
-                  sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+               ARGUSBUF_APPEND("%c", '"');
+         if (fn_printn(bp, size, snapend, &ArgusBuf[strlen(ArgusBuf)], MAXSTRLEN - strlen(ArgusBuf)) == NULL) {
+                  ARGUSBUF_APPEND("%c", '"');
                   goto trunc;
                }
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+               ARGUSBUF_APPEND("%c", '"');
                bp += size;
                size = 0;
                break;
             } else {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"[%s]", tok2str(arp2str, "type-%d", type));
+               ARGUSBUF_APPEND("[%s]", tok2str(arp2str, "type-%d", type));
             }
             while (size > 0) {
                if (!first)
-                  sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ':');
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02x", *bp);
+                  ARGUSBUF_APPEND("%c", ':');
+               ARGUSBUF_APPEND("%02x", *bp);
                ++bp;
                --size;
                first = 0;
@@ -625,7 +625,7 @@ rfc1048_print(register const u_char *bp)
              }
 
          default:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"[unknown special tag %u, size %u]",
+            ARGUSBUF_APPEND("[unknown special tag %u, size %u]",
                 tag, size);
             bp += size;
             size = 0;
@@ -635,13 +635,13 @@ rfc1048_print(register const u_char *bp)
       }
       /* Data left over? */
       if (size) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"[len %u]", len);
+         ARGUSBUF_APPEND("[len %u]", len);
          bp += size;
       }
    }
    return;
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"|[rfc1048]");
+   ARGUSBUF_APPEND("|[rfc1048]");
    return;
 }
 
@@ -652,15 +652,15 @@ cmu_print(register const u_char *bp)
 
 #define PRINTCMUADDR(m, s) { TCHECK(cmu->m); \
     if (cmu->m.s_addr != 0) \
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s:%s", s, ipaddr_string(&cmu->m.s_addr)); }
+   ARGUSBUF_APPEND(" %s:%s", s, ipaddr_string(&cmu->m.s_addr)); }
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," vend-cmu");
+   ARGUSBUF_APPEND(" vend-cmu");
    cmu = (const struct cmu_vend *)bp;
 
    /* Only print if there are unknown bits */
    TCHECK(cmu->v_flags);
    if ((cmu->v_flags & ~(VF_SMASK)) != 0)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," F:0x%x", cmu->v_flags);
+      ARGUSBUF_APPEND(" F:0x%x", cmu->v_flags);
    PRINTCMUADDR(v_dgate, "DG");
    PRINTCMUADDR(v_smask, cmu->v_flags & VF_SMASK ? "SM" : "SM*");
    PRINTCMUADDR(v_dns1, "NS1");
@@ -672,6 +672,6 @@ cmu_print(register const u_char *bp)
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 #undef PRINTCMUADDR
 }

--- a/examples/radump/print-domain.c
+++ b/examples/radump/print-domain.c
@@ -104,24 +104,24 @@ blabel_print(const u_char *cp)
    lim = cp + 1 + slen;
 
    /* print the bit string as a hex string */
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"\\[x");
+   ARGUSBUF_APPEND("\\[x");
    for (bitp = cp + 1, b = bitlen; bitp < lim && b > 7; b -= 8, bitp++) {
       TCHECK(*bitp);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02x", *bitp);
+      ARGUSBUF_APPEND("%02x", *bitp);
    }
    if (b > 4) {
       TCHECK(*bitp);
       tc = *bitp++;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02x", tc & (0xff << (8 - b)));
+      ARGUSBUF_APPEND("%02x", tc & (0xff << (8 - b)));
    } else if (b > 0) {
       TCHECK(*bitp);
       tc = *bitp++;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%1x", ((tc >> 4) & 0x0f) & (0x0f << (4 - b)));
+      ARGUSBUF_APPEND("%1x", ((tc >> 4) & 0x0f) & (0x0f << (4 - b)));
    }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"/%d]", bitlen);
+   ARGUSBUF_APPEND("/%d]", bitlen);
    return lim;
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],".../%d]", bitlen);
+   ARGUSBUF_APPEND(".../%d]", bitlen);
    return NULL;
 }
 
@@ -136,7 +136,7 @@ labellen(const u_char *cp)
    if ((i & INDIR_MASK) == EDNS0_MASK) {
       int bitlen, elt;
       if ((elt = (i & ~INDIR_MASK)) != EDNS0_ELT_BITLABEL) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"<ELT %d>", elt);
+         ARGUSBUF_APPEND("<ELT %d>", elt);
          return(-1);
       }
       if (!TTEST2(*(cp + 1), 1))
@@ -192,7 +192,7 @@ ns_nprint(register const u_char *cp, register const u_char *bp)
              * which means we're looping.
              */
             if (chars_processed >= data_size) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"<LOOP>");
+               ARGUSBUF_APPEND("<LOOP>");
                return (NULL);
             }
             continue;
@@ -206,17 +206,17 @@ ns_nprint(register const u_char *cp, register const u_char *bp)
                break;
             default:
                /* unknown ELT */
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"<ELT %d>", elt);
+               ARGUSBUF_APPEND("<ELT %d>", elt);
                return(NULL);
             }
          } else {
-            if (fn_printn(cp, l, snapend, &ArgusBuf[strlen(ArgusBuf)]) == NULL)
+            if (fn_printn(cp, l, snapend, &ArgusBuf[strlen(ArgusBuf)], MAXSTRLEN - strlen(ArgusBuf)) == NULL)
                return(NULL);
          }
 
          cp += l;
          chars_processed += l;
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '.');
+         ARGUSBUF_APPEND("%c", '.');
          if ((l = labellen(cp)) == (u_int)-1)
             return(NULL);
          if (!TTEST2(*cp, 1))
@@ -227,7 +227,7 @@ ns_nprint(register const u_char *cp, register const u_char *bp)
             rp += l + 1;
       }
    else
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '.');
+      ARGUSBUF_APPEND("%c", '.');
    return (rp);
 }
 
@@ -240,7 +240,7 @@ ns_cprint(register const u_char *cp)
    if (!TTEST2(*cp, 1))
       return (NULL);
    i = *cp++;
-   if (fn_printn(cp, i, snapend, &ArgusBuf[strlen(ArgusBuf)]) == NULL)
+   if (fn_printn(cp, i, snapend, &ArgusBuf[strlen(ArgusBuf)], MAXSTRLEN - strlen(ArgusBuf)) == NULL)
       return (NULL);
    return (cp + i);
 }
@@ -323,15 +323,15 @@ ns_qprint(register const u_char *cp, register const u_char *bp, int is_mdns)
    /* print the qtype and qclass (if it's not IN) */
    i = EXTRACT_16BITS(cp);
    cp += 2;
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", tok2str(ns_type2str, "Type%d", i));
+   ARGUSBUF_APPEND(" %s", tok2str(ns_type2str, "Type%d", i));
    i = EXTRACT_16BITS(cp);
    cp += 2;
    if (is_mdns && i == (C_IN|C_CACHE_FLUSH))
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," (Cache flush)");
+      ARGUSBUF_APPEND(" (Cache flush)");
    else if (i != C_IN)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", tok2str(ns_class2str, "(Class %d)", i));
+      ARGUSBUF_APPEND(" %s", tok2str(ns_class2str, "(Class %d)", i));
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"? ");
+   ARGUSBUF_APPEND("? ");
    cp = ns_nprint(np, bp);
    return(cp ? cp + 4 : NULL);
 }
@@ -345,7 +345,7 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
    register const u_char *rp;
 
    if (ArgusParser->vflag) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if ((cp = ns_nprint(cp, bp)) == NULL)
          return NULL;
    } else
@@ -360,9 +360,9 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
    class = EXTRACT_16BITS(cp);
    cp += 2;
    if (is_mdns && class == (C_IN|C_CACHE_FLUSH))
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," (Cache flush)");
+      ARGUSBUF_APPEND(" (Cache flush)");
    else if (class != C_IN && typ != T_OPT)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", tok2str(ns_class2str, "(Class %d)", class));
+      ARGUSBUF_APPEND(" %s", tok2str(ns_class2str, "(Class %d)", class));
 
    /* ignore ttl */
    cp += 4;
@@ -372,7 +372,7 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
 
    rp = cp + len;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", tok2str(ns_type2str, "Type%d", typ));
+   ARGUSBUF_APPEND(" %s", tok2str(ns_type2str, "Type%d", typ));
    if (rp > snapend)
       return(NULL);
 
@@ -381,7 +381,7 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
       unsigned int addr = htonl(*(unsigned int *)cp);
       if (!TTEST2(*cp, sizeof(struct in_addr)))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", ipaddr_string(&addr));
+      ARGUSBUF_APPEND(" %s", ipaddr_string(&addr));
       break;
    }
 
@@ -391,7 +391,7 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
 #ifdef T_DNAME
    case T_DNAME:
 #endif
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if (ns_nprint(cp, bp) == NULL)
          return(NULL);
       break;
@@ -399,51 +399,51 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
    case T_SOA:
       if (!ArgusParser->vflag)
          break;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if ((cp = ns_nprint(cp, bp)) == NULL)
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if ((cp = ns_nprint(cp, bp)) == NULL)
          return(NULL);
       if (!TTEST2(*cp, 5 * 4))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u", EXTRACT_32BITS(cp));
+      ARGUSBUF_APPEND(" %u", EXTRACT_32BITS(cp));
       cp += 4;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u", EXTRACT_32BITS(cp));
+      ARGUSBUF_APPEND(" %u", EXTRACT_32BITS(cp));
       cp += 4;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u", EXTRACT_32BITS(cp));
+      ARGUSBUF_APPEND(" %u", EXTRACT_32BITS(cp));
       cp += 4;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u", EXTRACT_32BITS(cp));
+      ARGUSBUF_APPEND(" %u", EXTRACT_32BITS(cp));
       cp += 4;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u", EXTRACT_32BITS(cp));
+      ARGUSBUF_APPEND(" %u", EXTRACT_32BITS(cp));
       cp += 4;
       break;
    case T_MX:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if (!TTEST2(*cp, 2))
          return(NULL);
       if (ns_nprint(cp + 2, bp) == NULL)
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %d", EXTRACT_16BITS(cp));
+      ARGUSBUF_APPEND(" %d", EXTRACT_16BITS(cp));
       break;
 
    case T_TXT:
       while (cp < rp) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," \"");
+         ARGUSBUF_APPEND(" \"");
          cp = ns_cprint(cp);
          if (cp == NULL)
             return(NULL);
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+         ARGUSBUF_APPEND("%c", '"');
       }
       break;
 
    case T_SRV:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if (!TTEST2(*cp, 6))
          return(NULL);
       if (ns_nprint(cp + 6, bp) == NULL)
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],":%d %d %d", EXTRACT_16BITS(cp + 4),
+      ARGUSBUF_APPEND(":%d %d %d", EXTRACT_16BITS(cp + 4),
          EXTRACT_16BITS(cp), EXTRACT_16BITS(cp + 2));
       break;
 
@@ -451,7 +451,7 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
    case T_AAAA:
       if (!TTEST2(*cp, sizeof(struct in6_addr)))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", ip6addr_string(cp));
+      ARGUSBUF_APPEND(" %s", ip6addr_string(cp));
       break;
 
    case T_A6:
@@ -464,17 +464,17 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
       pbit = *cp;
       pbyte = (pbit & ~7) / 8;
       if (pbit > 128) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u(bad plen)", pbit);
+         ARGUSBUF_APPEND(" %u(bad plen)", pbit);
          break;
       } else if (pbit < 128) {
          if (!TTEST2(*(cp + 1), sizeof(a) - pbyte))
             return(NULL);
          memset(&a, 0, sizeof(a));
          memcpy(&a.s6_addr[pbyte], cp + 1, sizeof(a) - pbyte);
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u %s", pbit, ip6addr_string(&a));
+         ARGUSBUF_APPEND(" %u %s", pbit, ip6addr_string(&a));
       }
       if (pbit > 0) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+         ARGUSBUF_APPEND("%c", ' ');
          if (ns_nprint(cp + 1 + sizeof(a) - pbyte, bp) == NULL)
             return(NULL);
       }
@@ -483,13 +483,13 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
 #endif /*INET6*/
 
    case T_OPT:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," UDPsize=%u", class);
+      ARGUSBUF_APPEND(" UDPsize=%u", class);
       break;
 
    case T_UNSPECA:      /* One long string */
       if (!TTEST2(*cp, len))
          return(NULL);
-      if (fn_printn(cp, len, snapend, &ArgusBuf[strlen(ArgusBuf)]) == NULL)
+      if (fn_printn(cp, len, snapend, &ArgusBuf[strlen(ArgusBuf)], MAXSTRLEN - strlen(ArgusBuf)) == NULL)
          return(NULL);
       break;
 
@@ -499,29 +499,29 @@ ns_rprint(register const u_char *cp, register const u_char *bp, int is_mdns)
          return(NULL);
       if (!ArgusParser->vflag)
          break;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+      ARGUSBUF_APPEND("%c", ' ');
       if ((cp = ns_nprint(cp, bp)) == NULL)
          return(NULL);
       cp += 6;
       if (!TTEST2(*cp, 2))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," fudge=%u", EXTRACT_16BITS(cp));
+      ARGUSBUF_APPEND(" fudge=%u", EXTRACT_16BITS(cp));
       cp += 2;
       if (!TTEST2(*cp, 2))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," maclen=%u", EXTRACT_16BITS(cp));
+      ARGUSBUF_APPEND(" maclen=%u", EXTRACT_16BITS(cp));
       cp += 2 + EXTRACT_16BITS(cp);
       if (!TTEST2(*cp, 2))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," origid=%u", EXTRACT_16BITS(cp));
+      ARGUSBUF_APPEND(" origid=%u", EXTRACT_16BITS(cp));
       cp += 2;
       if (!TTEST2(*cp, 2))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," error=%u", EXTRACT_16BITS(cp));
+      ARGUSBUF_APPEND(" error=%u", EXTRACT_16BITS(cp));
       cp += 2;
       if (!TTEST2(*cp, 2))
          return(NULL);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," otherlen=%u", EXTRACT_16BITS(cp));
+      ARGUSBUF_APPEND(" otherlen=%u", EXTRACT_16BITS(cp));
       cp += 2;
        }
    }
@@ -546,7 +546,7 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
 
    if (DNS_QR(np)) {
       /* this is a response */
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d%s%s%s%s%s%s",
+      ARGUSBUF_APPEND("%d%s%s%s%s%s%s",
          EXTRACT_16BITS(&np->id),
          ns_ops[DNS_OPCODE(np)],
          ns_resp[DNS_RCODE(np)],
@@ -556,15 +556,15 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
          DNS_AD(np)? "$" : "");
 
       if (qdcount != 1)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," [%dq]", qdcount);
+         ARGUSBUF_APPEND(" [%dq]", qdcount);
 
       /* Print QUESTION section on -vv */
       cp = (const u_char *)(np + 1);
       while (qdcount--) {
          if (qdcount < EXTRACT_16BITS(&np->qdcount) - 1)
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+            ARGUSBUF_APPEND("%c", ',');
          if (ArgusParser->vflag > 1) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," q:");
+            ARGUSBUF_APPEND(" q:");
             if ((cp = ns_qprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
          } else {
@@ -573,12 +573,12 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
             cp += 4;   /* skip QTYPE and QCLASS */
          }
       }
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %d/%d/%d", ancount, nscount, arcount);
+      ARGUSBUF_APPEND(" %d/%d/%d", ancount, nscount, arcount);
       if (ancount--) {
          if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
             goto trunc;
          while (cp < snapend && ancount--) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+            ARGUSBUF_APPEND("%c", ',');
             if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
          }
@@ -588,11 +588,11 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
       /* Print NS and AR sections on -vv */
       if (ArgusParser->vflag > 1) {
          if (cp < snapend && nscount--) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," ns:");
+            ARGUSBUF_APPEND(" ns:");
             if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
             while (cp < snapend && nscount--) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
                if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                   goto trunc;
             }
@@ -600,11 +600,11 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
          if (nscount > 0)
             goto trunc;
          if (cp < snapend && arcount--) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," ar:");
+            ARGUSBUF_APPEND(" ar:");
             if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
             while (cp < snapend && arcount--) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
                if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                   goto trunc;
             }
@@ -618,7 +618,7 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
       bzero(tbuf, sizeof(tbuf));
 
       /* this is a request */
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d%s%s%s", EXTRACT_16BITS(&np->id), ns_ops[DNS_OPCODE(np)],
+      ARGUSBUF_APPEND("%d%s%s%s", EXTRACT_16BITS(&np->id), ns_ops[DNS_OPCODE(np)],
           DNS_RD(np) ? "+" : "",
           DNS_CD(np) ? "%" : "");
 
@@ -645,9 +645,9 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
          sprintf(&tbuf[strlen(tbuf)]," [%dau]", arcount);
 
       if (strlen(tbuf) > 0) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", tbuf);
+         ARGUSBUF_APPEND(" %s", tbuf);
       } else {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," [_]");
+         ARGUSBUF_APPEND(" [_]");
       }
 
       cp = (const u_char *)(np + 1);
@@ -672,7 +672,7 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
             if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
             while (cp < snapend && ancount--) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
                if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                   goto trunc;
             }
@@ -680,11 +680,11 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
          if (ancount > 0)
             goto trunc;
          if (cp < snapend && nscount--) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," ns:");
+            ARGUSBUF_APPEND(" ns:");
             if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
             while (nscount-- && cp < snapend) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
                if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                   goto trunc;
             }
@@ -692,11 +692,11 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
          if (nscount > 0)
             goto trunc;
          if (cp < snapend && arcount--) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," ar:");
+            ARGUSBUF_APPEND(" ar:");
             if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                goto trunc;
             while (cp < snapend && arcount--) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ',');
+               ARGUSBUF_APPEND("%c", ',');
                if ((cp = ns_rprint(cp, bp, is_mdns)) == NULL)
                   goto trunc;
             }
@@ -705,10 +705,10 @@ ns_print(register const u_char *bp, u_int length, int is_mdns)
             goto trunc;
       }
    }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," (%d)", length);
+   ARGUSBUF_APPEND(" (%d)", length);
    return ArgusBuf;
 
   trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|domain]");
+   ARGUSBUF_APPEND("[|domain]");
    return ArgusBuf;
 }

--- a/examples/radump/print-dvmrp.c
+++ b/examples/radump/print-dvmrp.c
@@ -98,7 +98,7 @@ dvmrp_print(register const u_char *bp, register u_int len)
 	switch (type) {
 
 	case DVMRP_PROBE:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," Probe");
+		ARGUSBUF_APPEND(" Probe");
 		if (ArgusParser->vflag) {
 			if (print_probe(bp, ep, len) < 0)
 				goto trunc;
@@ -106,7 +106,7 @@ dvmrp_print(register const u_char *bp, register u_int len)
 		break;
 
 	case DVMRP_REPORT:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," Report");
+		ARGUSBUF_APPEND(" Report");
 		if (ArgusParser->vflag > 1) {
 			if (print_report(bp, ep, len) < 0)
 				goto trunc;
@@ -114,21 +114,21 @@ dvmrp_print(register const u_char *bp, register u_int len)
 		break;
 
 	case DVMRP_ASK_NEIGHBORS:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," Ask-neighbors(old)");
+		ARGUSBUF_APPEND(" Ask-neighbors(old)");
 		break;
 
 	case DVMRP_NEIGHBORS:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," Neighbors(old)");
+		ARGUSBUF_APPEND(" Neighbors(old)");
 		if (print_neighbors(bp, ep, len) < 0)
 			goto trunc;
 		break;
 
 	case DVMRP_ASK_NEIGHBORS2:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," Ask-neighbors2");
+		ARGUSBUF_APPEND(" Ask-neighbors2");
 		break;
 
 	case DVMRP_NEIGHBORS2:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," Neighbors2");
+		ARGUSBUF_APPEND(" Neighbors2");
 		/*
 		 * extract version and capabilities from IGMP group
 		 * address field
@@ -143,31 +143,31 @@ dvmrp_print(register const u_char *bp, register u_int len)
 		break;
 
 	case DVMRP_PRUNE:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," Prune");
+		ARGUSBUF_APPEND(" Prune");
 		if (print_prune(bp) < 0)
 			goto trunc;
 		break;
 
 	case DVMRP_GRAFT:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," Graft");
+		ARGUSBUF_APPEND(" Graft");
 		if (print_graft(bp) < 0)
 			goto trunc;
 		break;
 
 	case DVMRP_GRAFT_ACK:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," Graft-ACK");
+		ARGUSBUF_APPEND(" Graft-ACK");
 		if (print_graft_ack(bp) < 0)
 			goto trunc;
 		break;
 
 	default:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," [type %d]", type);
+		ARGUSBUF_APPEND(" [type %d]", type);
 		break;
 	}
 	return ArgusBuf;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|dvmrp]");
+	ARGUSBUF_APPEND("[|dvmrp]");
 	return ArgusBuf;
 }
 
@@ -181,7 +181,7 @@ print_report(register const u_char *bp, register const u_char *ep,
 
 	while (len > 0) {
 		if (len < 3) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|]");
+			ARGUSBUF_APPEND(" [|]");
 			return (0);
 		}
 		TCHECK2(bp[0], 3);
@@ -194,16 +194,16 @@ print_report(register const u_char *bp, register const u_char *ep,
 		if (bp[2])
 			width = 4;
 
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\tMask %s", intoa(htonl(mask)));
+		ARGUSBUF_APPEND("\n\tMask %s", intoa(htonl(mask)));
 		bp += 3;
 		len -= 3;
 		do {
 			if (bp + width + 1 > ep) {
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|]");
+				ARGUSBUF_APPEND(" [|]");
 				return (0);
 			}
 			if (len < width + 1) {
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  [Truncated Report]");
+				ARGUSBUF_APPEND("\n\t  [Truncated Report]");
 				return (0);
 			}
 			origin = 0;
@@ -218,7 +218,7 @@ print_report(register const u_char *bp, register const u_char *ep,
 			metric = *bp++;
 			done = metric & 0x80;
 			metric &= 0x7f;
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s metric %d", intoa(htonl(origin)),
+			ARGUSBUF_APPEND("\n\t  %s metric %d", intoa(htonl(origin)),
 				metric);
 			len -= width + 1;
 		} while (!done);
@@ -237,23 +237,23 @@ print_probe(register const u_char *bp, register const u_char *ep,
 	TCHECK2(bp[0], 4);
 	if ((len < 4) || ((bp + 4) > ep)) {
 		/* { (ctags) */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|}");
+		ARGUSBUF_APPEND(" [|}");
 		return (0);
 	}
 	genid = (bp[0] << 24) | (bp[1] << 16) | (bp[2] << 8) | bp[3];
 	bp += 4;
 	len -= 4;
 	if (ArgusParser->vflag > 1)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t");
+		ARGUSBUF_APPEND("\n\t");
 	else
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"genid %u", genid);
+		ARGUSBUF_APPEND(" ");
+	ARGUSBUF_APPEND("genid %u", genid);
 	if (ArgusParser->vflag < 2)
 		return (0);
 
 	while ((len > 0) && (bp < ep)) {
 		TCHECK2(bp[0], 4);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\tneighbor %s", ipaddr_string(bp));
+		ARGUSBUF_APPEND("\n\tneighbor %s", ipaddr_string(bp));
 		bp += 4; len -= 4;
 	}
 	return (0);
@@ -280,8 +280,8 @@ print_neighbors(register const u_char *bp, register const u_char *ep,
 		len -= 7;
 		while (--ncount >= 0) {
 			TCHECK2(bp[0], 4);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," [%s ->", ipaddr_string(laddr));
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s, (%d/%d)]",
+			ARGUSBUF_APPEND(" [%s ->", ipaddr_string(laddr));
+			ARGUSBUF_APPEND(" %s, (%d/%d)]",
 				   ipaddr_string(bp), metric, thresh);
 			bp += 4;
 			len -= 4;
@@ -300,7 +300,7 @@ print_neighbors2(register const u_char *bp, register const u_char *ep,
 	register u_char metric, thresh, flags;
 	register int ncount;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," (v %d.%d):",
+	ARGUSBUF_APPEND(" (v %d.%d):",
 	       (int)target_level & 0xff,
 	       (int)(target_level >> 8) & 0xff);
 
@@ -314,25 +314,25 @@ print_neighbors2(register const u_char *bp, register const u_char *ep,
 		ncount = *bp++;
 		len -= 8;
 		while (--ncount >= 0 && (len >= 4) && (bp + 4) <= ep) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," [%s -> ", ipaddr_string(laddr));
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s (%d/%d", ipaddr_string(bp),
+			ARGUSBUF_APPEND(" [%s -> ", ipaddr_string(laddr));
+			ARGUSBUF_APPEND("%s (%d/%d", ipaddr_string(bp),
 				     metric, thresh);
 			if (flags & DVMRP_NF_TUNNEL)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"/tunnel");
+				ARGUSBUF_APPEND("/tunnel");
 			if (flags & DVMRP_NF_SRCRT)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"/srcrt");
+				ARGUSBUF_APPEND("/srcrt");
 			if (flags & DVMRP_NF_QUERIER)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"/querier");
+				ARGUSBUF_APPEND("/querier");
 			if (flags & DVMRP_NF_DISABLED)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"/disabled");
+				ARGUSBUF_APPEND("/disabled");
 			if (flags & DVMRP_NF_DOWN)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"/down");
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],")]");
+				ARGUSBUF_APPEND("/down");
+			ARGUSBUF_APPEND(")]");
 			bp += 4;
 			len -= 4;
 		}
 		if (ncount != -1) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|]");
+			ARGUSBUF_APPEND(" [|]");
 			return (0);
 		}
 	}
@@ -345,9 +345,9 @@ static int
 print_prune(register const u_char *bp)
 {
 	TCHECK2(bp[0], 12);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," src %s grp %s", ipaddr_string(bp), ipaddr_string(bp + 4));
+	ARGUSBUF_APPEND(" src %s grp %s", ipaddr_string(bp), ipaddr_string(bp + 4));
 	bp += 8;
-	(void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," timer ");
+	ARGUSBUF_APPEND(" timer ");
 	relts_print(&ArgusBuf[strlen(ArgusBuf)],EXTRACT_32BITS(bp));
 	return (0);
 trunc:
@@ -358,7 +358,7 @@ static int
 print_graft(register const u_char *bp)
 {
 	TCHECK2(bp[0], 8);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," src %s grp %s", ipaddr_string(bp), ipaddr_string(bp + 4));
+	ARGUSBUF_APPEND(" src %s grp %s", ipaddr_string(bp), ipaddr_string(bp + 4));
 	return (0);
 trunc:
 	return (-1);
@@ -368,7 +368,7 @@ static int
 print_graft_ack(register const u_char *bp)
 {
 	TCHECK2(bp[0], 8);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," src %s grp %s", ipaddr_string(bp), ipaddr_string(bp + 4));
+	ARGUSBUF_APPEND(" src %s grp %s", ipaddr_string(bp), ipaddr_string(bp + 4));
 	return (0);
 trunc:
 	return (-1);

--- a/examples/radump/print-ether.c
+++ b/examples/radump/print-ether.c
@@ -52,24 +52,24 @@ ether_hdr_print(register const u_char *bp, u_int length)
    register const struct ether_header *ep;
    ep = (const struct ether_header *)bp;
 
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s > %s", etheraddr_string(ArgusParser, (u_char *)&ESRC(ep)),
+   ARGUSBUF_APPEND("%s > %s", etheraddr_string(ArgusParser, (u_char *)&ESRC(ep)),
                                                         etheraddr_string(ArgusParser, (u_char *)&EDST(ep)));
 
    if (!ArgusParser->qflag) {
            if (ntohs(ep->ether_type) <= ETHERMTU)
-                (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", 802.3");
+                ARGUSBUF_APPEND(", 802.3");
                 else 
-                (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", ethertype %s (0x%04x)",
+                ARGUSBUF_APPEND(", ethertype %s (0x%04x)",
                    tok2str(ethertype_values,"Unknown", ntohs(ep->ether_type)),
                                        ntohs(ep->ether_type));         
         } else {
                 if (ntohs(ep->ether_type) <= ETHERMTU)
-                          (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", 802.3");
+                          ARGUSBUF_APPEND(", 802.3");
                 else 
-                          (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", %s", tok2str(ethertype_values,"Unknown Ethertype (0x%04x)", ntohs(ep->ether_type)));  
+                          ARGUSBUF_APPEND(", %s", tok2str(ethertype_values,"Unknown Ethertype (0x%04x)", ntohs(ep->ether_type)));  
         }
 
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", length %u: ", length);
+   ARGUSBUF_APPEND(", length %u: ", length);
 }
 
 int ether_encap_print(u_short, const u_char *, u_int, u_int, u_short *);
@@ -87,7 +87,7 @@ ether_print(struct ArgusParserStruct *parser, struct ArgusRecordStruct *argus, c
       u_short extracted_ether_type;
 
       if (caplen < ETHER_HDRLEN) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|ether]");
+         ARGUSBUF_APPEND("[|ether]");
          return ArgusBuf;
       }
 
@@ -159,7 +159,7 @@ ether_encap_print(u_short ether_type, const u_char *p,
 
    case ETHERTYPE_ATALK:
       if (ArgusParser->vflag)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"et1 ");
+         ARGUSBUF_APPEND("et1 ");
       atalk_print(p, length);
       return (1);
 
@@ -168,13 +168,13 @@ ether_encap_print(u_short ether_type, const u_char *p,
       return (1);
 
    case ETHERTYPE_IPX:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"(NOV-ETHII) ");
+      ARGUSBUF_APPEND("(NOV-ETHII) ");
       ipx_print(p, length);
       return (1);
 
    case ETHERTYPE_8021Q:
            if (ArgusParser->eflag)
-          sprintf(&ArgusBuf[strlen(ArgusBuf)],"vlan %u, p %u%s, ",
+          ARGUSBUF_APPEND("vlan %u, p %u%s, ",
             ntohs(*(u_int16_t *)p) & 0xfff,
             ntohs(*(u_int16_t *)p) >> 13,
             (ntohs(*(u_int16_t *)p) & 0x1000) ? ", CFI" : "");
@@ -186,7 +186,7 @@ ether_encap_print(u_short ether_type, const u_char *p,
 
       if (ether_type > ETHERMTU) {
               if (ArgusParser->eflag)
-                 sprintf(&ArgusBuf[strlen(ArgusBuf)],"ethertype %s, ",
+                 ARGUSBUF_APPEND("ethertype %s, ",
                    tok2str(ethertype_values,"0x%04x", ether_type));
          goto recurse;
       }
@@ -210,7 +210,7 @@ ether_encap_print(u_short ether_type, const u_char *p,
 
                 if (ether_type > ETHERMTU) {
                     if (ArgusParser->eflag)
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],"ethertype %s, ",
+                        ARGUSBUF_APPEND("ethertype %s, ",
                                tok2str(ethertype_values,"0x%04x", ether_type));
                     goto recurse;
                 }
@@ -242,7 +242,7 @@ ether_encap_print(u_short ether_type, const u_char *p,
 
    case ETHERTYPE_PPP:
       if (length) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],": ");
+         ARGUSBUF_APPEND(": ");
          ppp_print(p, length);
       }
       return (1);

--- a/examples/radump/print-igmp.c
+++ b/examples/radump/print-igmp.c
@@ -119,7 +119,7 @@ print_mtrace(register const u_char *bp, register u_int len)
 
     TCHECK(*tr);
     if (len < 8 + sizeof (struct tr_query)) {
-	(void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [invalid len %d]", len);
+	ARGUSBUF_APPEND(" [invalid len %d]", len);
 	return;
     }
 
@@ -127,15 +127,15 @@ print_mtrace(register const u_char *bp, register u_int len)
     tr->tr_dst   = EXTRACT_32BITS(&tr->tr_dst);
     tr->tr_raddr = EXTRACT_32BITS(&tr->tr_raddr);
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"mtrace %u: %s to %s reply-to %s",
+    ARGUSBUF_APPEND("mtrace %u: %s to %s reply-to %s",
         TR_GETQID(EXTRACT_32BITS(&tr->tr_rttlqid)),
         ipaddr_string(&tr->tr_src), ipaddr_string(&tr->tr_dst),
         ipaddr_string(&tr->tr_raddr));
     if (IN_CLASSD(EXTRACT_32BITS(&tr->tr_raddr)))
-        sprintf(&ArgusBuf[strlen(ArgusBuf)]," with-ttl %d", TR_GETTTL(EXTRACT_32BITS(&tr->tr_rttlqid)));
+        ARGUSBUF_APPEND(" with-ttl %d", TR_GETTTL(EXTRACT_32BITS(&tr->tr_rttlqid)));
     return;
 trunc:
-    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|igmp]");
+    ARGUSBUF_APPEND("[|igmp]");
     return;
 }
 
@@ -146,7 +146,7 @@ print_mresp(register const u_char *bp, register u_int len)
 
     TCHECK(*tr);
     if (len < 8 + sizeof (struct tr_query)) {
-	(void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [invalid len %d]", len);
+	ARGUSBUF_APPEND(" [invalid len %d]", len);
 	return;
     }
 
@@ -154,15 +154,15 @@ print_mresp(register const u_char *bp, register u_int len)
     tr->tr_dst   = EXTRACT_32BITS(&tr->tr_dst);
     tr->tr_raddr = EXTRACT_32BITS(&tr->tr_raddr);
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"mresp %lu: %s to %s reply-to %s",
+    ARGUSBUF_APPEND("mresp %lu: %s to %s reply-to %s",
         (u_long)TR_GETQID(EXTRACT_32BITS(&tr->tr_rttlqid)),
         ipaddr_string(&tr->tr_src), ipaddr_string(&tr->tr_dst),
         ipaddr_string(&tr->tr_raddr));
     if (IN_CLASSD(EXTRACT_32BITS(&tr->tr_raddr)))
-        sprintf(&ArgusBuf[strlen(ArgusBuf)]," with-ttl %d", TR_GETTTL(EXTRACT_32BITS(&tr->tr_rttlqid)));
+        ARGUSBUF_APPEND(" with-ttl %d", TR_GETTTL(EXTRACT_32BITS(&tr->tr_rttlqid)));
     return;
 trunc:
-    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|igmp]");
+    ARGUSBUF_APPEND("[|igmp]");
     return;
 }
 
@@ -174,51 +174,51 @@ print_igmpv3_report(register const u_char *bp, register u_int len)
 
     /* Minimum len is 16, and should be a multiple of 4 */
     if (len < 16 || len & 0x03) {
-	(void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [invalid len %d]", len);
+	ARGUSBUF_APPEND(" [invalid len %d]", len);
 	return;
     }
     TCHECK2(bp[6], 2);
     ngroups = EXTRACT_16BITS(&bp[6]);
-    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", %d group record(s)", ngroups);
+    ARGUSBUF_APPEND(", %d group record(s)", ngroups);
     if (ArgusParser->vflag > 0) {
 	/* Print the group records */
 	group = 8;
         for (i=0; i<ngroups; i++) {
 	    if (len < group+8) {
-		(void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [invalid number of groups]");
+		ARGUSBUF_APPEND(" [invalid number of groups]");
 		return;
 	    }
 	    TCHECK2(bp[group+4], 4);
 	    haddr = EXTRACT_32BITS(&bp[group+4]);
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [gaddr %s", ipaddr_string(&haddr));
-	    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", tok2str(igmpv3report2str, " [v3-report-#%d]",
+            ARGUSBUF_APPEND(" [gaddr %s", ipaddr_string(&haddr));
+	    ARGUSBUF_APPEND(" %s", tok2str(igmpv3report2str, " [v3-report-#%d]",
 								bp[group]));
             nsrcs = EXTRACT_16BITS(&bp[group+2]);
 	    /* Check the number of sources and print them */
 	    if (len < group+8+(nsrcs<<2)) {
-		(void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [invalid number of sources %d]", nsrcs);
+		ARGUSBUF_APPEND(" [invalid number of sources %d]", nsrcs);
 		return;
 	    }
             if (ArgusParser->vflag == 1)
-                (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", %d source(s)", nsrcs);
+                ARGUSBUF_APPEND(", %d source(s)", nsrcs);
             else {
 		/* Print the sources */
-                (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," {");
+                ARGUSBUF_APPEND(" {");
                 for (j=0; j<nsrcs; j++) {
 		    TCHECK2(bp[group+8+(j<<2)], 4);
 	            haddr = EXTRACT_32BITS(&bp[group+8+(j<<2)]);
-		    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", ipaddr_string(&haddr));
+		    ARGUSBUF_APPEND(" %s", ipaddr_string(&haddr));
 		}
-                (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," }");
+                ARGUSBUF_APPEND(" }");
             }
 	    /* Next group record */
             group += 8 + (nsrcs << 2);
-	    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"]");
+	    ARGUSBUF_APPEND("]");
         }
     }
     return;
 trunc:
-    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|igmp]");
+    ARGUSBUF_APPEND("[|igmp]");
     return;
 }
 
@@ -230,10 +230,10 @@ print_igmpv3_query(register const u_char *bp, register u_int len)
     u_int nsrcs;
     register u_int i;
 
-    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," v3");
+    ARGUSBUF_APPEND(" v3");
     /* Minimum len is 12, and should be a multiple of 4 */
     if (len < 12 || len & 0x03) {
-	(void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [invalid len %d]", len);
+	ARGUSBUF_APPEND(" [invalid len %d]", len);
 	return;
     }
     TCHECK(bp[1]);
@@ -244,34 +244,34 @@ print_igmpv3_query(register const u_char *bp, register u_int len)
         mrt = ((mrc & 0x0f) | 0x10) << (((mrc & 0x70) >> 4) + 3);
     }
     if (mrc != 100) {
-	(void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [max resp time ");
+	ARGUSBUF_APPEND(" [max resp time ");
 	relts_print(&ArgusBuf[strlen(ArgusBuf)], mrt);
-	(void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"]");
+	ARGUSBUF_APPEND("]");
     }
     TCHECK2(bp[4], 4);
     if ((haddr = EXTRACT_32BITS(&bp[4])) == 0)
 	return;
-    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [gaddr %s", ipaddr_string(&haddr));
+    ARGUSBUF_APPEND(" [gaddr %s", ipaddr_string(&haddr));
     TCHECK2(bp[10], 2);
     nsrcs = EXTRACT_16BITS(&bp[10]);
     if (nsrcs > 0) {
 	if (len < 12 + (nsrcs << 2))
-	    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [invalid number of sources]");
+	    ARGUSBUF_APPEND(" [invalid number of sources]");
 	else if (ArgusParser->vflag > 1) {
-	    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," {");
+	    ARGUSBUF_APPEND(" {");
 	    for (i=0; i<nsrcs; i++) {
 		TCHECK2(bp[12+(i<<2)], 4);
 	        haddr = EXTRACT_32BITS(&bp[12+(i<<2)]);
-		(void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", ipaddr_string(&haddr));
+		ARGUSBUF_APPEND(" %s", ipaddr_string(&haddr));
 	    }
-	    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," }");
+	    ARGUSBUF_APPEND(" }");
 	} else
-	    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", %d source(s)", nsrcs);
+	    ARGUSBUF_APPEND(", %d source(s)", nsrcs);
     }
-    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"]");
+    ARGUSBUF_APPEND("]");
     return;
 trunc:
-    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|igmp]");
+    ARGUSBUF_APPEND("[|igmp]");
     return;
 }
 
@@ -281,61 +281,61 @@ igmp_print(register const u_char *bp, register u_int len)
 {
     unsigned int haddr;
     if (ArgusParser->qflag) {
-        (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"igmp");
+        ARGUSBUF_APPEND("igmp");
         return ArgusBuf;
     }
 
     TCHECK(bp[0]);
     switch (bp[0]) {
     case 0x11:
-        (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"igmp query");
+        ARGUSBUF_APPEND("igmp query");
 	if (len >= 12)
 	    print_igmpv3_query(bp, len);
 	else {
             TCHECK(bp[1]);
 	    if (bp[1]) {
-		(void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," v2");
+		ARGUSBUF_APPEND(" v2");
 		if (bp[1] != 100)
-		    (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [max resp time %d]", bp[1]);
+		    ARGUSBUF_APPEND(" [max resp time %d]", bp[1]);
 	    } else
-		(void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," v1");
+		ARGUSBUF_APPEND(" v1");
             TCHECK2(bp[4], 4);
 	    haddr = EXTRACT_32BITS(&bp[4]);
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [gaddr %s]", ipaddr_string(&haddr));
+            ARGUSBUF_APPEND(" [gaddr %s]", ipaddr_string(&haddr));
             if (len != 8)
-                (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [len %d]", len);
+                ARGUSBUF_APPEND(" [len %d]", len);
 	}
         break;
     case 0x12:
         TCHECK2(bp[4], 4);
 	haddr = EXTRACT_32BITS(&bp[4]);
-        (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"igmp v1 report %s", ipaddr_string(&haddr));
+        ARGUSBUF_APPEND("igmp v1 report %s", ipaddr_string(&haddr));
         if (len != 8)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [len %d]", len);
+            ARGUSBUF_APPEND(" [len %d]", len);
         break;
     case 0x16:
         TCHECK2(bp[4], 4);
 	haddr = EXTRACT_32BITS(&bp[4]);
-        (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"igmp v2 report %s", ipaddr_string(&haddr));
+        ARGUSBUF_APPEND("igmp v2 report %s", ipaddr_string(&haddr));
         break;
     case 0x22:
-        (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"igmp v3 report");
+        ARGUSBUF_APPEND("igmp v3 report");
 	print_igmpv3_report(bp, len);
         break;
     case 0x17:
         TCHECK2(bp[4], 4);
 	haddr = EXTRACT_32BITS(&bp[4]);
-        (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"igmp leave %s", ipaddr_string(&haddr));
+        ARGUSBUF_APPEND("igmp leave %s", ipaddr_string(&haddr));
         break;
     case 0x13:
-        (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"igmp dvmrp");
+        ARGUSBUF_APPEND("igmp dvmrp");
         if (len < 8)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [len %d]", len);
+            ARGUSBUF_APPEND(" [len %d]", len);
         else
             dvmrp_print(bp, len);
         break;
     case 0x14:
-        (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"igmp pimv1");
+        ARGUSBUF_APPEND("igmp pimv1");
         pimv1_print(bp, len);
         break;
     case 0x1e:
@@ -345,20 +345,20 @@ igmp_print(register const u_char *bp, register u_int len)
         print_mtrace(bp, len);
         break;
     default:
-        (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"igmp-%d", bp[0]);
+        ARGUSBUF_APPEND("igmp-%d", bp[0]);
         break;
     }
 
     if (ArgusParser->vflag && TTEST2(bp[0], len)) {
         /* Check the IGMP checksum 
         if (in_cksum((const u_short*)bp, len, 0))
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," bad igmp cksum %x!", EXTRACT_16BITS(&bp[2]));
+            ARGUSBUF_APPEND(" bad igmp cksum %x!", EXTRACT_16BITS(&bp[2]));
         */
     }
 
     return ArgusBuf;
 
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|igmp]");
+    ARGUSBUF_APPEND("[|igmp]");
     return ArgusBuf;
 }

--- a/examples/radump/print-isakmp.c
+++ b/examples/radump/print-isakmp.c
@@ -334,7 +334,7 @@ rawprint(caddr_t loc, size_t len)
 	
 	p = (u_char *)loc;
 	for (i = 0; i < len; i++)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02x", p[i] & 0xff);
+		ARGUSBUF_APPEND("%02x", p[i] & 0xff);
 	return 1;
 trunc:
 	return 0;
@@ -360,28 +360,28 @@ isakmp_attrmap_print(const u_char *p, const u_char *ep,
 	else
 		totlen = 4 + EXTRACT_16BITS(&q[1]);
 	if (ep < p + totlen) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|attr]");
+		ARGUSBUF_APPEND("[|attr]");
 		return ep + 1;
 	}
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"(");
+	ARGUSBUF_APPEND("(");
 	t = EXTRACT_16BITS(&q[0]) & 0x7fff;
 	if (map && t < nmap && map[t].type)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"type=%s ", map[t].type);
+		ARGUSBUF_APPEND("type=%s ", map[t].type);
 	else
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"type=#%d ", t);
+		ARGUSBUF_APPEND("type=#%d ", t);
 	if (p[0] & 0x80) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"value=");
+		ARGUSBUF_APPEND("value=");
 		v = EXTRACT_16BITS(&q[1]);
 		if (map && t < nmap && v < map[t].nvalue && map[t].value[v])
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", map[t].value[v]);
+			ARGUSBUF_APPEND("%s", map[t].value[v]);
 		else
 			rawprint((caddr_t)&q[1], 2);
 	} else {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"len=%d value=", EXTRACT_16BITS(&q[1]));
+		ARGUSBUF_APPEND("len=%d value=", EXTRACT_16BITS(&q[1]));
 		rawprint((caddr_t)&p[4], EXTRACT_16BITS(&q[1]));
 	}
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+	ARGUSBUF_APPEND(")");
 	return p + totlen;
 }
 
@@ -398,22 +398,22 @@ isakmp_attr_print(const u_char *p, const u_char *ep)
 	else
 		totlen = 4 + EXTRACT_16BITS(&q[1]);
 	if (ep < p + totlen) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|attr]");
+		ARGUSBUF_APPEND("[|attr]");
 		return ep + 1;
 	}
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"(");
+	ARGUSBUF_APPEND("(");
 	t = EXTRACT_16BITS(&q[0]) & 0x7fff;
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"type=#%d ", t);
+	ARGUSBUF_APPEND("type=#%d ", t);
 	if (p[0] & 0x80) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"value=");
+		ARGUSBUF_APPEND("value=");
 		t = q[1];
 		rawprint((caddr_t)&q[1], 2);
 	} else {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"len=%d value=", EXTRACT_16BITS(&q[1]));
+		ARGUSBUF_APPEND("len=%d value=", EXTRACT_16BITS(&q[1]));
 		rawprint((caddr_t)&p[2], EXTRACT_16BITS(&q[1]));
 	}
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+	ARGUSBUF_APPEND(")");
 	return p + totlen;
 }
 
@@ -430,7 +430,7 @@ isakmp_sa_print(const struct isakmp_gen *ext,
 	const u_char *cp, *np;
 	int t;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_SA));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_SA));
 
 	p = (struct isakmp_pl_sa *)ext;
 	TCHECK(*p);
@@ -438,31 +438,31 @@ isakmp_sa_print(const struct isakmp_gen *ext,
 	doi = ntohl(sa.doi);
 	sit = ntohl(sa.sit);
 	if (doi != 1) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," doi=%d", doi);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," situation=%u", (u_int32_t)ntohl(sa.sit));
+		ARGUSBUF_APPEND(" doi=%d", doi);
+		ARGUSBUF_APPEND(" situation=%u", (u_int32_t)ntohl(sa.sit));
 		return (u_char *)(p + 1);
 	}
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," doi=ipsec");
+	ARGUSBUF_APPEND(" doi=ipsec");
 //	q = (u_int32_t *)&sa.sit;
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," situation=");
+	ARGUSBUF_APPEND(" situation=");
 	t = 0;
 	if (sit & 0x01) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"identity");
+		ARGUSBUF_APPEND("identity");
 		t++;
 	}
 	if (sit & 0x02) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%ssecrecy", t ? "+" : "");
+		ARGUSBUF_APPEND("%ssecrecy", t ? "+" : "");
 		t++;
 	}
 	if (sit & 0x04)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%sintegrity", t ? "+" : "");
+		ARGUSBUF_APPEND("%sintegrity", t ? "+" : "");
 
 	np = (u_char *)ext + sizeof(sa);
 	if (sit != 0x01) {
 		TCHECK2(*(ext + 1), sizeof(ident));
 		safememcpy(&ident, ext + 1, sizeof(ident));
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ident=%u", (u_int32_t)ntohl(ident));
+		ARGUSBUF_APPEND(" ident=%u", (u_int32_t)ntohl(ident));
 		np += sizeof(ident);
 	}
 
@@ -474,7 +474,7 @@ isakmp_sa_print(const struct isakmp_gen *ext,
 
 	return cp;
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_SA));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_SA));
 	return NULL;
 }
 
@@ -487,15 +487,15 @@ isakmp_p_print(const struct isakmp_gen *ext, u_int item_len,
 	struct isakmp_pl_p prop;
 	const u_char *cp;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_P));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_P));
 
 	p = (struct isakmp_pl_p *)ext;
 	TCHECK(*p);
 	safememcpy(&prop, ext, sizeof(prop));
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," #%d protoid=%s transform=%d",
+	ARGUSBUF_APPEND(" #%d protoid=%s transform=%d",
 		prop.p_no, PROTOIDSTR(prop.prot_id), prop.num_t);
 	if (prop.spi_size) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," spi=");
+		ARGUSBUF_APPEND(" spi=");
 		if (!rawprint((caddr_t)(p + 1), prop.spi_size))
 			goto trunc;
 	}
@@ -508,7 +508,7 @@ isakmp_p_print(const struct isakmp_gen *ext, u_int item_len,
 
 	return cp;
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_P));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_P));
 	return NULL;
 }
 
@@ -581,7 +581,7 @@ isakmp_t_print(const struct isakmp_gen *ext, u_int item_len,
 	size_t nmap;
 	const u_char *ep2;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_T));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_T));
 
 	p = (struct isakmp_pl_t *)ext;
 	TCHECK(*p);
@@ -616,9 +616,9 @@ isakmp_t_print(const struct isakmp_gen *ext, u_int item_len,
 	}
 
 	if (idstr)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," #%d id=%s ", t.t_no, idstr);
+		ARGUSBUF_APPEND(" #%d id=%s ", t.t_no, idstr);
 	else
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," #%d id=%d ", t.t_no, t.t_id);
+		ARGUSBUF_APPEND(" #%d id=%d ", t.t_no, t.t_id);
 	cp = (u_char *)(p + 1);
 	ep2 = (u_char *)p + item_len;
 	while (cp < ep && cp < ep2) {
@@ -629,10 +629,10 @@ isakmp_t_print(const struct isakmp_gen *ext, u_int item_len,
 			cp = isakmp_attr_print(cp, (ep < ep2) ? ep : ep2);
 	}
 	if (ep < ep2)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+		ARGUSBUF_APPEND("...");
 	return cp;
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_T));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_T));
 	return NULL;
 }
 
@@ -643,19 +643,19 @@ isakmp_ke_print(const struct isakmp_gen *ext, u_int item_len,
 {
 	struct isakmp_gen e;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_KE));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_KE));
 
 	TCHECK(*ext);
 	safememcpy(&e, ext, sizeof(e));
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," key len=%d", ntohs(e.len) - 4);
+	ARGUSBUF_APPEND(" key len=%d", ntohs(e.len) - 4);
 	if (2 < ArgusParser->vflag && 4 < ntohs(e.len)) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+		ARGUSBUF_APPEND(" ");
 		if (!rawprint((caddr_t)(ext + 1), ntohs(e.len) - 4))
 			goto trunc;
 	}
 	return (u_char *)ext + ntohs(e.len);
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_KE));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_KE));
 	return NULL;
 }
 
@@ -678,7 +678,7 @@ isakmp_id_print(const struct isakmp_gen *ext, u_int item_len,
 	int len;
 	const u_char *data;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_ID));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_ID));
 
 	p = (struct isakmp_pl_id *)ext;
 	TCHECK(*p);
@@ -692,15 +692,15 @@ isakmp_id_print(const struct isakmp_gen *ext, u_int item_len,
 	}
 
 #if 0 /*debug*/
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [phase=%d doi=%d proto=%d]", phase, doi, proto);
+	ARGUSBUF_APPEND(" [phase=%d doi=%d proto=%d]", phase, doi, proto);
 #endif
 	switch (phase) {
 #ifndef USE_IPSECDOI_IN_PHASE1
 	case 1:
 #endif
 	default:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," idtype=%s", STR_OR_ID(id.d.id_type, idtypestr));
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," doi_data=%u",
+		ARGUSBUF_APPEND(" idtype=%s", STR_OR_ID(id.d.id_type, idtypestr));
+		ARGUSBUF_APPEND(" doi_data=%u",
 			(u_int32_t)(ntohl(id.d.doi_data) & 0xffffff));
 		break;
 
@@ -716,22 +716,22 @@ isakmp_id_print(const struct isakmp_gen *ext, u_int item_len,
 		p = (struct ipsecdoi_id *)ext;
 		TCHECK(*p);
 		safememcpy(&id, ext, sizeof(id));
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," idtype=%s", STR_OR_ID(id.type, ipsecidtypestr));
+		ARGUSBUF_APPEND(" idtype=%s", STR_OR_ID(id.type, ipsecidtypestr));
 		if (id.proto_id) {
 #ifndef WIN32
 			setprotoent(1);
 #endif /* WIN32 */
 			pe = getprotobynumber(id.proto_id);
 			if (pe)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," protoid=%s", pe->p_name);
+				ARGUSBUF_APPEND(" protoid=%s", pe->p_name);
 #ifndef WIN32
 			endprotoent();
 #endif /* WIN32 */
 		} else {
 			/* it DOES NOT mean IPPROTO_IP! */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," protoid=%s", "0");
+			ARGUSBUF_APPEND(" protoid=%s", "0");
 		}
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," port=%d", ntohs(id.port));
+		ARGUSBUF_APPEND(" port=%d", ntohs(id.port));
 		if (!len)
 			break;
 		if (data == NULL)
@@ -740,18 +740,18 @@ isakmp_id_print(const struct isakmp_gen *ext, u_int item_len,
 		switch (id.type) {
 		case IPSECDOI_ID_IPV4_ADDR:
 			if (len < 4)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d [bad: < 4]", len);
+				ARGUSBUF_APPEND(" len=%d [bad: < 4]", len);
 			else
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d %s", len, ipaddr_string(data));
+				ARGUSBUF_APPEND(" len=%d %s", len, ipaddr_string(data));
 			len = 0;
 			break;
 		case IPSECDOI_ID_FQDN:
 		case IPSECDOI_ID_USER_FQDN:
 		    {
 			int i;
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d ", len);
+			ARGUSBUF_APPEND(" len=%d ", len);
 			for (i = 0; i < len; i++)
-			   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%c", data[i]);
+			   ARGUSBUF_APPEND("%c", data[i]);
 			len = 0;
 			break;
 		    }
@@ -759,10 +759,10 @@ isakmp_id_print(const struct isakmp_gen *ext, u_int item_len,
 		    {
 			const u_char *mask;
 			if (len < 8)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d [bad: < 8]", len);
+				ARGUSBUF_APPEND(" len=%d [bad: < 8]", len);
 			else {
 				mask = data + sizeof(struct in_addr);
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d %s/%u.%u.%u.%u", len,
+				ARGUSBUF_APPEND(" len=%d %s/%u.%u.%u.%u", len,
 					ipaddr_string(data),
 					mask[0], mask[1], mask[2], mask[3]);
 			}
@@ -772,20 +772,20 @@ isakmp_id_print(const struct isakmp_gen *ext, u_int item_len,
 #ifdef INET6
 		case IPSECDOI_ID_IPV6_ADDR:
 			if (len < 16)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d [bad: < 16]", len);
+				ARGUSBUF_APPEND(" len=%d [bad: < 16]", len);
 			else
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d %s", len, ip6addr_string(data));
+				ARGUSBUF_APPEND(" len=%d %s", len, ip6addr_string(data));
 			len = 0;
 			break;
 		case IPSECDOI_ID_IPV6_ADDR_SUBNET:
 		    {
 			const u_int32_t *mask;
 			if (len < 20)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d [bad: < 20]", len);
+				ARGUSBUF_APPEND(" len=%d [bad: < 20]", len);
 			else {
 				mask = (u_int32_t *)(data + sizeof(struct in6_addr));
 				/*XXX*/
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d %s/0x%08x%08x%08x%08x", len,
+				ARGUSBUF_APPEND(" len=%d %s/0x%08x%08x%08x%08x", len,
 					ip6addr_string(data),
 					mask[0], mask[1], mask[2], mask[3]);
 			}
@@ -795,9 +795,9 @@ isakmp_id_print(const struct isakmp_gen *ext, u_int item_len,
 #endif /*INET6*/
 		case IPSECDOI_ID_IPV4_ADDR_RANGE:
 			if (len < 8)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d [bad: < 8]", len);
+				ARGUSBUF_APPEND(" len=%d [bad: < 8]", len);
 			else {
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d %s-%s", len,
+				ARGUSBUF_APPEND(" len=%d %s-%s", len,
 					ipaddr_string(data),
 					ipaddr_string(data + sizeof(struct in_addr)));
 			}
@@ -806,9 +806,9 @@ isakmp_id_print(const struct isakmp_gen *ext, u_int item_len,
 #ifdef INET6
 		case IPSECDOI_ID_IPV6_ADDR_RANGE:
 			if (len < 32)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d [bad: < 32]", len);
+				ARGUSBUF_APPEND(" len=%d [bad: < 32]", len);
 			else {
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d %s-%s", len,
+				ARGUSBUF_APPEND(" len=%d %s-%s", len,
 					ip6addr_string(data),
 					ip6addr_string(data + sizeof(struct in6_addr)));
 			}
@@ -824,16 +824,16 @@ isakmp_id_print(const struct isakmp_gen *ext, u_int item_len,
 	    }
 	}
 	if (data && len) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d", len);
+		ARGUSBUF_APPEND(" len=%d", len);
 		if (2 < ArgusParser->vflag) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+			ARGUSBUF_APPEND(" ");
 			if (!rawprint((caddr_t)data, len))
 				goto trunc;
 		}
 	}
 	return (u_char *)ext + item_len;
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_ID));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_ID));
 	return NULL;
 }
 
@@ -851,21 +851,21 @@ isakmp_cert_print(const struct isakmp_gen *ext, u_int item_len,
 		"arl", "spki", "x509attr",
 	};
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_CERT));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_CERT));
 
 	p = (struct isakmp_pl_cert *)ext;
 	TCHECK(*p);
 	safememcpy(&cert, ext, sizeof(cert));
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d", item_len - 4);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," type=%s", STR_OR_ID((cert.encode), certstr));
+	ARGUSBUF_APPEND(" len=%d", item_len - 4);
+	ARGUSBUF_APPEND(" type=%s", STR_OR_ID((cert.encode), certstr));
 	if (2 < ArgusParser->vflag && 4 < item_len) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+		ARGUSBUF_APPEND(" ");
 		if (!rawprint((caddr_t)(ext + 1), item_len - 4))
 			goto trunc;
 	}
 	return (u_char *)ext + item_len;
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_CERT));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_CERT));
 	return NULL;
 }
 
@@ -882,21 +882,21 @@ isakmp_cr_print(const struct isakmp_gen *ext, u_int item_len,
 		"arl", "spki", "x509attr",
 	};
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_CR));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_CR));
 
 	p = (struct isakmp_pl_cert *)ext;
 	TCHECK(*p);
 	safememcpy(&cert, ext, sizeof(cert));
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d", item_len - 4);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," type=%s", STR_OR_ID((cert.encode), certstr));
+	ARGUSBUF_APPEND(" len=%d", item_len - 4);
+	ARGUSBUF_APPEND(" type=%s", STR_OR_ID((cert.encode), certstr));
 	if (2 < ArgusParser->vflag && 4 < item_len) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+		ARGUSBUF_APPEND(" ");
 		if (!rawprint((caddr_t)(ext + 1), item_len - 4))
 			goto trunc;
 	}
 	return (u_char *)ext + item_len;
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_CR));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_CR));
 	return NULL;
 }
 
@@ -907,19 +907,19 @@ isakmp_hash_print(const struct isakmp_gen *ext, u_int item_len,
 {
 	struct isakmp_gen e;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_HASH));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_HASH));
 
 	TCHECK(*ext);
 	safememcpy(&e, ext, sizeof(e));
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d", ntohs(e.len) - 4);
+	ARGUSBUF_APPEND(" len=%d", ntohs(e.len) - 4);
 	if (2 < ArgusParser->vflag && 4 < ntohs(e.len)) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+		ARGUSBUF_APPEND(" ");
 		if (!rawprint((caddr_t)(ext + 1), ntohs(e.len) - 4))
 			goto trunc;
 	}
 	return (u_char *)ext + ntohs(e.len);
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_HASH));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_HASH));
 	return NULL;
 }
 
@@ -930,19 +930,19 @@ isakmp_sig_print(const struct isakmp_gen *ext, u_int item_len,
 {
 	struct isakmp_gen e;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_SIG));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_SIG));
 
 	TCHECK(*ext);
 	safememcpy(&e, ext, sizeof(e));
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d", ntohs(e.len) - 4);
+	ARGUSBUF_APPEND(" len=%d", ntohs(e.len) - 4);
 	if (2 < ArgusParser->vflag && 4 < ntohs(e.len)) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+		ARGUSBUF_APPEND(" ");
 		if (!rawprint((caddr_t)(ext + 1), ntohs(e.len) - 4))
 			goto trunc;
 	}
 	return (u_char *)ext + ntohs(e.len);
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_SIG));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_SIG));
 	return NULL;
 }
 
@@ -955,19 +955,19 @@ isakmp_nonce_print(const struct isakmp_gen *ext,
 {
 	struct isakmp_gen e;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_NONCE));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_NONCE));
 
 	TCHECK(*ext);
 	safememcpy(&e, ext, sizeof(e));
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," n len=%d", ntohs(e.len) - 4);
+	ARGUSBUF_APPEND(" n len=%d", ntohs(e.len) - 4);
 	if (2 < ArgusParser->vflag && 4 < ntohs(e.len)) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+		ARGUSBUF_APPEND(" ");
 		if (!rawprint((caddr_t)(ext + 1), ntohs(e.len) - 4))
 			goto trunc;
 	}
 	return (u_char *)ext + ntohs(e.len);
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_NONCE));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_NONCE));
 	return NULL;
 }
 
@@ -1027,7 +1027,7 @@ isakmp_n_print(const struct isakmp_gen *ext, u_int item_len,
 #define IPSEC_NOTIFY_STATUS_STR(x) \
 	STR_OR_ID((u_int)((x) - 24576), ipsec_notify_status_str)
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_N));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_N));
 
 	p = (struct isakmp_pl_n *)ext;
 	TCHECK(*p);
@@ -1035,38 +1035,38 @@ isakmp_n_print(const struct isakmp_gen *ext, u_int item_len,
 	doi = ntohl(n.doi);
 	proto = n.prot_id;
 	if (doi != 1) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," doi=%d", doi);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," proto=%d", proto);
+		ARGUSBUF_APPEND(" doi=%d", doi);
+		ARGUSBUF_APPEND(" proto=%d", proto);
 		if (ntohs(n.type) < 8192)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," type=%s", NOTIFY_ERROR_STR(ntohs(n.type)));
+			ARGUSBUF_APPEND(" type=%s", NOTIFY_ERROR_STR(ntohs(n.type)));
 		else if (ntohs(n.type) < 16384)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," type=%s", numstr(ntohs(n.type)));
+			ARGUSBUF_APPEND(" type=%s", numstr(ntohs(n.type)));
 		else if (ntohs(n.type) < 24576)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," type=%s", NOTIFY_STATUS_STR(ntohs(n.type)));
+			ARGUSBUF_APPEND(" type=%s", NOTIFY_STATUS_STR(ntohs(n.type)));
 		else
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," type=%s", numstr(ntohs(n.type)));
+			ARGUSBUF_APPEND(" type=%s", numstr(ntohs(n.type)));
 		if (n.spi_size) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," spi=");
+			ARGUSBUF_APPEND(" spi=");
 			if (!rawprint((caddr_t)(p + 1), n.spi_size))
 				goto trunc;
 		}
 		return (u_char *)(p + 1) + n.spi_size;
 	}
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," doi=ipsec");
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," proto=%s", PROTOIDSTR(proto));
+	ARGUSBUF_APPEND(" doi=ipsec");
+	ARGUSBUF_APPEND(" proto=%s", PROTOIDSTR(proto));
 	if (ntohs(n.type) < 8192)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," type=%s", NOTIFY_ERROR_STR(ntohs(n.type)));
+		ARGUSBUF_APPEND(" type=%s", NOTIFY_ERROR_STR(ntohs(n.type)));
 	else if (ntohs(n.type) < 16384)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," type=%s", IPSEC_NOTIFY_ERROR_STR(ntohs(n.type)));
+		ARGUSBUF_APPEND(" type=%s", IPSEC_NOTIFY_ERROR_STR(ntohs(n.type)));
 	else if (ntohs(n.type) < 24576)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," type=%s", NOTIFY_STATUS_STR(ntohs(n.type)));
+		ARGUSBUF_APPEND(" type=%s", NOTIFY_STATUS_STR(ntohs(n.type)));
 	else if (ntohs(n.type) < 32768)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," type=%s", IPSEC_NOTIFY_STATUS_STR(ntohs(n.type)));
+		ARGUSBUF_APPEND(" type=%s", IPSEC_NOTIFY_STATUS_STR(ntohs(n.type)));
 	else
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," type=%s", numstr(ntohs(n.type)));
+		ARGUSBUF_APPEND(" type=%s", numstr(ntohs(n.type)));
 	if (n.spi_size) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," spi=");
+		ARGUSBUF_APPEND(" spi=");
 		if (!rawprint((caddr_t)(p + 1), n.spi_size))
 			goto trunc;
 	}
@@ -1075,7 +1075,7 @@ isakmp_n_print(const struct isakmp_gen *ext, u_int item_len,
 	ep2 = (u_char *)p + item_len;
 
 	if (cp < ep) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," orig=(");
+		ARGUSBUF_APPEND(" orig=(");
 		switch (ntohs(n.type)) {
 		case IPSECDOI_NTYPE_RESPONDER_LIFETIME:
 		    {
@@ -1088,7 +1088,7 @@ isakmp_n_print(const struct isakmp_gen *ext, u_int item_len,
 			break;
 		    }
 		case IPSECDOI_NTYPE_REPLAY_STATUS:
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"replay detection %sabled",
+			ARGUSBUF_APPEND("replay detection %sabled",
 				(*(u_int32_t *)cp) ? "en" : "dis");
 			break;
 		case ISAKMP_NTYPE_NO_PROPOSAL_CHOSEN:
@@ -1101,11 +1101,11 @@ isakmp_n_print(const struct isakmp_gen *ext, u_int item_len,
 			/* NULL is dummy */
 			isakmp_print(cp, item_len - sizeof(*p) - n.spi_size);
 		}
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+		ARGUSBUF_APPEND(")");
 	}
 	return (u_char *)ext + item_len;
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_N));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_N));
 	return NULL;
 }
 
@@ -1121,7 +1121,7 @@ isakmp_d_print(const struct isakmp_gen *ext, u_int item_len,
 	u_int32_t proto;
 	int i;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_D));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_D));
 
 	p = (struct isakmp_pl_d *)ext;
 	TCHECK(*p);
@@ -1129,26 +1129,26 @@ isakmp_d_print(const struct isakmp_gen *ext, u_int item_len,
 	doi = ntohl(d.doi);
 	proto = d.prot_id;
 	if (doi != 1) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," doi=%u", doi);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," proto=%u", proto);
+		ARGUSBUF_APPEND(" doi=%u", doi);
+		ARGUSBUF_APPEND(" proto=%u", proto);
 	} else {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," doi=ipsec");
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," proto=%s", PROTOIDSTR(proto));
+		ARGUSBUF_APPEND(" doi=ipsec");
+		ARGUSBUF_APPEND(" proto=%s", PROTOIDSTR(proto));
 	}
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," spilen=%u", d.spi_size);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," nspi=%u", ntohs(d.num_spi));
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," spi=");
+	ARGUSBUF_APPEND(" spilen=%u", d.spi_size);
+	ARGUSBUF_APPEND(" nspi=%u", ntohs(d.num_spi));
+	ARGUSBUF_APPEND(" spi=");
 	q = (u_int8_t *)(p + 1);
 	for (i = 0; i < ntohs(d.num_spi); i++) {
 		if (i != 0)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],",");
+			ARGUSBUF_APPEND(",");
 		if (!rawprint((caddr_t)q, d.spi_size))
 			goto trunc;
 		q += d.spi_size;
 	}
 	return q;
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_D));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_D));
 	return NULL;
 }
 
@@ -1160,19 +1160,19 @@ isakmp_vid_print(const struct isakmp_gen *ext,
 {
 	struct isakmp_gen e;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:", NPSTR(ISAKMP_NPTYPE_VID));
+	ARGUSBUF_APPEND("%s:", NPSTR(ISAKMP_NPTYPE_VID));
 
 	TCHECK(*ext);
 	safememcpy(&e, ext, sizeof(e));
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," len=%d", ntohs(e.len) - 4);
+	ARGUSBUF_APPEND(" len=%d", ntohs(e.len) - 4);
 	if (2 < ArgusParser->vflag && 4 < ntohs(e.len)) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+		ARGUSBUF_APPEND(" ");
 		if (!rawprint((caddr_t)(ext + 1), ntohs(e.len) - 4))
 			goto trunc;
 	}
 	return (u_char *)ext + ntohs(e.len);
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(ISAKMP_NPTYPE_VID));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(ISAKMP_NPTYPE_VID));
 	return NULL;
 }
 
@@ -1205,13 +1205,13 @@ isakmp_sub0_print(u_char np, const struct isakmp_gen *ext, const u_char *ep,
 		 */
 		cp = (*npfunc[np])(ext, item_len, ep, phase, doi, proto, depth);
 	} else {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", NPSTR(np));
+		ARGUSBUF_APPEND("%s", NPSTR(np));
 		cp += item_len;
 	}
 
 	return cp;
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|isakmp]");
+	ARGUSBUF_APPEND(" [|isakmp]");
 	return NULL;
 }
 
@@ -1233,12 +1233,12 @@ isakmp_sub_print(u_char np, const struct isakmp_gen *ext, const u_char *ep,
 		TCHECK2(*ext, ntohs(e.len));
 
 		depth++;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+		ARGUSBUF_APPEND("\n");
 		for (i = 0; i < depth; i++)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"    ");
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"(");
+			ARGUSBUF_APPEND("    ");
+		ARGUSBUF_APPEND("(");
 		cp = isakmp_sub0_print(np, ext, ep, phase, doi, proto, depth);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+		ARGUSBUF_APPEND(")");
 		depth--;
 
 		if (cp == NULL) {
@@ -1251,7 +1251,7 @@ isakmp_sub_print(u_char np, const struct isakmp_gen *ext, const u_char *ep,
 	}
 	return cp;
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(np));
+	ARGUSBUF_APPEND(" [|%s]", NPSTR(np));
 	return NULL;
 }
 
@@ -1289,65 +1289,65 @@ isakmp_print(const u_char *bp, u_int length)
 	ep = snapend;
 
 	if ((struct isakmp *)ep < p + 1) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|isakmp]");
+		ARGUSBUF_APPEND("[|isakmp]");
 		return ArgusBuf;
 	}
 
 	safememcpy(&base, p, sizeof(base));
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"isakmp");
+	ARGUSBUF_APPEND("isakmp");
 	if (ArgusParser->vflag) {
 		major = (base.vers & ISAKMP_VERS_MAJOR)
 				>> ISAKMP_VERS_MAJOR_SHIFT;
 		minor = (base.vers & ISAKMP_VERS_MINOR)
 				>> ISAKMP_VERS_MINOR_SHIFT;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," %d.%d", major, minor);
+		ARGUSBUF_APPEND(" %d.%d", major, minor);
 	}
 
 	if (ArgusParser->vflag) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," msgid ");
+		ARGUSBUF_APPEND(" msgid ");
 		rawprint((caddr_t)&base.msgid, sizeof(base.msgid));
 	}
 
 	if (1 < ArgusParser->vflag) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," cookie ");
+		ARGUSBUF_APPEND(" cookie ");
 		rawprint((caddr_t)&base.i_ck, sizeof(base.i_ck));
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"->");
+		ARGUSBUF_APPEND("->");
 		rawprint((caddr_t)&base.r_ck, sizeof(base.r_ck));
 	}
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],":");
+	ARGUSBUF_APPEND(":");
 
 	phase = (EXTRACT_32BITS(base.msgid) == 0) ? 1 : 2;
 	if (phase == 1)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," phase %d", phase);
+		ARGUSBUF_APPEND(" phase %d", phase);
 	else
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," phase %d/others", phase);
+		ARGUSBUF_APPEND(" phase %d/others", phase);
 
 	i = cookie_find(&base.i_ck);
 	if (i < 0) {
 		if (iszero((u_char *)&base.r_ck, sizeof(base.r_ck))) {
 			/* the first packet */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," I");
+			ARGUSBUF_APPEND(" I");
 /*
 			if (bp2)
 				cookie_record(&base.i_ck, bp2);
 */
 		} else
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," ?");
+			ARGUSBUF_APPEND(" ?");
 	} else {
 /*
 		if (bp2 && cookie_isinitiator(i, bp2))
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," I");
+			ARGUSBUF_APPEND(" I");
 		else if (bp2 && cookie_isresponder(i, bp2))
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," R");
+			ARGUSBUF_APPEND(" R");
 		else
 */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," ?");
+			ARGUSBUF_APPEND(" ?");
 	}
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", ETYPESTR(base.etype));
+	ARGUSBUF_APPEND(" %s", ETYPESTR(base.etype));
 	if (base.flags) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"[%s%s]", base.flags & ISAKMP_FLAG_E ? "E" : "",
+		ARGUSBUF_APPEND("[%s%s]", base.flags & ISAKMP_FLAG_E ? "E" : "",
 			base.flags & ISAKMP_FLAG_C ? "C" : "");
 	}
 
@@ -1357,11 +1357,11 @@ isakmp_print(const u_char *bp, u_int length)
 
 #define CHECKLEN(p, np) \
 		if (ep < (u_char *)(p)) {				\
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|%s]", NPSTR(np));			\
+			ARGUSBUF_APPEND(" [|%s]", NPSTR(np));			\
 			goto done;					\
 		}
 
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],":");
+		ARGUSBUF_APPEND(":");
 
 		/* regardless of phase... */
 		if (base.flags & ISAKMP_FLAG_E) {
@@ -1369,7 +1369,7 @@ isakmp_print(const u_char *bp, u_int length)
 			 * encrypted, nothing we can do right now.
 			 * we hope to decrypt the packet in the future...
 			 */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," [encrypted %s]", NPSTR(base.np));
+			ARGUSBUF_APPEND(" [encrypted %s]", NPSTR(base.np));
 			goto done;
 		}
 
@@ -1384,7 +1384,7 @@ isakmp_print(const u_char *bp, u_int length)
 done:
 	if (ArgusParser->vflag) {
 		if (ntohl(base.len) != length) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," (len mismatch: isakmp %u/ip %u)",
+			ARGUSBUF_APPEND(" (len mismatch: isakmp %u/ip %u)",
 				(u_int32_t)ntohl(base.len), length);
 		}
 	}
@@ -1399,7 +1399,7 @@ isakmp_rfc3948_print(const u_char *bp, u_int length)
 	ep = snapend;
 */
 	if(length == 1 && bp[0]==0xff) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"isakmp-nat-keep-alive");
+		ARGUSBUF_APPEND("isakmp-nat-keep-alive");
 		return ArgusBuf;
 	}
 
@@ -1411,7 +1411,7 @@ isakmp_rfc3948_print(const u_char *bp, u_int length)
 	 * see if this is an IKE packet
 	 */
 	if(bp[0]==0 && bp[1]==0 && bp[2]==0 && bp[3]==0) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"NONESP-encap: ");
+		ARGUSBUF_APPEND("NONESP-encap: ");
 		isakmp_print(bp+4, length-4);
 		return ArgusBuf;
 	}
@@ -1422,7 +1422,7 @@ isakmp_rfc3948_print(const u_char *bp, u_int length)
   		int nh = 0, enh = 0, padlen = 0;
 		int advance = 0;
 */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"UDP-encap: ");
+		ARGUSBUF_APPEND("UDP-encap: ");
 /*
 		advance = esp_print(ndo, bp, length, bp2, &enh, &padlen);
 
@@ -1440,7 +1440,7 @@ isakmp_rfc3948_print(const u_char *bp, u_int length)
 	}
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|isakmp]");
+	ARGUSBUF_APPEND("[|isakmp]");
 	return ArgusBuf;
 }
 

--- a/examples/radump/print-isoclns.c
+++ b/examples/radump/print-isoclns.c
@@ -543,12 +543,12 @@ isoclns_print(const u_int8_t *p, u_int length, u_int caplen)
 	header = (const struct isis_common_header *)p;
 */
         if (caplen <= 1) { /* enough bytes on the wire ? */
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"|OSI");
+            ARGUSBUF_APPEND("|OSI");
             return ArgusBuf;
         }
 
         if (ArgusParser->eflag)
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"OSI NLPID %s (0x%02x): ",
+            ARGUSBUF_APPEND("OSI NLPID %s (0x%02x): ",
                    tok2str(nlpid_values,"Unknown",*p),
                    *p);
         
@@ -569,7 +569,7 @@ isoclns_print(const u_int8_t *p, u_int length, u_int caplen)
 		break;
 
 	case NLPID_NULLNS:
-		(void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"%slength: %u",
+		ARGUSBUF_APPEND("%slength: %u",
 		             ArgusParser->eflag ? "" : ", ",
                              length);
 		break;
@@ -594,8 +594,8 @@ isoclns_print(const u_int8_t *p, u_int length, u_int caplen)
 */
 	default:
                 if (!ArgusParser->eflag)
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"OSI NLPID 0x%02x unknown",*p);
-		(void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"%slength: %u",
+                    ARGUSBUF_APPEND("OSI NLPID 0x%02x unknown",*p);
+		ARGUSBUF_APPEND("%slength: %u",
 		             ArgusParser->eflag ? "" : ", ",
                              length);
 		if (caplen > 1)
@@ -656,14 +656,14 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
         optr = pptr;
 
         if (!ArgusParser->eflag)
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"CLNP");
+            ARGUSBUF_APPEND("CLNP");
 
         /*
          * Sanity checking of the header.
          */
 
         if (clnp_header->version != CLNP_VERSION) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"version %d packet not supported", clnp_header->version);
+            ARGUSBUF_APPEND("version %d packet not supported", clnp_header->version);
             return (0);
         }
 
@@ -686,7 +686,7 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
         li -= (1 + source_address_length);
 
         if (ArgusParser->vflag < 1) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s%s > %s, %s, length %u",
+            ARGUSBUF_APPEND("%s%s > %s, %s, length %u",
                    ArgusParser->eflag ? "" : ", ",
                    isonsap_string(source_address, source_address_length),
                    isonsap_string(dest_address, dest_address_length),
@@ -694,9 +694,9 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
                    length);
             return (1);
         }
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"%slength %u",ArgusParser->eflag ? "" : ", ",length);
+        ARGUSBUF_APPEND("%slength %u",ArgusParser->eflag ? "" : ", ",length);
 
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t%s PDU, hlen: %u, v: %u, lifetime: %u.%us, Segment PDU length: %u, checksum: 0x%04x ",
+        ARGUSBUF_APPEND("\n\t%s PDU, hlen: %u, v: %u, lifetime: %u.%us, Segment PDU length: %u, checksum: 0x%04x ",
                tok2str(clnp_pdu_values, "unknown (%u)",clnp_pdu_type),
                clnp_header->length_indicator,
                clnp_header->version,
@@ -707,13 +707,13 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
 
         /* do not attempt to verify the checksum if it is zero */
         if (EXTRACT_16BITS(clnp_header->cksum) == 0)
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"(unverified)");
-            else sprintf(&ArgusBuf[strlen(ArgusBuf)],"(%s)", osi_cksum(optr, clnp_header->length_indicator) ? "incorrect" : "correct");
+                ARGUSBUF_APPEND("(unverified)");
+            else ARGUSBUF_APPEND("(%s)", osi_cksum(optr, clnp_header->length_indicator) ? "incorrect" : "correct");
 
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\tFlags [%s]",
+        ARGUSBUF_APPEND("\n\tFlags [%s]",
                bittok2str(clnp_flag_values,"none",clnp_flags));
 
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\tsource address (length %u): %s\n\tdest   address (length %u): %s",
+        ARGUSBUF_APPEND("\n\tsource address (length %u): %s\n\tdest   address (length %u): %s",
                source_address_length,
                isonsap_string(source_address, source_address_length),
                dest_address_length,
@@ -722,7 +722,7 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
         if (clnp_flags & CLNP_SEGMENT_PART) {
             	clnp_segment_header = (const struct clnp_segment_header_t *) pptr;
                 TCHECK(*clnp_segment_header);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\tData Unit ID: 0x%04x, Segment Offset: %u, Total PDU Length: %u",
+                ARGUSBUF_APPEND("\n\tData Unit ID: 0x%04x, Segment Offset: %u, Total PDU Length: %u",
                        EXTRACT_16BITS(clnp_segment_header->data_unit_id),
                        EXTRACT_16BITS(clnp_segment_header->segment_offset),
                        EXTRACT_16BITS(clnp_segment_header->total_length));
@@ -737,7 +737,7 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
             
             TCHECK2(*pptr, 2);
             if (li < 2) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad opts/li");
+                ARGUSBUF_APPEND(", bad opts/li");
                 return (0);
             }
             op = *pptr++;
@@ -745,14 +745,14 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
             li -= 2;
             TCHECK2(*pptr, opli);
             if (opli > li) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],", opt (%d) too long", op);
+                ARGUSBUF_APPEND(", opt (%d) too long", op);
                 return (0);
             }
             li -= opli;
             tptr = pptr;
             tlen = opli;
             
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s Option #%u, length %u, value: ",
+            ARGUSBUF_APPEND("\n\t  %s Option #%u, length %u, value: ",
                    tok2str(clnp_option_values,"Unknown",op),
                    op,
                    opli);
@@ -762,17 +762,17 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
 
             case CLNP_OPTION_ROUTE_RECORDING: /* those two options share the format */
             case CLNP_OPTION_SOURCE_ROUTING:  
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s %s",
+                    ARGUSBUF_APPEND("%s %s",
                            tok2str(clnp_option_sr_rr_values,"Unknown",*tptr),
                            tok2str(clnp_option_sr_rr_string_values,"Unknown Option %u",op));
                     nsap_offset=*(tptr+1);
                     if (nsap_offset == 0) {
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," Bad NSAP offset (0)");
+                            ARGUSBUF_APPEND(" Bad NSAP offset (0)");
                             break;
                     }
                     nsap_offset-=1; /* offset to nsap list */
                     if (nsap_offset > tlen) {
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)]," Bad NSAP offset (past end of option)");
+                            ARGUSBUF_APPEND(" Bad NSAP offset (past end of option)");
                             break;
                     }
                     tptr+=nsap_offset;
@@ -780,13 +780,13 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
                     while (tlen > 0) {
                             source_address_length=*tptr;
                             if (tlen < source_address_length+1) {
-                                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    NSAP address goes past end of option");
+                                    ARGUSBUF_APPEND("\n\t    NSAP address goes past end of option");
                                     break;
                             }
                             if (source_address_length > 0) {
                                     source_address=(tptr+1);
                                     TCHECK2(*source_address, source_address_length);
-                                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    NSAP address (length %u): %s",
+                                    ARGUSBUF_APPEND("\n\t    NSAP address (length %u): %s",
                                            source_address_length,
                                            isonsap_string(source_address, source_address_length));
                             }
@@ -795,22 +795,22 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
                     break;
 
             case CLNP_OPTION_PRIORITY:
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"0x%1x", *tptr&0x0f);
+                    ARGUSBUF_APPEND("0x%1x", *tptr&0x0f);
                     break;
 
             case CLNP_OPTION_QOS_MAINTENANCE:
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Format Code: %s",
+                    ARGUSBUF_APPEND("\n\t    Format Code: %s",
                            tok2str(clnp_option_scope_values,"Reserved",*tptr&CLNP_OPTION_SCOPE_MASK));
 
                     if ((*tptr&CLNP_OPTION_SCOPE_MASK) == CLNP_OPTION_SCOPE_GLOBAL)
-                            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    QoS Flags [%s]",
+                            ARGUSBUF_APPEND("\n\t    QoS Flags [%s]",
                                    bittok2str(clnp_option_qos_global_values,
                                               "none",
                                               *tptr&CLNP_OPTION_OPTION_QOS_MASK));
                     break;
 
             case CLNP_OPTION_SECURITY:
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Format Code: %s, Security-Level %u",
+                    ARGUSBUF_APPEND("\n\t    Format Code: %s, Security-Level %u",
                            tok2str(clnp_option_scope_values,"Reserved",*tptr&CLNP_OPTION_SCOPE_MASK),
                            *(tptr+1));
                     break;
@@ -818,7 +818,7 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
             case CLNP_OPTION_DISCARD_REASON:
                 rfd_error_major = (*tptr&0xf0) >> 4;
                 rfd_error_minor = *tptr&0x0f;
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Class: %s Error (0x%01x), %s (0x%01x)",
+                ARGUSBUF_APPEND("\n\t    Class: %s Error (0x%01x), %s (0x%01x)",
                        tok2str(clnp_option_rfd_class_values,"Unknown",rfd_error_major),
                        rfd_error_major,
                        tok2str(clnp_option_rfd_error_class[rfd_error_major],"Unknown",rfd_error_minor),
@@ -826,7 +826,7 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
                 break;
 
             case CLNP_OPTION_PADDING:
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"padding data");
+                    ARGUSBUF_APPEND("padding data");
                 break;
 
                 /*
@@ -849,7 +849,7 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
         case 	CLNP_PDU_ERP:
             TCHECK(*pptr);
             if (*(pptr) == NLPID_CLNP) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t-----original packet-----\n\t");
+                ARGUSBUF_APPEND("\n\t-----original packet-----\n\t");
                 /* FIXME recursion protection */
                 clnp_print(pptr, length-clnp_header->length_indicator);
                 break;
@@ -862,7 +862,7 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
         default:
             /* dump the PDU specific data */
             if (length-(pptr-optr) > 0) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  undecoded non-header data, length %u",length-clnp_header->length_indicator);
+                ARGUSBUF_APPEND("\n\t  undecoded non-header data, length %u",length-clnp_header->length_indicator);
                 print_unknown_data(pptr,"\n\t  ",length-(pptr-optr));
             }
         }
@@ -870,7 +870,7 @@ static int clnp_print (const u_int8_t *pptr, u_int length)
         return (1);
 
  trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)], "[|clnp]");
+    ARGUSBUF_APPEND("[|clnp]");
     return (1);
 
 }
@@ -905,13 +905,13 @@ esis_print(const u_int8_t *pptr, u_int length)
 	const struct esis_header_t *esis_header;
 
         if (!ArgusParser->eflag)
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"ES-IS");
+            ARGUSBUF_APPEND("ES-IS");
 
 	if (length <= 2) {
 		if (ArgusParser->qflag)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"bad pkt!");
+			ARGUSBUF_APPEND("bad pkt!");
 		else
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"no header at all!");
+			ARGUSBUF_APPEND("no header at all!");
 		return;
 	}
 
@@ -925,51 +925,51 @@ esis_print(const u_int8_t *pptr, u_int length)
          */
 
         if (esis_header->nlpid != NLPID_ESIS) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," nlpid 0x%02x packet not supported", esis_header->nlpid);
+            ARGUSBUF_APPEND(" nlpid 0x%02x packet not supported", esis_header->nlpid);
             return;
         }
 
         if (esis_header->version != ESIS_VERSION) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," version %d packet not supported", esis_header->version);
+            ARGUSBUF_APPEND(" version %d packet not supported", esis_header->version);
             return;
         }
                 
 	if (li > length) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," length indicator(%d) > PDU size (%d)!", li, length);
+            ARGUSBUF_APPEND(" length indicator(%d) > PDU size (%d)!", li, length);
             return;
 	}
 
 	if (li < sizeof(struct esis_header_t) + 2) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," length indicator < min PDU size %d:", li);
+            ARGUSBUF_APPEND(" length indicator < min PDU size %d:", li);
             while (--length != 0)
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02X", *pptr++);
+                ARGUSBUF_APPEND("%02X", *pptr++);
             return;
 	}
 
         esis_pdu_type = esis_header->type & ESIS_PDU_TYPE_MASK;
 
         if (ArgusParser->vflag < 1) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s%s, length %u",
+            ARGUSBUF_APPEND("%s%s, length %u",
                    ArgusParser->eflag ? "" : ", ",
                    tok2str(esis_pdu_values,"unknown type (%u)",esis_pdu_type),
                    length);
             return;
         } else
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%slength %u\n\t%s (%u)",
+            ARGUSBUF_APPEND("%slength %u\n\t%s (%u)",
                    ArgusParser->eflag ? "" : ", ",
                    length,
                    tok2str(esis_pdu_values,"unknown type: %u", esis_pdu_type),
                    esis_pdu_type);
 
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],", v: %u%s", esis_header->version, esis_header->version == ESIS_VERSION ? "" : "unsupported" );
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],", checksum: 0x%04x ", EXTRACT_16BITS(esis_header->cksum));
+        ARGUSBUF_APPEND(", v: %u%s", esis_header->version, esis_header->version == ESIS_VERSION ? "" : "unsupported" );
+        ARGUSBUF_APPEND(", checksum: 0x%04x ", EXTRACT_16BITS(esis_header->cksum));
         /* do not attempt to verify the checksum if it is zero */
         if (EXTRACT_16BITS(esis_header->cksum) == 0)
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"(unverified)");
+                ARGUSBUF_APPEND("(unverified)");
         else
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"(%s)", osi_cksum(pptr, li) ? "incorrect" : "correct");
+                ARGUSBUF_APPEND("(%s)", osi_cksum(pptr, li) ? "incorrect" : "correct");
 
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],", holding time: %us, length indicator: %u",EXTRACT_16BITS(esis_header->holdtime),li);
+        ARGUSBUF_APPEND(", holding time: %us, length indicator: %u",EXTRACT_16BITS(esis_header->holdtime),li);
 
         if (ArgusParser->vflag > 1)
             print_unknown_data(optr,"\n\t",sizeof(struct esis_header_t));
@@ -984,7 +984,7 @@ esis_print(const u_int8_t *pptr, u_int length)
 
 		TCHECK(*pptr);
 		if (li < 1) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad redirect/li");
+			ARGUSBUF_APPEND(", bad redirect/li");
 			return;
 		}
 		dstl = *pptr;
@@ -992,17 +992,17 @@ esis_print(const u_int8_t *pptr, u_int length)
 		li--;
 		TCHECK2(*pptr, dstl);
 		if (li < dstl) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad redirect/li");
+			ARGUSBUF_APPEND(", bad redirect/li");
 			return;
 		}
 		dst = pptr;
 		pptr += dstl;
                 li -= dstl;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s", isonsap_string(dst,dstl));
+		ARGUSBUF_APPEND("\n\t  %s", isonsap_string(dst,dstl));
 
 		TCHECK(*pptr);
 		if (li < 1) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad redirect/li");
+			ARGUSBUF_APPEND(", bad redirect/li");
 			return;
 		}
 		snpal = *pptr;
@@ -1010,7 +1010,7 @@ esis_print(const u_int8_t *pptr, u_int length)
 		li--;
 		TCHECK2(*pptr, snpal);
 		if (li < snpal) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad redirect/li");
+			ARGUSBUF_APPEND(", bad redirect/li");
 			return;
 		}
 		snpa = pptr;
@@ -1018,14 +1018,14 @@ esis_print(const u_int8_t *pptr, u_int length)
                 li -= snpal;
 		TCHECK(*pptr);
 		if (li < 1) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad redirect/li");
+			ARGUSBUF_APPEND(", bad redirect/li");
 			return;
 		}
 		netal = *pptr;
 		pptr++;
 		TCHECK2(*pptr, netal);
 		if (li < netal) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad redirect/li");
+			ARGUSBUF_APPEND(", bad redirect/li");
 			return;
 		}
 		neta = pptr;
@@ -1033,28 +1033,28 @@ esis_print(const u_int8_t *pptr, u_int length)
                 li -= netal;
 
 		if (netal == 0)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s", etheraddr_string(ArgusParser, (unsigned char *)snpa));
+			ARGUSBUF_APPEND("\n\t  %s", etheraddr_string(ArgusParser, (unsigned char *)snpa));
 		else
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s", isonsap_string(neta,netal));
+			ARGUSBUF_APPEND("\n\t  %s", isonsap_string(neta,netal));
 		break;
 	}
 
 	case ESIS_PDU_ESH:
             TCHECK(*pptr);
             if (li < 1) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad esh/li");
+                ARGUSBUF_APPEND(", bad esh/li");
                 return;
             }
             source_address_number = *pptr;
             pptr++;
             li--;
 
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  Number of Source Addresses: %u", source_address_number);
+            ARGUSBUF_APPEND("\n\t  Number of Source Addresses: %u", source_address_number);
            
             while (source_address_number > 0) {
                 TCHECK(*pptr);
             	if (li < 1) {
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad esh/li");
+                    ARGUSBUF_APPEND(", bad esh/li");
             	    return;
             	}
                 source_address_length = *pptr;
@@ -1063,10 +1063,10 @@ esis_print(const u_int8_t *pptr, u_int length)
 
                 TCHECK2(*pptr, source_address_length);
             	if (li < source_address_length) {
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad esh/li");
+                    ARGUSBUF_APPEND(", bad esh/li");
             	    return;
             	}
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  NET (length: %u): %s",
+                ARGUSBUF_APPEND("\n\t  NET (length: %u): %s",
                        source_address_length,
                        isonsap_string(pptr,source_address_length));
                 pptr += source_address_length;
@@ -1079,7 +1079,7 @@ esis_print(const u_int8_t *pptr, u_int length)
 	case ESIS_PDU_ISH: {
             TCHECK(*pptr);
             if (li < 1) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad ish/li");
+                ARGUSBUF_APPEND(", bad ish/li");
                 return;
             }
             source_address_length = *pptr;
@@ -1087,10 +1087,10 @@ esis_print(const u_int8_t *pptr, u_int length)
             li--;
             TCHECK2(*pptr, source_address_length);
             if (li < source_address_length) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad ish/li");
+                ARGUSBUF_APPEND(", bad ish/li");
                 return;
             }
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  NET (length: %u): %s", source_address_length, isonsap_string(pptr, source_address_length));
+            ARGUSBUF_APPEND("\n\t  NET (length: %u): %s", source_address_length, isonsap_string(pptr, source_address_length));
             pptr += source_address_length;
             li -= source_address_length;
             break;
@@ -1111,20 +1111,20 @@ esis_print(const u_int8_t *pptr, u_int length)
             
             TCHECK2(*pptr, 2);
             if (li < 2) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],", bad opts/li");
+                ARGUSBUF_APPEND(", bad opts/li");
                 return;
             }
             op = *pptr++;
             opli = *pptr++;
             li -= 2;
             if (opli > li) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],", opt (%d) too long", op);
+                ARGUSBUF_APPEND(", opt (%d) too long", op);
                 return;
             }
             li -= opli;
             tptr = pptr;
             
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s Option #%u, length %u, value: ",
+            ARGUSBUF_APPEND("\n\t  %s Option #%u, length %u, value: ",
                    tok2str(esis_option_values,"Unknown",op),
                    op,
                    opli);
@@ -1133,19 +1133,19 @@ esis_print(const u_int8_t *pptr, u_int length)
 
             case ESIS_OPTION_ES_CONF_TIME:
                 TCHECK2(*pptr, 2);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"%us", EXTRACT_16BITS(tptr));
+                ARGUSBUF_APPEND("%us", EXTRACT_16BITS(tptr));
                 break;
 
             case ESIS_OPTION_PROTOCOLS:
                 while (opli>0) {
                     TCHECK(*pptr);
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s (0x%02x)",
+                    ARGUSBUF_APPEND("%s (0x%02x)",
                            tok2str(nlpid_values,
                                    "unknown",
                                    *tptr),
                            *tptr);
                     if (opli>1) /* further NPLIDs ? - put comma */
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],", ");
+                        ARGUSBUF_APPEND(", ");
                     tptr++;
                     opli--;
                 }
@@ -1201,19 +1201,19 @@ isis_print_id(const u_int8_t *cp, int id_len)
 static int
 isis_print_metric_block (const struct isis_metric_block *isis_metric_block)
 {
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],", Default Metric: %d, %s",
+    ARGUSBUF_APPEND(", Default Metric: %d, %s",
            ISIS_LSP_TLV_METRIC_VALUE(isis_metric_block->metric_default),
            ISIS_LSP_TLV_METRIC_IE(isis_metric_block->metric_default) ? "External" : "Internal");
     if (!ISIS_LSP_TLV_METRIC_SUPPORTED(isis_metric_block->metric_delay))
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t  Delay Metric: %d, %s",
+        ARGUSBUF_APPEND("\n\t\t  Delay Metric: %d, %s",
                ISIS_LSP_TLV_METRIC_VALUE(isis_metric_block->metric_delay),
                ISIS_LSP_TLV_METRIC_IE(isis_metric_block->metric_delay) ? "External" : "Internal");
     if (!ISIS_LSP_TLV_METRIC_SUPPORTED(isis_metric_block->metric_expense))
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t  Expense Metric: %d, %s",
+        ARGUSBUF_APPEND("\n\t\t  Expense Metric: %d, %s",
                ISIS_LSP_TLV_METRIC_VALUE(isis_metric_block->metric_expense),
                ISIS_LSP_TLV_METRIC_IE(isis_metric_block->metric_expense) ? "External" : "Internal");
     if (!ISIS_LSP_TLV_METRIC_SUPPORTED(isis_metric_block->metric_error))
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t  Error Metric: %d, %s",
+        ARGUSBUF_APPEND("\n\t\t  Error Metric: %d, %s",
                ISIS_LSP_TLV_METRIC_VALUE(isis_metric_block->metric_error),
                ISIS_LSP_TLV_METRIC_IE(isis_metric_block->metric_error) ? "External" : "Internal");
 
@@ -1230,7 +1230,7 @@ isis_print_tlv_ip_reach (const u_int8_t *cp, const char *ident, int length)
 
 	while (length > 0) {
 		if ((size_t)length < sizeof(*tlv_ip_reach)) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"short IPv4 Reachability (%d vs %lu)",
+			ARGUSBUF_APPEND("short IPv4 Reachability (%d vs %lu)",
                                length,
                                (unsigned long)sizeof(*tlv_ip_reach));
 			return (0);
@@ -1242,35 +1242,35 @@ isis_print_tlv_ip_reach (const u_int8_t *cp, const char *ident, int length)
 		prefix_len = mask2plen(EXTRACT_32BITS(tlv_ip_reach->mask));
 
 		if (prefix_len == -1)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"%sIPv4 prefix: %s mask %s",
+			ARGUSBUF_APPEND("%sIPv4 prefix: %s mask %s",
                                ident,
 			       ipaddr_string((tlv_ip_reach->prefix)),
 			       ipaddr_string((tlv_ip_reach->mask)));
 		else
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"%sIPv4 prefix: %15s/%u",
+			ARGUSBUF_APPEND("%sIPv4 prefix: %15s/%u",
                                ident,
 			       ipaddr_string((tlv_ip_reach->prefix)),
 			       prefix_len);
 
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],", Distribution: %s, Metric: %u, %s",
+		ARGUSBUF_APPEND(", Distribution: %s, Metric: %u, %s",
                        ISIS_LSP_TLV_METRIC_UPDOWN(tlv_ip_reach->isis_metric_block.metric_default) ? "down" : "up",
                        ISIS_LSP_TLV_METRIC_VALUE(tlv_ip_reach->isis_metric_block.metric_default),
                        ISIS_LSP_TLV_METRIC_IE(tlv_ip_reach->isis_metric_block.metric_default) ? "External" : "Internal");
 
 		if (!ISIS_LSP_TLV_METRIC_SUPPORTED(tlv_ip_reach->isis_metric_block.metric_delay))
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s  Delay Metric: %u, %s",
+                    ARGUSBUF_APPEND("%s  Delay Metric: %u, %s",
                            ident,
                            ISIS_LSP_TLV_METRIC_VALUE(tlv_ip_reach->isis_metric_block.metric_delay),
                            ISIS_LSP_TLV_METRIC_IE(tlv_ip_reach->isis_metric_block.metric_delay) ? "External" : "Internal");
                 
 		if (!ISIS_LSP_TLV_METRIC_SUPPORTED(tlv_ip_reach->isis_metric_block.metric_expense))
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s  Expense Metric: %u, %s",
+                    ARGUSBUF_APPEND("%s  Expense Metric: %u, %s",
                            ident,
                            ISIS_LSP_TLV_METRIC_VALUE(tlv_ip_reach->isis_metric_block.metric_expense),
                            ISIS_LSP_TLV_METRIC_IE(tlv_ip_reach->isis_metric_block.metric_expense) ? "External" : "Internal");
                 
 		if (!ISIS_LSP_TLV_METRIC_SUPPORTED(tlv_ip_reach->isis_metric_block.metric_error))
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s  Error Metric: %u, %s",
+                    ARGUSBUF_APPEND("%s  Error Metric: %u, %s",
                            ident,
                            ISIS_LSP_TLV_METRIC_VALUE(tlv_ip_reach->isis_metric_block.metric_error),
                            ISIS_LSP_TLV_METRIC_IE(tlv_ip_reach->isis_metric_block.metric_error) ? "External" : "Internal");
@@ -1290,7 +1290,7 @@ static int
 isis_print_ip_reach_subtlv (const u_int8_t *tptr,int subt,int subl,const char *ident) {
 
         /* first lets see if we know the subTLVs name*/
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s%s subTLV #%u, length: %u",
+	ARGUSBUF_APPEND("%s%s subTLV #%u, length: %u",
 	       ident,
                tok2str(isis_ext_ip_reach_subtlv_values,
                        "unknown",
@@ -1305,7 +1305,7 @@ isis_print_ip_reach_subtlv (const u_int8_t *tptr,int subt,int subl,const char *i
     case ISIS_SUBTLV_EXTD_IP_REACH_MGMT_PREFIX_COLOR: /* fall through */
     case ISIS_SUBTLV_EXTD_IP_REACH_ADMIN_TAG32:
         while (subl >= 4) {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", 0x%08x (=%u)",
+	    ARGUSBUF_APPEND(", 0x%08x (=%u)",
 		   EXTRACT_32BITS(tptr),
 		   EXTRACT_32BITS(tptr));
 	    tptr+=4;
@@ -1314,7 +1314,7 @@ isis_print_ip_reach_subtlv (const u_int8_t *tptr,int subt,int subl,const char *i
 	break;
     case ISIS_SUBTLV_EXTD_IP_REACH_ADMIN_TAG64:
         while (subl >= 8) {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", 0x%08x%08x",
+	    ARGUSBUF_APPEND(", 0x%08x%08x",
 		   EXTRACT_32BITS(tptr),
 		   EXTRACT_32BITS(tptr+4));
 	    tptr+=8;
@@ -1330,7 +1330,7 @@ isis_print_ip_reach_subtlv (const u_int8_t *tptr,int subt,int subl,const char *i
     return(1);
 	
 trunctlv:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%spacket exceeded snapshot",ident);
+    ARGUSBUF_APPEND("%spacket exceeded snapshot",ident);
     return(0);
 }
 
@@ -1349,7 +1349,7 @@ isis_print_is_reach_subtlv (const u_int8_t *tptr,u_int subt,u_int subl,const cha
         } bw;
 
         /* first lets see if we know the subTLVs name*/
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s%s subTLV #%u, length: %u",
+	ARGUSBUF_APPEND("%s%s subTLV #%u, length: %u",
 	       ident,
                tok2str(isis_ext_is_reach_subtlv_values,
                        "unknown",
@@ -1365,28 +1365,28 @@ isis_print_is_reach_subtlv (const u_int8_t *tptr,u_int subt,u_int subl,const cha
         case ISIS_SUBTLV_EXT_IS_REACH_LINK_LOCAL_REMOTE_ID:
         case ISIS_SUBTLV_EXT_IS_REACH_LINK_REMOTE_ID:
 	    if (subl >= 4) {
-	      sprintf(&ArgusBuf[strlen(ArgusBuf)],", 0x%08x", EXTRACT_32BITS(tptr));
+	      ARGUSBUF_APPEND(", 0x%08x", EXTRACT_32BITS(tptr));
 	      if (subl == 8) /* draft-ietf-isis-gmpls-extensions */
-	        sprintf(&ArgusBuf[strlen(ArgusBuf)],", 0x%08x", EXTRACT_32BITS(tptr+4));
+	        ARGUSBUF_APPEND(", 0x%08x", EXTRACT_32BITS(tptr+4));
 	    }
 	    break;
         case ISIS_SUBTLV_EXT_IS_REACH_IPV4_INTF_ADDR:
         case ISIS_SUBTLV_EXT_IS_REACH_IPV4_NEIGHBOR_ADDR:
             if (subl >= sizeof(struct in_addr))
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],", %s", ipaddr_string(tptr));
+              ARGUSBUF_APPEND(", %s", ipaddr_string(tptr));
             break;
         case ISIS_SUBTLV_EXT_IS_REACH_MAX_LINK_BW :
 	case ISIS_SUBTLV_EXT_IS_REACH_RESERVABLE_BW:  
             if (subl >= 4) {
               bw.i = EXTRACT_32BITS(tptr);
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],", %.3f Mbps", bw.f*8/1000000 );
+              ARGUSBUF_APPEND(", %.3f Mbps", bw.f*8/1000000 );
             }
             break;
         case ISIS_SUBTLV_EXT_IS_REACH_UNRESERVED_BW :
             if (subl >= 32) {
               for (te_class = 0; te_class < 8; te_class++) {
                 bw.i = EXTRACT_32BITS(tptr);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s  TE-Class %u: %.3f Mbps",
+                ARGUSBUF_APPEND("%s  TE-Class %u: %.3f Mbps",
                        ident,
                        te_class,
                        bw.f*8/1000000 );
@@ -1396,7 +1396,7 @@ isis_print_is_reach_subtlv (const u_int8_t *tptr,u_int subt,u_int subl,const cha
             break;
         case ISIS_SUBTLV_EXT_IS_REACH_BW_CONSTRAINTS: /* fall through */
         case ISIS_SUBTLV_EXT_IS_REACH_BW_CONSTRAINTS_OLD:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%sBandwidth Constraints Model ID: %s (%u)",
+            ARGUSBUF_APPEND("%sBandwidth Constraints Model ID: %s (%u)",
                    ident,
                    tok2str(diffserv_te_bc_values, "unknown", *tptr),
                    *tptr);
@@ -1404,7 +1404,7 @@ isis_print_is_reach_subtlv (const u_int8_t *tptr,u_int subt,u_int subl,const cha
             /* decode BCs until the subTLV ends */
             for (te_class = 0; te_class < (subl-1)/4; te_class++) {
                 bw.i = EXTRACT_32BITS(tptr);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s  Bandwidth constraint CT%u: %.3f Mbps",
+                ARGUSBUF_APPEND("%s  Bandwidth constraint CT%u: %.3f Mbps",
                        ident,
                        te_class,
                        bw.f*8/1000000 );
@@ -1413,27 +1413,27 @@ isis_print_is_reach_subtlv (const u_int8_t *tptr,u_int subt,u_int subl,const cha
             break;
         case ISIS_SUBTLV_EXT_IS_REACH_TE_METRIC:
             if (subl >= 3)
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],", %u", EXTRACT_24BITS(tptr));
+              ARGUSBUF_APPEND(", %u", EXTRACT_24BITS(tptr));
             break;
         case ISIS_SUBTLV_EXT_IS_REACH_LINK_PROTECTION_TYPE:
             if (subl >= 2) {
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],", %s, Priority %u",
+              ARGUSBUF_APPEND(", %s, Priority %u",
 		   bittok2str(gmpls_link_prot_values, "none", *tptr),
                    *(tptr+1));
             }
             break;
         case ISIS_SUBTLV_EXT_IS_REACH_INTF_SW_CAP_DESCR:
             if (subl >= 36) {
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s  Interface Switching Capability:%s",
+              ARGUSBUF_APPEND("%s  Interface Switching Capability:%s",
                    ident,
                    tok2str(gmpls_switch_cap_values, "Unknown", *(tptr)));
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],", LSP Encoding: %s",
+              ARGUSBUF_APPEND(", LSP Encoding: %s",
                    tok2str(gmpls_encoding_values, "Unknown", *(tptr+1)));
 	      tptr+=4;
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s  Max LSP Bandwidth:",ident);
+              ARGUSBUF_APPEND("%s  Max LSP Bandwidth:",ident);
               for (priority_level = 0; priority_level < 8; priority_level++) {
                 bw.i = EXTRACT_32BITS(tptr);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s    priority level %d: %.3f Mbps",
+                ARGUSBUF_APPEND("%s    priority level %d: %.3f Mbps",
                        ident,
                        priority_level,
                        bw.f*8/1000000 );
@@ -1458,7 +1458,7 @@ isis_print_is_reach_subtlv (const u_int8_t *tptr,u_int subt,u_int subl,const cha
         return(1);
 
 trunctlv:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%spacket exceeded snapshot",ident);
+    ARGUSBUF_APPEND("%spacket exceeded snapshot",ident);
     return(0);
 }
 
@@ -1478,13 +1478,13 @@ isis_print_ext_is_reach (const u_int8_t *tptr,const char *ident, int tlv_type) {
     if (!TTEST2(*tptr, NODE_ID_LEN))
         return(0);
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%sIS Neighbor: %s", ident, isis_print_id(tptr, NODE_ID_LEN));
+    ARGUSBUF_APPEND("%sIS Neighbor: %s", ident, isis_print_id(tptr, NODE_ID_LEN));
     tptr+=(NODE_ID_LEN);
 
     if (tlv_type != ISIS_TLV_IS_ALIAS_ID) { /* the Alias TLV Metric field is implicit 0 */
         if (!TTEST2(*tptr, 3))    /* and is therefore skipped */
 	    return(0);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],", Metric: %d",EXTRACT_24BITS(tptr));
+	ARGUSBUF_APPEND(", Metric: %d",EXTRACT_24BITS(tptr));
 	tptr+=3;
     }
         
@@ -1492,9 +1492,9 @@ isis_print_ext_is_reach (const u_int8_t *tptr,const char *ident, int tlv_type) {
         return(0);
     subtlv_sum_len=*(tptr++); /* read out subTLV length */
     proc_bytes=NODE_ID_LEN+3+1;
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],", %ssub-TLVs present",subtlv_sum_len ? "" : "no ");
+    ARGUSBUF_APPEND(", %ssub-TLVs present",subtlv_sum_len ? "" : "no ");
     if (subtlv_sum_len) {
-        sprintf(&ArgusBuf[strlen(ArgusBuf)]," (%u)",subtlv_sum_len);
+        ARGUSBUF_APPEND(" (%u)",subtlv_sum_len);
         while (subtlv_sum_len>0) {
             if (!TTEST2(*tptr,2))
                 return(0);
@@ -1523,13 +1523,13 @@ isis_print_mtid (const u_int8_t *tptr,const char *ident) {
     if (!TTEST2(*tptr, 2))
         return(0);
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s%s",
+    ARGUSBUF_APPEND("%s%s",
            ident,
            tok2str(isis_mt_values,
                    "Reserved for IETF Consensus",
                    ISIS_MASK_MTID(EXTRACT_16BITS(tptr))));
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)]," Topology (0x%03x), Flags: [%s]",
+    ARGUSBUF_APPEND(" Topology (0x%03x), Flags: [%s]",
            ISIS_MASK_MTID(EXTRACT_16BITS(tptr)),
            bittok2str(isis_mt_flag_values, "none",ISIS_MASK_MTFLAGS(EXTRACT_16BITS(tptr))));
 
@@ -1583,27 +1583,27 @@ isis_print_extd_ip_reach (const u_int8_t *tptr, const char *ident, u_int16_t afi
     processed+=byte_length;
 
     if (afi == IPV4)
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"%sIPv4 prefix: %15s/%u",
+        ARGUSBUF_APPEND("%sIPv4 prefix: %15s/%u",
                ident,
                ipaddr_string(prefix),
                bit_length);
 #ifdef INET6
     if (afi == IPV6)
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"%sIPv6 prefix: %s/%u",
+        ARGUSBUF_APPEND("%sIPv6 prefix: %s/%u",
                ident,
                ip6addr_string(prefix),
                bit_length);
 #endif 
    
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],", Distribution: %s, Metric: %u",
+    ARGUSBUF_APPEND(", Distribution: %s, Metric: %u",
            ISIS_MASK_TLV_EXTD_IP_UPDOWN(status_byte) ? "down" : "up",
            metric);
 
     if (afi == IPV4 && ISIS_MASK_TLV_EXTD_IP_SUBTLV(status_byte))
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],", sub-TLVs present");
+        ARGUSBUF_APPEND(", sub-TLVs present");
 #ifdef INET6
     if (afi == IPV6)
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],", %s%s",
+        ARGUSBUF_APPEND(", %s%s",
                ISIS_MASK_TLV_EXTD_IP6_IE(status_byte) ? "External" : "Internal",
                ISIS_MASK_TLV_EXTD_IP6_SUBTLV(status_byte) ? ", sub-TLVs present" : "");
 #endif
@@ -1618,7 +1618,7 @@ isis_print_extd_ip_reach (const u_int8_t *tptr, const char *ident, u_int16_t afi
             return (0);
         sublen=*(tptr++);
         processed+=sublen+1;
-        sprintf(&ArgusBuf[strlen(ArgusBuf)]," (%u)",sublen);   /* print out subTLV length */
+        ARGUSBUF_APPEND(" (%u)",sublen);   /* print out subTLV length */
         
         while (sublen>0) {
             if (!TTEST2(*tptr,2))
@@ -1675,25 +1675,25 @@ static int isis_print (const u_int8_t *p, u_int length)
     header_psnp = (const struct isis_psnp_header *)pptr;
 
     if (!ArgusParser->eflag)
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"IS-IS");
+        ARGUSBUF_APPEND("IS-IS");
 
     /*
      * Sanity checking of the header.
      */
 
     if (isis_header->version != ISIS_VERSION) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"version %d packet not supported", isis_header->version);
+	ARGUSBUF_APPEND("version %d packet not supported", isis_header->version);
 	return (0);
     }
 
     if ((isis_header->id_length != SYSTEM_ID_LEN) && (isis_header->id_length != 0)) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"system ID length of %d is not supported",
+	ARGUSBUF_APPEND("system ID length of %d is not supported",
 	       isis_header->id_length);
 	return (0);
     }
 
     if (isis_header->pdu_version != ISIS_VERSION) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"version %d packet not supported", isis_header->pdu_version);
+	ARGUSBUF_APPEND("version %d packet not supported", isis_header->pdu_version);
 	return (0);
     }
 
@@ -1703,7 +1703,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 	max_area = 3;	 /* silly shit */
 	break;
     case 255:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"bad packet -- 255 areas");
+	ARGUSBUF_APPEND("bad packet -- 255 areas");
 	return (0);
     default:
 	break;
@@ -1732,7 +1732,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 
     /* toss any non 6-byte sys-ID len PDUs */
     if (id_length != 6 ) { 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"bad packet -- illegal sys-ID length (%u)", id_length);
+	ARGUSBUF_APPEND("bad packet -- illegal sys-ID length (%u)", id_length);
 	return (0);
     }
 
@@ -1740,7 +1740,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 
     /* in non-verbose mode print the basic PDU Type plus PDU specific brief information*/
     if (ArgusParser->vflag < 1) {
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s%s",
+        ARGUSBUF_APPEND("%s%s",
                ArgusParser->eflag ? "" : ", ",
                tok2str(isis_pdu_values,"unknown PDU-Type %u",pdu_type));
 
@@ -1748,41 +1748,41 @@ static int isis_print (const u_int8_t *p, u_int length)
 
 	case ISIS_PDU_L1_LAN_IIH:
 	case ISIS_PDU_L2_LAN_IIH:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", src-id %s",
+	    ARGUSBUF_APPEND(", src-id %s",
                    isis_print_id(header_iih_lan->source_id,SYSTEM_ID_LEN));
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", lan-id %s, prio %u",
+	    ARGUSBUF_APPEND(", lan-id %s, prio %u",
                    isis_print_id(header_iih_lan->lan_id,NODE_ID_LEN),
                    header_iih_lan->priority);
 	    break;
 	case ISIS_PDU_PTP_IIH:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", src-id %s", isis_print_id(header_iih_ptp->source_id,SYSTEM_ID_LEN));
+	    ARGUSBUF_APPEND(", src-id %s", isis_print_id(header_iih_ptp->source_id,SYSTEM_ID_LEN));
 	    break;
 	case ISIS_PDU_L1_LSP:
 	case ISIS_PDU_L2_LSP:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", lsp-id %s, seq 0x%08x, lifetime %5us",
+	    ARGUSBUF_APPEND(", lsp-id %s, seq 0x%08x, lifetime %5us",
 		   isis_print_id(header_lsp->lsp_id, LSP_ID_LEN),
 		   EXTRACT_32BITS(header_lsp->sequence_number),
 		   EXTRACT_16BITS(header_lsp->remaining_lifetime));
 	    break;
 	case ISIS_PDU_L1_CSNP:
 	case ISIS_PDU_L2_CSNP:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", src-id %s", isis_print_id(header_csnp->source_id,NODE_ID_LEN));
+	    ARGUSBUF_APPEND(", src-id %s", isis_print_id(header_csnp->source_id,NODE_ID_LEN));
 	    break;
 	case ISIS_PDU_L1_PSNP:
 	case ISIS_PDU_L2_PSNP:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", src-id %s", isis_print_id(header_psnp->source_id,NODE_ID_LEN));
+	    ARGUSBUF_APPEND(", src-id %s", isis_print_id(header_psnp->source_id,NODE_ID_LEN));
 	    break;
 
 	}
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],", length %u", length);
+	ARGUSBUF_APPEND(", length %u", length);
 
         return(1);
     }
 
     /* ok they seem to want to know everything - lets fully decode it */
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%slength %u", ArgusParser->eflag ? "" : ", ",length);
+    ARGUSBUF_APPEND("%slength %u", ArgusParser->eflag ? "" : ", ",length);
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t%s, hlen: %u, v: %u, pdu-v: %u, sys-id-len: %u (%u), max-area: %u (%u)",
+    ARGUSBUF_APPEND("\n\t%s, hlen: %u, v: %u, pdu-v: %u, sys-id-len: %u (%u), max-area: %u (%u)",
            tok2str(isis_pdu_values,
                    "unknown, type %u",
                    pdu_type),
@@ -1804,7 +1804,7 @@ static int isis_print (const u_int8_t *p, u_int length)
     case ISIS_PDU_L1_LAN_IIH:
     case ISIS_PDU_L2_LAN_IIH:
 	if (isis_header->fixed_len != (ISIS_COMMON_HEADER_SIZE+ISIS_IIH_LAN_HEADER_SIZE)) {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", bogus fixed header length %u should be %lu",
+	    ARGUSBUF_APPEND(", bogus fixed header length %u should be %lu",
 		   isis_header->fixed_len, (unsigned long)ISIS_IIH_LAN_HEADER_SIZE);
 	    return (0);
 	}
@@ -1816,14 +1816,14 @@ static int isis_print (const u_int8_t *p, u_int length)
 	}
 
 	TCHECK(*header_iih_lan);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  source-id: %s,  holding time: %us, Flags: [%s]",
+	ARGUSBUF_APPEND("\n\t  source-id: %s,  holding time: %us, Flags: [%s]",
                isis_print_id(header_iih_lan->source_id,SYSTEM_ID_LEN),
                EXTRACT_16BITS(header_iih_lan->holding_time),
                tok2str(isis_iih_circuit_type_values,
                        "unknown circuit type 0x%02x",
                        header_iih_lan->circuit_type));
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  lan-id:    %s, Priority: %u, PDU length: %u",
+	ARGUSBUF_APPEND("\n\t  lan-id:    %s, Priority: %u, PDU length: %u",
                isis_print_id(header_iih_lan->lan_id, NODE_ID_LEN),
                (header_iih_lan->priority) & ISIS_LAN_PRIORITY_MASK,
                pdu_len);
@@ -1839,7 +1839,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 
     case ISIS_PDU_PTP_IIH:
 	if (isis_header->fixed_len != (ISIS_COMMON_HEADER_SIZE+ISIS_IIH_PTP_HEADER_SIZE)) {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", bogus fixed header length %u should be %lu",
+	    ARGUSBUF_APPEND(", bogus fixed header length %u should be %lu",
 		   isis_header->fixed_len, (unsigned long)ISIS_IIH_PTP_HEADER_SIZE);
 	    return (0);
 	}
@@ -1851,14 +1851,14 @@ static int isis_print (const u_int8_t *p, u_int length)
 	}
 
 	TCHECK(*header_iih_ptp);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  source-id: %s, holding time: %us, Flags: [%s]",
+	ARGUSBUF_APPEND("\n\t  source-id: %s, holding time: %us, Flags: [%s]",
                isis_print_id(header_iih_ptp->source_id,SYSTEM_ID_LEN),
                EXTRACT_16BITS(header_iih_ptp->holding_time),
                tok2str(isis_iih_circuit_type_values,
                        "unknown circuit type 0x%02x",
                        header_iih_ptp->circuit_type));
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  circuit-id: 0x%02x, PDU length: %u",
+	ARGUSBUF_APPEND("\n\t  circuit-id: 0x%02x, PDU length: %u",
                header_iih_ptp->circuit_id,
                pdu_len);
 
@@ -1874,7 +1874,7 @@ static int isis_print (const u_int8_t *p, u_int length)
     case ISIS_PDU_L1_LSP:
     case ISIS_PDU_L2_LSP:
 	if (isis_header->fixed_len != (ISIS_COMMON_HEADER_SIZE+ISIS_LSP_HEADER_SIZE)) {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", bogus fixed header length %u should be %lu",
+	    ARGUSBUF_APPEND(", bogus fixed header length %u should be %lu",
 		   isis_header->fixed_len, (unsigned long)ISIS_LSP_HEADER_SIZE);
 	    return (0);
 	}
@@ -1886,7 +1886,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 	}
 
 	TCHECK(*header_lsp);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  lsp-id: %s, seq: 0x%08x, lifetime: %5us\n\t  chksum: 0x%04x",
+	ARGUSBUF_APPEND("\n\t  lsp-id: %s, seq: 0x%08x, lifetime: %5us\n\t  chksum: 0x%04x",
                isis_print_id(header_lsp->lsp_id, LSP_ID_LEN),
                EXTRACT_32BITS(header_lsp->sequence_number),
                EXTRACT_16BITS(header_lsp->remaining_lifetime),
@@ -1895,26 +1895,26 @@ static int isis_print (const u_int8_t *p, u_int length)
         /* if this is a purge do not attempt to verify the checksum */
         if ( EXTRACT_16BITS(header_lsp->remaining_lifetime) == 0 &&
              EXTRACT_16BITS(header_lsp->checksum) == 0)
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (purged)");
+            ARGUSBUF_APPEND(" (purged)");
         else
             /* verify the checksum -
              * checking starts at the lsp-id field at byte position [12]
              * hence the length needs to be reduced by 12 bytes */
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," (%s)", (osi_cksum((u_int8_t *)header_lsp->lsp_id, length-12)) ? "incorrect" : "correct");
+            ARGUSBUF_APPEND(" (%s)", (osi_cksum((u_int8_t *)header_lsp->lsp_id, length-12)) ? "incorrect" : "correct");
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],", PDU length: %u, Flags: [ %s",
+	ARGUSBUF_APPEND(", PDU length: %u, Flags: [ %s",
                pdu_len,
                ISIS_MASK_LSP_OL_BIT(header_lsp->typeblock) ? "Overload bit set, " : "");
 
 	if (ISIS_MASK_LSP_ATT_BITS(header_lsp->typeblock)) {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ISIS_MASK_LSP_ATT_DEFAULT_BIT(header_lsp->typeblock) ? "default " : "");
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ISIS_MASK_LSP_ATT_DELAY_BIT(header_lsp->typeblock) ? "delay " : "");
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ISIS_MASK_LSP_ATT_EXPENSE_BIT(header_lsp->typeblock) ? "expense " : "");
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ISIS_MASK_LSP_ATT_ERROR_BIT(header_lsp->typeblock) ? "error " : "");
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"ATT bit set, ");
+	    ARGUSBUF_APPEND("%s", ISIS_MASK_LSP_ATT_DEFAULT_BIT(header_lsp->typeblock) ? "default " : "");
+	    ARGUSBUF_APPEND("%s", ISIS_MASK_LSP_ATT_DELAY_BIT(header_lsp->typeblock) ? "delay " : "");
+	    ARGUSBUF_APPEND("%s", ISIS_MASK_LSP_ATT_EXPENSE_BIT(header_lsp->typeblock) ? "expense " : "");
+	    ARGUSBUF_APPEND("%s", ISIS_MASK_LSP_ATT_ERROR_BIT(header_lsp->typeblock) ? "error " : "");
+	    ARGUSBUF_APPEND("ATT bit set, ");
 	}
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ISIS_MASK_LSP_PARTITION_BIT(header_lsp->typeblock) ? "P bit set, " : "");
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s ]", tok2str(isis_lsp_istype_values,"Unknown(0x%x)",ISIS_MASK_LSP_ISTYPE_BITS(header_lsp->typeblock)));
+	ARGUSBUF_APPEND("%s", ISIS_MASK_LSP_PARTITION_BIT(header_lsp->typeblock) ? "P bit set, " : "");
+	ARGUSBUF_APPEND("%s ]", tok2str(isis_lsp_istype_values,"Unknown(0x%x)",ISIS_MASK_LSP_ISTYPE_BITS(header_lsp->typeblock)));
 
         if (ArgusParser->vflag > 1) {
             if(!print_unknown_data(pptr,"\n\t  ",ISIS_LSP_HEADER_SIZE))
@@ -1928,7 +1928,7 @@ static int isis_print (const u_int8_t *p, u_int length)
     case ISIS_PDU_L1_CSNP:
     case ISIS_PDU_L2_CSNP:
 	if (isis_header->fixed_len != (ISIS_COMMON_HEADER_SIZE+ISIS_CSNP_HEADER_SIZE)) {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", bogus fixed header length %u should be %lu",
+	    ARGUSBUF_APPEND(", bogus fixed header length %u should be %lu",
 		   isis_header->fixed_len, (unsigned long)ISIS_CSNP_HEADER_SIZE);
 	    return (0);
 	}
@@ -1940,12 +1940,12 @@ static int isis_print (const u_int8_t *p, u_int length)
 	}
 
 	TCHECK(*header_csnp);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  source-id:    %s, PDU length: %u",
+	ARGUSBUF_APPEND("\n\t  source-id:    %s, PDU length: %u",
                isis_print_id(header_csnp->source_id, NODE_ID_LEN),
                pdu_len);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  start lsp-id: %s",
+	ARGUSBUF_APPEND("\n\t  start lsp-id: %s",
                isis_print_id(header_csnp->start_lsp_id, LSP_ID_LEN));
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  end lsp-id:   %s",
+	ARGUSBUF_APPEND("\n\t  end lsp-id:   %s",
                isis_print_id(header_csnp->end_lsp_id, LSP_ID_LEN));
 
         if (ArgusParser->vflag > 1) {
@@ -1960,7 +1960,7 @@ static int isis_print (const u_int8_t *p, u_int length)
     case ISIS_PDU_L1_PSNP:
     case ISIS_PDU_L2_PSNP:
 	if (isis_header->fixed_len != (ISIS_COMMON_HEADER_SIZE+ISIS_PSNP_HEADER_SIZE)) {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"- bogus fixed header length %u should be %lu",
+	    ARGUSBUF_APPEND("- bogus fixed header length %u should be %lu",
 		   isis_header->fixed_len, (unsigned long)ISIS_PSNP_HEADER_SIZE);
 	    return (0);
 	}
@@ -1972,7 +1972,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 	}
 
 	TCHECK(*header_psnp);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  source-id:    %s, PDU length: %u",
+	ARGUSBUF_APPEND("\n\t  source-id:    %s, PDU length: %u",
                isis_print_id(header_psnp->source_id, NODE_ID_LEN),
                pdu_len);
 
@@ -2001,7 +2001,7 @@ static int isis_print (const u_int8_t *p, u_int length)
         }
 
 	if (!TTEST2(*pptr, 2)) {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t packet exceeded snapshot (%ld) bytes",
+	    ARGUSBUF_APPEND("\n\t\t packet exceeded snapshot (%ld) bytes",
                    (long)(pptr-snapend));
 	    return (1);
 	}
@@ -2015,7 +2015,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 	}
 
         /* first lets see if we know the TLVs name*/
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    %s TLV #%u, length: %u",
+	ARGUSBUF_APPEND("\n\t    %s TLV #%u, length: %u",
                tok2str(isis_tlv_values,
                        "unknown",
                        tlv_type),
@@ -2032,7 +2032,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 		goto trunctlv;
 	    alen = *tptr++;
 	    while (tmp && alen < tmp) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Area address (length: %u): %s",
+		ARGUSBUF_APPEND("\n\t      Area address (length: %u): %s",
                        alen,
                        isonsap_string(tptr,alen));
 		tptr += alen;
@@ -2048,7 +2048,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 	    while (tmp >= ETHER_ADDR_LEN) {
                 if (!TTEST2(*tptr, ETHER_ADDR_LEN))
                     goto trunctlv;
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      SNPA: %s",isis_print_id(tptr,ETHER_ADDR_LEN));
+                ARGUSBUF_APPEND("\n\t      SNPA: %s",isis_print_id(tptr,ETHER_ADDR_LEN));
                 tmp -= ETHER_ADDR_LEN;
                 tptr += ETHER_ADDR_LEN;
 	    }
@@ -2059,15 +2059,15 @@ static int isis_print (const u_int8_t *p, u_int length)
 		goto trunctlv;
 	    lan_alen = *tptr++; /* LAN address length */
 	    if (lan_alen == 0) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      LAN address length 0 bytes (invalid)");
+                ARGUSBUF_APPEND("\n\t      LAN address length 0 bytes (invalid)");
                 break;
             }
             tmp --;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      LAN address length %u bytes ",lan_alen);
+            ARGUSBUF_APPEND("\n\t      LAN address length %u bytes ",lan_alen);
 	    while (tmp >= lan_alen) {
                 if (!TTEST2(*tptr, lan_alen))
                     goto trunctlv;
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\tIS Neighbor: %s",isis_print_id(tptr,lan_alen));
+                ARGUSBUF_APPEND("\n\t\tIS Neighbor: %s",isis_print_id(tptr,lan_alen));
                 tmp -= lan_alen;
                 tptr +=lan_alen;
             }
@@ -2115,7 +2115,7 @@ static int isis_print (const u_int8_t *p, u_int length)
         case ISIS_TLV_IS_REACH:
 	    if (!TTEST2(*tptr,1))  /* check if there is one byte left to read out the virtual flag */
                 goto trunctlv;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      %s",
+            ARGUSBUF_APPEND("\n\t      %s",
                    tok2str(isis_is_reach_virtual_values,
                            "bogus virtual flag 0x%02x",
                            *tptr++));
@@ -2123,7 +2123,7 @@ static int isis_print (const u_int8_t *p, u_int length)
             while (tmp >= sizeof(struct isis_tlv_is_reach)) {
 		if (!TTEST(*tlv_is_reach))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      IS Neighbor: %s",
+		ARGUSBUF_APPEND("\n\t      IS Neighbor: %s",
 		       isis_print_id(tlv_is_reach->neighbor_nodeid, NODE_ID_LEN));
                 isis_print_metric_block(&tlv_is_reach->isis_metric_block);
 		tmp -= sizeof(struct isis_tlv_is_reach);
@@ -2136,7 +2136,7 @@ static int isis_print (const u_int8_t *p, u_int length)
             while (tmp >= sizeof(struct isis_tlv_es_reach)) {
 		if (!TTEST(*tlv_es_reach))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      ES Neighbor: %s",
+		ARGUSBUF_APPEND("\n\t      ES Neighbor: %s",
                        isis_print_id(tlv_es_reach->neighbor_sysid,SYSTEM_ID_LEN));
                 isis_print_metric_block(&tlv_es_reach->isis_metric_block);
 		tmp -= sizeof(struct isis_tlv_es_reach);
@@ -2209,7 +2209,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 		if (!TTEST2(*tptr, sizeof(struct in6_addr)))
 		    goto trunctlv;
 
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      IPv6 interface address: %s",
+                ARGUSBUF_APPEND("\n\t      IPv6 interface address: %s",
 		       ip6addr_string(tptr));
 
 		tptr += sizeof(struct in6_addr);
@@ -2221,7 +2221,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 	    if (!TTEST2(*tptr, 1))
 		goto trunctlv;
 
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      %s: ",
+            ARGUSBUF_APPEND("\n\t      %s: ",
                    tok2str(isis_subtlv_auth_values,
                            "unknown Authentication type 0x%02x",
                            *tptr));
@@ -2231,17 +2231,17 @@ static int isis_print (const u_int8_t *p, u_int length)
 		for(i=1;i<tlv_len;i++) {
 		    if (!TTEST2(*(tptr+i), 1))
 			goto trunctlv;
-		    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%c",*(tptr+i));
+		    ARGUSBUF_APPEND("%c",*(tptr+i));
 		}
 		break;
 	    case ISIS_SUBTLV_AUTH_MD5:
 		for(i=1;i<tlv_len;i++) {
 		    if (!TTEST2(*(tptr+i), 1))
 			goto trunctlv;
-		    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02x",*(tptr+i));
+		    ARGUSBUF_APPEND("%02x",*(tptr+i));
 		}
 		if (tlv_len != ISIS_SUBTLV_AUTH_MD5_LEN+1)
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],", (malformed subTLV) ");
+                    ARGUSBUF_APPEND(", (malformed subTLV) ");
 		break;
 	    case ISIS_SUBTLV_AUTH_PRIVATE:
 	    default:
@@ -2256,7 +2256,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 	    if(tmp>=1) {
 		if (!TTEST2(*tptr, 1))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Adjacency State: %s (%u)",
+		ARGUSBUF_APPEND("\n\t      Adjacency State: %s (%u)",
 		       tok2str(isis_ptp_adjancey_values, "unknown", *tptr),
                         *tptr);
 		tmp--;
@@ -2265,14 +2265,14 @@ static int isis_print (const u_int8_t *p, u_int length)
 		if (!TTEST2(tlv_ptp_adj->extd_local_circuit_id,
                             sizeof(tlv_ptp_adj->extd_local_circuit_id)))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Extended Local circuit-ID: 0x%08x",
+		ARGUSBUF_APPEND("\n\t      Extended Local circuit-ID: 0x%08x",
 		       EXTRACT_32BITS(tlv_ptp_adj->extd_local_circuit_id));
 		tmp-=sizeof(tlv_ptp_adj->extd_local_circuit_id);
 	    }
 	    if(tmp>=SYSTEM_ID_LEN) {
 		if (!TTEST2(tlv_ptp_adj->neighbor_sysid, SYSTEM_ID_LEN))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Neighbor System-ID: %s",
+		ARGUSBUF_APPEND("\n\t      Neighbor System-ID: %s",
 		       isis_print_id(tlv_ptp_adj->neighbor_sysid,SYSTEM_ID_LEN));
 		tmp-=SYSTEM_ID_LEN;
 	    }
@@ -2280,23 +2280,23 @@ static int isis_print (const u_int8_t *p, u_int length)
 		if (!TTEST2(tlv_ptp_adj->neighbor_extd_local_circuit_id,
                             sizeof(tlv_ptp_adj->neighbor_extd_local_circuit_id)))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Neighbor Extended Local circuit-ID: 0x%08x",
+		ARGUSBUF_APPEND("\n\t      Neighbor Extended Local circuit-ID: 0x%08x",
 		       EXTRACT_32BITS(tlv_ptp_adj->neighbor_extd_local_circuit_id));
 	    }
 	    break;
 
 	case ISIS_TLV_PROTOCOLS:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      NLPID(s): ");
+	    ARGUSBUF_APPEND("\n\t      NLPID(s): ");
 	    while (tmp>0) {
 		if (!TTEST2(*(tptr), 1))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s (0x%02x)",
+		ARGUSBUF_APPEND("%s (0x%02x)",
                        tok2str(nlpid_values,
                                "unknown",
                                *tptr),
                        *tptr);
 		if (tmp>1) /* further NPLIDs ? - put comma */
-		    sprintf(&ArgusBuf[strlen(ArgusBuf)],", ");
+		    ARGUSBUF_APPEND(", ");
                 tptr++;
                 tmp--;
 	    }
@@ -2305,25 +2305,25 @@ static int isis_print (const u_int8_t *p, u_int length)
 	case ISIS_TLV_TE_ROUTER_ID:
 	    if (!TTEST2(*pptr, sizeof(struct in_addr)))
 		goto trunctlv;
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Traffic Engineering Router ID: %s", ipaddr_string(pptr));
+	    ARGUSBUF_APPEND("\n\t      Traffic Engineering Router ID: %s", ipaddr_string(pptr));
 	    break;
 
 	case ISIS_TLV_IPADDR:
 	    while (tmp>=sizeof(struct in_addr)) {
 		if (!TTEST2(*tptr, sizeof(struct in_addr)))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      IPv4 interface address: %s", ipaddr_string(tptr));
+		ARGUSBUF_APPEND("\n\t      IPv4 interface address: %s", ipaddr_string(tptr));
 		tptr += sizeof(struct in_addr);
 		tmp -= sizeof(struct in_addr);
 	    }
 	    break;
 
 	case ISIS_TLV_HOSTNAME:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Hostname: ");
+	    ARGUSBUF_APPEND("\n\t      Hostname: ");
 	    while (tmp>0) {
 		if (!TTEST2(*tptr, 1))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%c",*tptr++);
+		ARGUSBUF_APPEND("%c",*tptr++);
                 tmp--;
 	    }
 	    break;
@@ -2333,7 +2333,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 	        break;
 	    if (!TTEST2(*tptr, NODE_ID_LEN))
                 goto trunctlv;
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      IS Neighbor: %s", isis_print_id(tptr, NODE_ID_LEN));
+	    ARGUSBUF_APPEND("\n\t      IS Neighbor: %s", isis_print_id(tptr, NODE_ID_LEN));
 	    tptr+=(NODE_ID_LEN);
 	    tmp-=(NODE_ID_LEN);
 
@@ -2341,14 +2341,14 @@ static int isis_print (const u_int8_t *p, u_int length)
 	        break;
 	    if (!TTEST2(*tptr, 1))
                 goto trunctlv;
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],", Flags: [%s]", ISIS_MASK_TLV_SHARED_RISK_GROUP(*tptr++) ? "numbered" : "unnumbered");
+	    ARGUSBUF_APPEND(", Flags: [%s]", ISIS_MASK_TLV_SHARED_RISK_GROUP(*tptr++) ? "numbered" : "unnumbered");
 	    tmp--;
 
 	    if (tmp < sizeof(struct in_addr))
 	        break;
 	    if (!TTEST2(*tptr,sizeof(struct in_addr)))
                 goto trunctlv;
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      IPv4 interface address: %s", ipaddr_string(tptr));
+	    ARGUSBUF_APPEND("\n\t      IPv4 interface address: %s", ipaddr_string(tptr));
 	    tptr+=sizeof(struct in_addr);
 	    tmp-=sizeof(struct in_addr);
 
@@ -2356,14 +2356,14 @@ static int isis_print (const u_int8_t *p, u_int length)
 	        break;
 	    if (!TTEST2(*tptr,sizeof(struct in_addr)))
                 goto trunctlv;
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      IPv4 neighbor address: %s", ipaddr_string(tptr));
+	    ARGUSBUF_APPEND("\n\t      IPv4 neighbor address: %s", ipaddr_string(tptr));
 	    tptr+=sizeof(struct in_addr);
 	    tmp-=sizeof(struct in_addr);
 
 	    while (tmp>=4) {
                 if (!TTEST2(*tptr, 4))
                     goto trunctlv;
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Link-ID: 0x%08x", EXTRACT_32BITS(tptr));
+                ARGUSBUF_APPEND("\n\t      Link-ID: 0x%08x", EXTRACT_32BITS(tptr));
                 tptr+=4;
                 tmp-=4;
 	    }
@@ -2374,17 +2374,17 @@ static int isis_print (const u_int8_t *p, u_int length)
 	    while(tmp>=sizeof(struct isis_tlv_lsp)) {
 		if (!TTEST((tlv_lsp->lsp_id)[LSP_ID_LEN-1]))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      lsp-id: %s",
+		ARGUSBUF_APPEND("\n\t      lsp-id: %s",
                        isis_print_id(tlv_lsp->lsp_id, LSP_ID_LEN));
 		if (!TTEST2(tlv_lsp->sequence_number, 4))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],", seq: 0x%08x",EXTRACT_32BITS(tlv_lsp->sequence_number));
+		ARGUSBUF_APPEND(", seq: 0x%08x",EXTRACT_32BITS(tlv_lsp->sequence_number));
 		if (!TTEST2(tlv_lsp->remaining_lifetime, 2))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],", lifetime: %5ds",EXTRACT_16BITS(tlv_lsp->remaining_lifetime));
+		ARGUSBUF_APPEND(", lifetime: %5ds",EXTRACT_16BITS(tlv_lsp->remaining_lifetime));
 		if (!TTEST2(tlv_lsp->checksum, 2))
 		    goto trunctlv;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],", chksum: 0x%04x",EXTRACT_16BITS(tlv_lsp->checksum));
+		ARGUSBUF_APPEND(", chksum: 0x%04x",EXTRACT_16BITS(tlv_lsp->checksum));
 		tmp-=sizeof(struct isis_tlv_lsp);
 		tlv_lsp++;
 	    }
@@ -2395,15 +2395,15 @@ static int isis_print (const u_int8_t *p, u_int length)
 	        break;
 	    if (!TTEST2(*tptr, ISIS_TLV_CHECKSUM_MINLEN))
 		goto trunctlv;
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      checksum: 0x%04x ", EXTRACT_16BITS(tptr));
+	    ARGUSBUF_APPEND("\n\t      checksum: 0x%04x ", EXTRACT_16BITS(tptr));
             /* do not attempt to verify the checksum if it is zero
              * most likely a HMAC-MD5 TLV is also present and
              * to avoid conflicts the checksum TLV is zeroed.
              * see rfc3358 for details
              */
             if (EXTRACT_16BITS(tptr) == 0)
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"(unverified)");
-            else sprintf(&ArgusBuf[strlen(ArgusBuf)],"(%s)", osi_cksum(optr, length) ? "incorrect" : "correct");
+                ARGUSBUF_APPEND("(unverified)");
+            else ARGUSBUF_APPEND("(%s)", osi_cksum(optr, length) ? "incorrect" : "correct");
 	    break;
 
 	case ISIS_TLV_MT_SUPPORTED:
@@ -2419,7 +2419,7 @@ static int isis_print (const u_int8_t *p, u_int length)
                     tptr+=mt_len;
                     tmp-=mt_len;
 		} else {
-		    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      malformed MT-ID");
+		    ARGUSBUF_APPEND("\n\t      malformed MT-ID");
 		    break;
 		}
 	    }
@@ -2431,7 +2431,7 @@ static int isis_print (const u_int8_t *p, u_int length)
                 break;
             if (!TTEST2(*tptr, ISIS_TLV_RESTART_SIGNALING_FLAGLEN))
                 goto trunctlv;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Flags [%s]",
+            ARGUSBUF_APPEND("\n\t      Flags [%s]",
                    bittok2str(isis_restart_flag_values, "none", *tptr));
             tptr+=ISIS_TLV_RESTART_SIGNALING_FLAGLEN;
             tmp-=ISIS_TLV_RESTART_SIGNALING_FLAGLEN;
@@ -2445,7 +2445,7 @@ static int isis_print (const u_int8_t *p, u_int length)
             if (!TTEST2(*tptr, ISIS_TLV_RESTART_SIGNALING_HOLDTIMELEN))
                 goto trunctlv;
 
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],", Remaining holding time %us", EXTRACT_16BITS(tptr+1));
+            ARGUSBUF_APPEND(", Remaining holding time %us", EXTRACT_16BITS(tptr+1));
             tptr+=ISIS_TLV_RESTART_SIGNALING_HOLDTIMELEN;
             tmp-=ISIS_TLV_RESTART_SIGNALING_HOLDTIMELEN;
 
@@ -2453,7 +2453,7 @@ static int isis_print (const u_int8_t *p, u_int length)
             if (tmp == SYSTEM_ID_LEN) {
                     if (!TTEST2(*tptr, SYSTEM_ID_LEN))
                             goto trunctlv;
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],", for %s",isis_print_id(tptr,SYSTEM_ID_LEN));
+                    ARGUSBUF_APPEND(", for %s",isis_print_id(tptr,SYSTEM_ID_LEN));
             } 
 	    break;
 
@@ -2462,7 +2462,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 	        break;
             if (!TTEST2(*tptr, ISIS_TLV_IDRP_INFO_MINLEN))
                 goto trunctlv;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Inter-Domain Information Type: %s",
+            ARGUSBUF_APPEND("\n\t      Inter-Domain Information Type: %s",
                    tok2str(isis_subtlv_idrp_values,
                            "Unknown (0x%02x)",
                            *tptr));
@@ -2470,7 +2470,7 @@ static int isis_print (const u_int8_t *p, u_int length)
             case ISIS_SUBTLV_IDRP_ASN:
                 if (!TTEST2(*tptr, 2)) /* fetch AS number */
                     goto trunctlv;
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"AS Number: %u",EXTRACT_16BITS(tptr));
+                ARGUSBUF_APPEND("AS Number: %u",EXTRACT_16BITS(tptr));
                 break;
             case ISIS_SUBTLV_IDRP_LOCAL:
             case ISIS_SUBTLV_IDRP_RES:
@@ -2486,14 +2486,14 @@ static int isis_print (const u_int8_t *p, u_int length)
 	        break;
             if (!TTEST2(*tptr, ISIS_TLV_LSP_BUFFERSIZE_MINLEN))
                 goto trunctlv;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      LSP Buffersize: %u",EXTRACT_16BITS(tptr));
+            ARGUSBUF_APPEND("\n\t      LSP Buffersize: %u",EXTRACT_16BITS(tptr));
             break;
 
         case ISIS_TLV_PART_DIS:
             while (tmp >= SYSTEM_ID_LEN) {
                 if (!TTEST2(*tptr, SYSTEM_ID_LEN))
                     goto trunctlv;
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      %s",isis_print_id(tptr,SYSTEM_ID_LEN));
+                ARGUSBUF_APPEND("\n\t      %s",isis_print_id(tptr,SYSTEM_ID_LEN));
                 tptr+=SYSTEM_ID_LEN;
                 tmp-=SYSTEM_ID_LEN;
             }
@@ -2504,7 +2504,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 	        break;
             if (!TTEST2(*tptr, sizeof(struct isis_metric_block)))
                 goto trunctlv;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Metric Block");
+            ARGUSBUF_APPEND("\n\t      Metric Block");
             isis_print_metric_block((const struct isis_metric_block *)tptr);
             tptr+=sizeof(struct isis_metric_block);
             tmp-=sizeof(struct isis_metric_block);
@@ -2514,7 +2514,7 @@ static int isis_print (const u_int8_t *p, u_int length)
                     goto trunctlv;
                 prefix_len=*tptr++; /* read out prefix length in semioctets*/
                 if (prefix_len < 2) {
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\tAddress: prefix length %u < 2", prefix_len);
+                    ARGUSBUF_APPEND("\n\t\tAddress: prefix length %u < 2", prefix_len);
                     break;
                 }
                 tmp--;
@@ -2522,7 +2522,7 @@ static int isis_print (const u_int8_t *p, u_int length)
                     break;
                 if (!TTEST2(*tptr, prefix_len/2))
                     goto trunctlv;
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\tAddress: %s/%u",
+                ARGUSBUF_APPEND("\n\t\tAddress: %s/%u",
                        isonsap_string(tptr,prefix_len/2),
                        prefix_len*4);
                 tptr+=prefix_len/2;
@@ -2535,7 +2535,7 @@ static int isis_print (const u_int8_t *p, u_int length)
 	        break;
             if (!TTEST2(*tptr, ISIS_TLV_IIH_SEQNR_MINLEN)) /* check if four bytes are on the wire */
                 goto trunctlv;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Sequence number: %u", EXTRACT_32BITS(tptr) );
+            ARGUSBUF_APPEND("\n\t      Sequence number: %u", EXTRACT_32BITS(tptr) );
             break;
 
         case ISIS_TLV_VENDOR_PRIVATE:
@@ -2544,7 +2544,7 @@ static int isis_print (const u_int8_t *p, u_int length)
             if (!TTEST2(*tptr, ISIS_TLV_VENDOR_PRIVATE_MINLEN)) /* check if enough byte for a full oui */
                 goto trunctlv;
             vendor_id = EXTRACT_24BITS(tptr);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Vendor: %s (%u)",
+            ARGUSBUF_APPEND("\n\t      Vendor: %s (%u)",
                    tok2str(oui_values,"Unknown",vendor_id),
                    vendor_id);
             tptr+=3;
@@ -2582,16 +2582,16 @@ static int isis_print (const u_int8_t *p, u_int length)
     }
 
     if (packet_len != 0) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      %u straggler bytes", packet_len);
+	ARGUSBUF_APPEND("\n\t      %u straggler bytes", packet_len);
     }
     return (1);
 
  trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)], "[|isis]");
+    ARGUSBUF_APPEND("[|isis]");
     return (1);
 
  trunctlv:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t packet exceeded snapshot");
+    ARGUSBUF_APPEND("\n\t\t packet exceeded snapshot");
     return(1);
 }
 

--- a/examples/radump/print-krb.c
+++ b/examples/radump/print-krb.c
@@ -120,13 +120,13 @@ c_print(register const u_char *s, register const u_char *ep)
       }
       if (!isascii(c)) {
          c = toascii(c);
-         sprintf (&ArgusBuf[strlen(ArgusBuf)], "M-");
+         ARGUSBUF_APPEND("M-");
       }
       if (!isprint(c)) {
          c ^= 0x40;   /* DEL to ?, others to alpha */
-         sprintf (&ArgusBuf[strlen(ArgusBuf)], "^");
+         ARGUSBUF_APPEND("^");
       }
-      sprintf (&ArgusBuf[strlen(ArgusBuf)], "%c", c);
+      ARGUSBUF_APPEND("%c", c);
    }
    if (flag)
       return NULL;
@@ -141,14 +141,14 @@ krb4_print_hdr(const u_char *cp)
 #define PRINT      if ((cp = c_print(cp, snapend)) == NULL) goto trunc
 
    PRINT;
-   sprintf (&ArgusBuf[strlen(ArgusBuf)], ".");
+   ARGUSBUF_APPEND(".");
    PRINT;
-   sprintf (&ArgusBuf[strlen(ArgusBuf)], "@");
+   ARGUSBUF_APPEND("@");
    PRINT;
    return (cp);
 
 trunc:
-   sprintf (&ArgusBuf[strlen(ArgusBuf)], "%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
    return (NULL);
 
 #undef PRINT
@@ -169,13 +169,13 @@ krb4_print(const u_char *cp)
    kp = (struct krb *)cp;
 
    if ((&kp->type) >= snapend) {
-      sprintf (&ArgusBuf[strlen(ArgusBuf)], "%s", tstr);
+      ARGUSBUF_APPEND("%s", tstr);
       return;
    }
 
    type = kp->type & (0xFF << 1);
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s %s: ",
+   ARGUSBUF_APPEND(" %s %s: ",
        IS_LENDIAN(kp) ? "le" : "be", tok2str(type2str, NULL, type));
 
    switch (type) {
@@ -185,21 +185,21 @@ krb4_print(const u_char *cp)
          return;
       cp += 4;   /* ctime */
       TCHECK(*cp);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %dmin ", *cp++ * 5);
+      ARGUSBUF_APPEND(" %dmin ", *cp++ * 5);
       PRINT;
-      sprintf (&ArgusBuf[strlen(ArgusBuf)], ".");
+      ARGUSBUF_APPEND(".");
       PRINT;
       break;
 
    case AUTH_MSG_APPL_REQUEST:
       cp += 2;
       TCHECK(*cp);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"v%d ", *cp++);
+      ARGUSBUF_APPEND("v%d ", *cp++);
       PRINT;
       TCHECK(*cp);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," (%d)", *cp++);
+      ARGUSBUF_APPEND(" (%d)", *cp++);
       TCHECK(*cp);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," (%d)", *cp);
+      ARGUSBUF_APPEND(" (%d)", *cp);
       break;
 
    case AUTH_MSG_KDC_REPLY:
@@ -208,7 +208,7 @@ krb4_print(const u_char *cp)
       cp += 10;   /* timestamp + n + exp + kvno */
       TCHECK2(*cp, sizeof(short));
       len = KTOHSP(kp, cp);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," (%d)", len);
+      ARGUSBUF_APPEND(" (%d)", len);
       break;
 
    case AUTH_MSG_ERR_REPLY:
@@ -216,20 +216,20 @@ krb4_print(const u_char *cp)
          return;
       cp += 4;      /* timestamp */
       TCHECK2(*cp, sizeof(short));
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s ", tok2str(kerr2str, NULL, KTOHSP(kp, cp)));
+      ARGUSBUF_APPEND(" %s ", tok2str(kerr2str, NULL, KTOHSP(kp, cp)));
       cp += 4;
       PRINT;
       break;
 
    default:
-      sprintf (&ArgusBuf[strlen(ArgusBuf)], "(unknown)");
+      ARGUSBUF_APPEND("(unknown)");
       break;
    }
 
    return;
 
 trunc:
-   sprintf (&ArgusBuf[strlen(ArgusBuf)], "%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 char *
@@ -240,7 +240,7 @@ krb_print(const u_char *dat, u_int len)
    kp = (struct krb *)dat;
 
    if (dat >= snapend) {
-      sprintf (&ArgusBuf[strlen(ArgusBuf)], "%s", tstr);
+      ARGUSBUF_APPEND("%s", tstr);
       return ArgusBuf;
    }
 
@@ -249,17 +249,17 @@ krb_print(const u_char *dat, u_int len)
    case 1:
    case 2:
    case 3:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," v%d", kp->pvno);
+      ARGUSBUF_APPEND(" v%d", kp->pvno);
       break;
 
    case 4:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," v%d", kp->pvno);
+      ARGUSBUF_APPEND(" v%d", kp->pvno);
       krb4_print((const u_char *)kp);
       break;
 
    case 106:
    case 107:
-      sprintf (&ArgusBuf[strlen(ArgusBuf)], " v5");
+      ARGUSBUF_APPEND(" v5");
       /* Decode ASN.1 here "someday" */
       break;
    }

--- a/examples/radump/print-l2tp.c
+++ b/examples/radump/print-l2tp.c
@@ -253,7 +253,7 @@ print_string(const u_char *dat, u_int length)
 {
 	u_int i;
 	for (i=0; i<length; i++) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%c", *dat++);
+		ARGUSBUF_APPEND("%c", *dat++);
 	}
 }
 
@@ -262,20 +262,20 @@ print_octets(const u_char *dat, u_int length)
 {
 	u_int i;
 	for (i=0; i<length; i++) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02x", *dat++);
+		ARGUSBUF_APPEND("%02x", *dat++);
 	}
 }
 
 static void
 print_16bits_val(const u_int16_t *dat)
 {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", EXTRACT_16BITS(dat));
+	ARGUSBUF_APPEND("%u", EXTRACT_16BITS(dat));
 }
 
 static void
 print_32bits_val(const u_int32_t *dat)
 {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%lu", (u_long)EXTRACT_32BITS(dat));
+	ARGUSBUF_APPEND("%lu", (u_long)EXTRACT_32BITS(dat));
 }
 
 /***********************************/
@@ -286,7 +286,7 @@ l2tp_msgtype_print(const u_char *dat)
 {
 	u_int16_t *ptr = (u_int16_t*)dat;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tok2str(l2tp_msgtype2str, "MSGTYPE-#%u",
+	ARGUSBUF_APPEND("%s", tok2str(l2tp_msgtype2str, "MSGTYPE-#%u",
 	    EXTRACT_16BITS(ptr)));
 }
 
@@ -295,12 +295,12 @@ l2tp_result_code_print(const u_char *dat, u_int length)
 {
 	u_int16_t *ptr = (u_int16_t *)dat;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", EXTRACT_16BITS(ptr)); ptr++;	/* Result Code */
+	ARGUSBUF_APPEND("%u", EXTRACT_16BITS(ptr)); ptr++;	/* Result Code */
 	if (length > 2) {				/* Error Code (opt) */
-	        sprintf(&ArgusBuf[strlen(ArgusBuf)],"/%u", EXTRACT_16BITS(ptr)); ptr++;
+	        ARGUSBUF_APPEND("/%u", EXTRACT_16BITS(ptr)); ptr++;
 	}
 	if (length > 4) {				/* Error Message (opt) */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+		ARGUSBUF_APPEND(" ");
 		print_string((u_char *)ptr, length - 4);
 	}
 }
@@ -308,7 +308,7 @@ l2tp_result_code_print(const u_char *dat, u_int length)
 static void
 l2tp_proto_ver_print(const u_int16_t *dat)
 {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u.%u", (EXTRACT_16BITS(dat) >> 8),
+	ARGUSBUF_APPEND("%u.%u", (EXTRACT_16BITS(dat) >> 8),
 	    (EXTRACT_16BITS(dat) & 0xff));
 }
 
@@ -318,10 +318,10 @@ l2tp_framing_cap_print(const u_char *dat)
 	u_int32_t *ptr = (u_int32_t *)dat;
 
 	if (EXTRACT_32BITS(ptr) &  L2TP_FRAMING_CAP_ASYNC_MASK) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"A");
+		ARGUSBUF_APPEND("A");
 	}
 	if (EXTRACT_32BITS(ptr) &  L2TP_FRAMING_CAP_SYNC_MASK) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"S");
+		ARGUSBUF_APPEND("S");
 	}
 }
 
@@ -331,10 +331,10 @@ l2tp_bearer_cap_print(const u_char *dat)
 	u_int32_t *ptr = (u_int32_t *)dat;
 
 	if (EXTRACT_32BITS(ptr) &  L2TP_BEARER_CAP_ANALOG_MASK) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"A");
+		ARGUSBUF_APPEND("A");
 	}
 	if (EXTRACT_32BITS(ptr) &  L2TP_BEARER_CAP_DIGITAL_MASK) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"D");
+		ARGUSBUF_APPEND("D");
 	}
 }
 
@@ -342,9 +342,9 @@ static void
 l2tp_q931_cc_print(const u_char *dat, u_int length)
 {
 	print_16bits_val((u_int16_t *)dat);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],", %02x", dat[2]);
+	ARGUSBUF_APPEND(", %02x", dat[2]);
 	if (length > 3) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+		ARGUSBUF_APPEND(" ");
 		print_string(dat+3, length-3);
 	}
 }
@@ -355,10 +355,10 @@ l2tp_bearer_type_print(const u_char *dat)
 	u_int32_t *ptr = (u_int32_t *)dat;
 
 	if (EXTRACT_32BITS(ptr) &  L2TP_BEARER_TYPE_ANALOG_MASK) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"A");
+		ARGUSBUF_APPEND("A");
 	}
 	if (EXTRACT_32BITS(ptr) &  L2TP_BEARER_TYPE_DIGITAL_MASK) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"D");
+		ARGUSBUF_APPEND("D");
 	}
 }
 
@@ -368,17 +368,17 @@ l2tp_framing_type_print(const u_char *dat)
 	u_int32_t *ptr = (u_int32_t *)dat;
 
 	if (EXTRACT_32BITS(ptr) &  L2TP_FRAMING_TYPE_ASYNC_MASK) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"A");
+		ARGUSBUF_APPEND("A");
 	}
 	if (EXTRACT_32BITS(ptr) &  L2TP_FRAMING_TYPE_SYNC_MASK) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"S");
+		ARGUSBUF_APPEND("S");
 	}
 }
 
 static void
 l2tp_packet_proc_delay_print(void)
 {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"obsolete");
+	ARGUSBUF_APPEND("obsolete");
 }
 
 static void
@@ -386,7 +386,7 @@ l2tp_proxy_auth_type_print(const u_char *dat)
 {
 	u_int16_t *ptr = (u_int16_t *)dat;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tok2str(l2tp_authentype2str,
+	ARGUSBUF_APPEND("%s", tok2str(l2tp_authentype2str,
 			     "AuthType-#%u", EXTRACT_16BITS(ptr)));
 }
 
@@ -395,7 +395,7 @@ l2tp_proxy_auth_id_print(const u_char *dat)
 {
 	u_int16_t *ptr = (u_int16_t *)dat;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", EXTRACT_16BITS(ptr) & L2TP_PROXY_AUTH_ID_MASK);
+	ARGUSBUF_APPEND("%u", EXTRACT_16BITS(ptr) & L2TP_PROXY_AUTH_ID_MASK);
 }
 
 static void
@@ -408,27 +408,27 @@ l2tp_call_errors_print(const u_char *dat)
 
 	val_h = EXTRACT_16BITS(ptr); ptr++;
 	val_l = EXTRACT_16BITS(ptr); ptr++;
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"CRCErr=%u ", (val_h<<16) + val_l);
+	ARGUSBUF_APPEND("CRCErr=%u ", (val_h<<16) + val_l);
 
 	val_h = EXTRACT_16BITS(ptr); ptr++;
 	val_l = EXTRACT_16BITS(ptr); ptr++;
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"FrameErr=%u ", (val_h<<16) + val_l);
+	ARGUSBUF_APPEND("FrameErr=%u ", (val_h<<16) + val_l);
 
 	val_h = EXTRACT_16BITS(ptr); ptr++;
 	val_l = EXTRACT_16BITS(ptr); ptr++;
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"HardOver=%u ", (val_h<<16) + val_l);
+	ARGUSBUF_APPEND("HardOver=%u ", (val_h<<16) + val_l);
 
 	val_h = EXTRACT_16BITS(ptr); ptr++;
 	val_l = EXTRACT_16BITS(ptr); ptr++;
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"BufOver=%u ", (val_h<<16) + val_l);
+	ARGUSBUF_APPEND("BufOver=%u ", (val_h<<16) + val_l);
 
 	val_h = EXTRACT_16BITS(ptr); ptr++;
 	val_l = EXTRACT_16BITS(ptr); ptr++;
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"Timeout=%u ", (val_h<<16) + val_l);
+	ARGUSBUF_APPEND("Timeout=%u ", (val_h<<16) + val_l);
 
 	val_h = EXTRACT_16BITS(ptr); ptr++;
 	val_l = EXTRACT_16BITS(ptr); ptr++;
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"AlignErr=%u ", (val_h<<16) + val_l);
+	ARGUSBUF_APPEND("AlignErr=%u ", (val_h<<16) + val_l);
 }
 
 static void
@@ -441,11 +441,11 @@ l2tp_accm_print(const u_char *dat)
 
 	val_h = EXTRACT_16BITS(ptr); ptr++;
 	val_l = EXTRACT_16BITS(ptr); ptr++;
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"send=%08x ", (val_h<<16) + val_l);
+	ARGUSBUF_APPEND("send=%08x ", (val_h<<16) + val_l);
 
 	val_h = EXTRACT_16BITS(ptr); ptr++;
 	val_l = EXTRACT_16BITS(ptr); ptr++;
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"recv=%08x ", (val_h<<16) + val_l);
+	ARGUSBUF_APPEND("recv=%08x ", (val_h<<16) + val_l);
 }
 
 static void
@@ -453,13 +453,13 @@ l2tp_ppp_discon_cc_print(const u_char *dat, u_int length)
 {
 	u_int16_t *ptr = (u_int16_t *)dat;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%04x, ", EXTRACT_16BITS(ptr)); ptr++;	/* Disconnect Code */
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%04x ",  EXTRACT_16BITS(ptr)); ptr++;	/* Control Protocol Number */
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tok2str(l2tp_cc_direction2str,
+	ARGUSBUF_APPEND("%04x, ", EXTRACT_16BITS(ptr)); ptr++;	/* Disconnect Code */
+	ARGUSBUF_APPEND("%04x ",  EXTRACT_16BITS(ptr)); ptr++;	/* Control Protocol Number */
+	ARGUSBUF_APPEND("%s", tok2str(l2tp_cc_direction2str,
 			     "Direction-#%u", *((u_char *)ptr++)));
 
 	if (length > 5) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+		ARGUSBUF_APPEND(" ");
 		print_string((const u_char *)ptr, length-5);
 	}
 }
@@ -476,7 +476,7 @@ l2tp_avp_print(const u_char *dat, int length)
 		return;
 	}
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+	ARGUSBUF_APPEND(" ");
 
 	TCHECK(*ptr);	/* Flags & Length */
 	len = EXTRACT_16BITS(ptr) & L2TP_AVP_HDR_LEN_MASK;
@@ -496,29 +496,29 @@ l2tp_avp_print(const u_char *dat, int length)
 	/* After this point, no need to worry about truncation */
 
 	if (EXTRACT_16BITS(ptr) & L2TP_AVP_HDR_FLAG_MANDATORY) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"*");
+		ARGUSBUF_APPEND("*");
 	}
 	if (EXTRACT_16BITS(ptr) & L2TP_AVP_HDR_FLAG_HIDDEN) {
 		hidden = TRUE;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"?");
+		ARGUSBUF_APPEND("?");
 	}
 	ptr++;
 
 	if (EXTRACT_16BITS(ptr)) {
 		/* Vendor Specific Attribute */
-	        sprintf(&ArgusBuf[strlen(ArgusBuf)],"VENDOR%04x:", EXTRACT_16BITS(ptr)); ptr++;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"ATTR%04x", EXTRACT_16BITS(ptr)); ptr++;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"(");
+	        ARGUSBUF_APPEND("VENDOR%04x:", EXTRACT_16BITS(ptr)); ptr++;
+		ARGUSBUF_APPEND("ATTR%04x", EXTRACT_16BITS(ptr)); ptr++;
+		ARGUSBUF_APPEND("(");
 		print_octets((u_char *)ptr, len-6);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+		ARGUSBUF_APPEND(")");
 	} else {
 		/* IETF-defined Attributes */
 		ptr++;
 		attr_type = EXTRACT_16BITS(ptr); ptr++;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tok2str(l2tp_avp2str, "AVP-#%u", attr_type));
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"(");
+		ARGUSBUF_APPEND("%s", tok2str(l2tp_avp2str, "AVP-#%u", attr_type));
+		ARGUSBUF_APPEND("(");
 		if (hidden) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"???");
+			ARGUSBUF_APPEND("???");
 		} else {
 			switch (attr_type) {
 			case L2TP_AVP_MSGTYPE:
@@ -607,14 +607,14 @@ l2tp_avp_print(const u_char *dat, int length)
 				break;
 			}
 		}
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+		ARGUSBUF_APPEND(")");
 	}
 
 	l2tp_avp_print(dat+len, length-len);
 	return;
 
  trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"|...");
+	ARGUSBUF_APPEND("|...");
 }
 
 
@@ -631,35 +631,35 @@ l2tp_print(const u_char *dat, u_int length)
 
 	TCHECK(*ptr);	/* Flags & Version */
 	if ((EXTRACT_16BITS(ptr) & L2TP_VERSION_MASK) == L2TP_VERSION_L2TP) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," l2tp:");
+		ARGUSBUF_APPEND(" l2tp:");
 	} else if ((EXTRACT_16BITS(ptr) & L2TP_VERSION_MASK) == L2TP_VERSION_L2F) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," l2f:");
+		ARGUSBUF_APPEND(" l2f:");
 		return ArgusBuf;		/* nothing to do */
 	} else {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," Unknown Version, neither L2F(1) nor L2TP(2)");
+		ARGUSBUF_APPEND(" Unknown Version, neither L2F(1) nor L2TP(2)");
 		return ArgusBuf;		/* nothing we can do */
 	}
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"[");
+	ARGUSBUF_APPEND("[");
 	if (EXTRACT_16BITS(ptr) & L2TP_FLAG_TYPE) {
 		flag_t = TRUE;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"T");
+		ARGUSBUF_APPEND("T");
 	}
 	if (EXTRACT_16BITS(ptr) & L2TP_FLAG_LENGTH) {
 		flag_l = TRUE;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"L");
+		ARGUSBUF_APPEND("L");
 	}
 	if (EXTRACT_16BITS(ptr) & L2TP_FLAG_SEQUENCE) {
 		flag_s = TRUE;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"S");
+		ARGUSBUF_APPEND("S");
 	}
 	if (EXTRACT_16BITS(ptr) & L2TP_FLAG_OFFSET) {
 		flag_o = TRUE;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"O");
+		ARGUSBUF_APPEND("O");
 	}
 	if (EXTRACT_16BITS(ptr) & L2TP_FLAG_PRIORITY)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"P");
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"]");
+		ARGUSBUF_APPEND("P");
+	ARGUSBUF_APPEND("]");
 
 	ptr++;
 	cnt += 2;
@@ -673,18 +673,18 @@ l2tp_print(const u_char *dat, u_int length)
 	}
 
 	TCHECK(*ptr);		/* Tunnel ID */
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"(%u/", EXTRACT_16BITS(ptr)); ptr++;
+	ARGUSBUF_APPEND("(%u/", EXTRACT_16BITS(ptr)); ptr++;
 	cnt += 2;
 	TCHECK(*ptr);		/* Session ID */
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u)",  EXTRACT_16BITS(ptr)); ptr++;
+	ARGUSBUF_APPEND("%u)",  EXTRACT_16BITS(ptr)); ptr++;
 	cnt += 2;
 
 	if (flag_s) {
 		TCHECK(*ptr);	/* Ns */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"Ns=%u,", EXTRACT_16BITS(ptr)); ptr++;
+		ARGUSBUF_APPEND("Ns=%u,", EXTRACT_16BITS(ptr)); ptr++;
 		cnt += 2;
 		TCHECK(*ptr);	/* Nr */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"Nr=%u",  EXTRACT_16BITS(ptr)); ptr++;
+		ARGUSBUF_APPEND("Nr=%u",  EXTRACT_16BITS(ptr)); ptr++;
 		cnt += 2;
 	}
 
@@ -697,37 +697,37 @@ l2tp_print(const u_char *dat, u_int length)
 
 	if (flag_l) {
 		if (length < l2tp_len) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," Length %u larger than packet", l2tp_len);
+			ARGUSBUF_APPEND(" Length %u larger than packet", l2tp_len);
 			return ArgusBuf;
 		}
 		length = l2tp_len;
 	}
 	if (length < cnt) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," Length %u smaller than header length", length);
+		ARGUSBUF_APPEND(" Length %u smaller than header length", length);
 		return ArgusBuf;
 	}
 	if (flag_t) {
 		if (!flag_l) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," No length");
+			ARGUSBUF_APPEND(" No length");
 			return ArgusBuf;
 		}
 		if (length - cnt == 0) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," ZLB");
+			ARGUSBUF_APPEND(" ZLB");
 		} else {
 			l2tp_avp_print((u_char *)ptr, length - cnt);
 		}
 	} else {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," {");
+		ARGUSBUF_APPEND(" {");
 /*
 		ppp_print((u_char *)ptr, length - cnt);
 */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"}");
+		ARGUSBUF_APPEND("}");
 	}
 
 	return ArgusBuf;
 
  trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+	ARGUSBUF_APPEND("%s", tstr);
 
    return ArgusBuf;
 }

--- a/examples/radump/print-ldp.c
+++ b/examples/radump/print-ldp.c
@@ -264,7 +264,7 @@ ldp_tlv_print(register const u_char *tptr) {
     tlv_type=LDP_MASK_TLV_TYPE(EXTRACT_16BITS(ldp_tlv_header->type));
 
     /* FIXME vendor private / experimental check */
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    %s TLV (0x%04x), length: %u, Flags: [%s and %s forward if unknown]",
+    ARGUSBUF_APPEND("\n\t    %s TLV (0x%04x), length: %u, Flags: [%s and %s forward if unknown]",
            tok2str(ldp_tlv_values,
                    "Unknown",
                    tlv_type),
@@ -278,40 +278,40 @@ ldp_tlv_print(register const u_char *tptr) {
     switch(tlv_type) {
 
     case LDP_TLV_COMMON_HELLO:
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Hold Time: %us, Flags: [%s Hello%s]",
+        ARGUSBUF_APPEND("\n\t      Hold Time: %us, Flags: [%s Hello%s]",
                EXTRACT_16BITS(tptr),
                (EXTRACT_16BITS(tptr+2)&0x8000) ? "Targeted" : "Link",
                (EXTRACT_16BITS(tptr+2)&0x4000) ? ", Request for targeted Hellos" : "");
         break;
 
     case LDP_TLV_IPV4_TRANSPORT_ADDR:
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      IPv4 Transport Address: %s", ipaddr_string(tptr));
+        ARGUSBUF_APPEND("\n\t      IPv4 Transport Address: %s", ipaddr_string(tptr));
         break;
 #ifdef INET6
     case LDP_TLV_IPV6_TRANSPORT_ADDR:
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      IPv6 Transport Address: %s", ip6addr_string(tptr));
+        ARGUSBUF_APPEND("\n\t      IPv6 Transport Address: %s", ip6addr_string(tptr));
         break;
 #endif
     case LDP_TLV_CONFIG_SEQ_NUMBER:
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Sequence Number: %u", EXTRACT_32BITS(tptr));
+        ARGUSBUF_APPEND("\n\t      Sequence Number: %u", EXTRACT_32BITS(tptr));
         break;
 
     case LDP_TLV_ADDRESS_LIST:
    af = EXTRACT_16BITS(tptr);
    tptr+=2;
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Adress Family: ");
+   ARGUSBUF_APPEND("\n\t      Adress Family: ");
    if (af == AFNUM_INET) {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"IPv4, addresses:");
+       ARGUSBUF_APPEND("IPv4, addresses:");
        for (i=0; i<(tlv_tlen-2)/4; i++) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s",ipaddr_string(tptr));
+      ARGUSBUF_APPEND(" %s",ipaddr_string(tptr));
       tptr+=sizeof(struct in_addr);
        }
    }
 #ifdef INET6
    else if (af == AFNUM_INET6) {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"IPv6, addresses:");
+       ARGUSBUF_APPEND("IPv6, addresses:");
        for (i=0; i<(tlv_tlen-2)/16; i++) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s",ip6addr_string(tptr));
+      ARGUSBUF_APPEND(" %s",ip6addr_string(tptr));
       tptr+=sizeof(struct in6_addr);
        }
    }
@@ -319,7 +319,7 @@ ldp_tlv_print(register const u_char *tptr) {
    break;
 
     case LDP_TLV_COMMON_SESSION:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Version: %u, Keepalive: %us, Flags: [Downstream %s, Loop Detection %s]",
+   ARGUSBUF_APPEND("\n\t      Version: %u, Keepalive: %us, Flags: [Downstream %s, Loop Detection %s]",
           EXTRACT_16BITS(tptr), EXTRACT_16BITS(tptr+2),
           (EXTRACT_16BITS(tptr+6)&0x8000) ? "On Demand" : "Unsolicited",
           (EXTRACT_16BITS(tptr+6)&0x4000) ? "Enabled" : "Disabled"
@@ -328,7 +328,7 @@ ldp_tlv_print(register const u_char *tptr) {
 
     case LDP_TLV_FEC:
         fec_type = *tptr;
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      %s FEC (0x%02x)",
+   ARGUSBUF_APPEND("\n\t      %s FEC (0x%02x)",
           tok2str(ldp_fec_values, "Unknown", fec_type),
           fec_type);
 
@@ -342,12 +342,12 @@ ldp_tlv_print(register const u_char *tptr) {
        tptr+=2;
        if (af == AFNUM_INET) {
       i=decode_prefix4(tptr,buf,sizeof(buf));
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],": IPv4 prefix %s",buf);
+      ARGUSBUF_APPEND(": IPv4 prefix %s",buf);
        }
 #ifdef INET6
        else if (af == AFNUM_INET6) {
       i=decode_prefix6(tptr,buf,sizeof(buf));
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],": IPv6 prefix %s",buf);
+      ARGUSBUF_APPEND(": IPv6 prefix %s",buf);
        }
 #endif
        break;
@@ -358,7 +358,7 @@ ldp_tlv_print(register const u_char *tptr) {
                 goto trunc;
             vc_info_len = *(tptr+2);
 
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],": %s, %scontrol word, group-ID %u, VC-ID %u, VC-info-length: %u",
+       ARGUSBUF_APPEND(": %s, %scontrol word, group-ID %u, VC-ID %u, VC-info-length: %u",
          tok2str(l2vpn_encaps_values, "Unknown", EXTRACT_16BITS(tptr)&0x7fff),
          EXTRACT_16BITS(tptr)&0x8000 ? "" : "no ",
                    EXTRACT_32BITS(tptr+3),
@@ -380,27 +380,27 @@ ldp_tlv_print(register const u_char *tptr) {
                 if (vc_info_len < vc_info_tlv_len)
                     break;
 
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\tInterface Parameter: %s (0x%02x), len %u",
+                ARGUSBUF_APPEND("\n\t\tInterface Parameter: %s (0x%02x), len %u",
                        tok2str(ldp_fec_martini_ifparm_values,"Unknown",vc_info_tlv_type),
                        vc_info_tlv_type,
                        vc_info_tlv_len);
 
                 switch(vc_info_tlv_type) {
                 case LDP_FEC_MARTINI_IFPARM_MTU:
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],": %u",EXTRACT_16BITS(tptr+2));
+                    ARGUSBUF_APPEND(": %u",EXTRACT_16BITS(tptr+2));
                     break;
 
                 case LDP_FEC_MARTINI_IFPARM_DESC:
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],": ");
+                    ARGUSBUF_APPEND(": ");
                     for (idx = 2; idx < vc_info_tlv_len; idx++)
-                       sprintf(&ArgusBuf[strlen(ArgusBuf)],"%c", *(tptr+idx));
+                       ARGUSBUF_APPEND("%c", *(tptr+idx));
                     break;
 
                 case LDP_FEC_MARTINI_IFPARM_VCCV:
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t  Control Channels (0x%02x) = [%s]",
+                    ARGUSBUF_APPEND("\n\t\t  Control Channels (0x%02x) = [%s]",
                            *(tptr+2),
                            bittok2str(ldp_fec_martini_ifparm_vccv_cc_values,"none",*(tptr+2)));
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t  CV Types (0x%02x) = [%s]",
+                    ARGUSBUF_APPEND("\n\t\t  CV Types (0x%02x) = [%s]",
                            *(tptr+3),
                            bittok2str(ldp_fec_martini_ifparm_vccv_cv_values,"none",*(tptr+3)));
                     break;
@@ -419,25 +419,25 @@ ldp_tlv_print(register const u_char *tptr) {
    break;
 
     case LDP_TLV_GENERIC_LABEL:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Label: %u", EXTRACT_32BITS(tptr) & 0xfffff);
+   ARGUSBUF_APPEND("\n\t      Label: %u", EXTRACT_32BITS(tptr) & 0xfffff);
    break;
 
     case LDP_TLV_STATUS:
    ui = EXTRACT_32BITS(tptr);
    tptr+=4;
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Status: 0x%02x, Flags: [%s and %s forward]",
+   ARGUSBUF_APPEND("\n\t      Status: 0x%02x, Flags: [%s and %s forward]",
           ui&0x3fffffff,
           ui&0x80000000 ? "Fatal error" : "Advisory Notification",
           ui&0x40000000 ? "do" : "don't");
    ui = EXTRACT_32BITS(tptr);
    tptr+=4;
    if (ui)
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],", causing Message ID: 0x%08x", ui);
+       ARGUSBUF_APPEND(", causing Message ID: 0x%08x", ui);
    break;
 
     case LDP_TLV_FT_SESSION:
    ft_flags = EXTRACT_16BITS(tptr);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Flags: [%sReconnect, %sSave State, %sAll-Label Protection, %s Checkpoint, %sRe-Learn State]",
+   ARGUSBUF_APPEND("\n\t      Flags: [%sReconnect, %sSave State, %sAll-Label Protection, %s Checkpoint, %sRe-Learn State]",
           ft_flags&0x8000 ? "" : "No ",
           ft_flags&0x8 ? "" : "Don't ",
           ft_flags&0x4 ? "" : "No ",
@@ -446,11 +446,11 @@ ldp_tlv_print(register const u_char *tptr) {
    tptr+=4;
    ui = EXTRACT_32BITS(tptr);
    if (ui)
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],", Reconnect Timeout: %ums", ui);
+       ARGUSBUF_APPEND(", Reconnect Timeout: %ums", ui);
    tptr+=4;
    ui = EXTRACT_32BITS(tptr);
    if (ui)
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],", Recovery Time: %ums", ui);
+       ARGUSBUF_APPEND(", Recovery Time: %ums", ui);
    break;
 
 
@@ -478,7 +478,7 @@ ldp_tlv_print(register const u_char *tptr) {
     return(tlv_len+4); /* Type & Length fields not included */
  
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t packet exceeded snapshot");
+    ARGUSBUF_APPEND("\n\t\t packet exceeded snapshot");
     return 0;
 }
 
@@ -516,7 +516,7 @@ ldp_msg_print(register const u_char *pptr) {
      * Sanity checking of the header.
      */
     if (EXTRACT_16BITS(&ldp_com_header->version) != LDP_VERSION) {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%sLDP version %u packet not supported",
+   ARGUSBUF_APPEND("%sLDP version %u packet not supported",
                (ArgusParser->vflag < 1) ? "" : "\n\t",
                EXTRACT_16BITS(&ldp_com_header->version));
    return 0;
@@ -524,7 +524,7 @@ ldp_msg_print(register const u_char *pptr) {
 
     /* print the LSR-ID, label-space & length */
     pdu_len = EXTRACT_16BITS(&ldp_com_header->pdu_length);
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%sLDP, Label-Space-ID: %s:%u, pdu-length: %u",
+    ARGUSBUF_APPEND("%sLDP, Label-Space-ID: %s:%u, pdu-length: %u",
            (ArgusParser->vflag < 1) ? "" : "\n\t",
            ipaddr_string(&ldp_com_header->lsr_id),
            EXTRACT_16BITS(&ldp_com_header->label_space),
@@ -550,7 +550,7 @@ ldp_msg_print(register const u_char *pptr) {
         msg_type=LDP_MASK_MSG_TYPE(EXTRACT_16BITS(ldp_msg_header->type));
 
         /* FIXME vendor private / experimental check */
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s Message (0x%04x), length: %u, Message ID: 0x%08x, Flags: [%s if unknown]",
+        ARGUSBUF_APPEND("\n\t  %s Message (0x%04x), length: %u, Message ID: 0x%08x, Flags: [%s if unknown]",
                tok2str(ldp_msg_values,
                        "Unknown",
                        msg_type),
@@ -613,7 +613,7 @@ ldp_msg_print(register const u_char *pptr) {
     }
     return pdu_len+4;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t packet exceeded snapshot");
+    ARGUSBUF_APPEND("\n\t\t packet exceeded snapshot");
     return 0;
 }
 

--- a/examples/radump/print-lldp.c
+++ b/examples/radump/print-lldp.c
@@ -596,7 +596,7 @@ lldp_private_8021_print(const u_char *tptr, u_int tlv_len)
     }
     subtype = *(tptr+3);
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s Subtype (%u)",
+    ARGUSBUF_APPEND("\n\t  %s Subtype (%u)",
            tok2str(lldp_8021_subtype_values, "unknown", subtype),
            subtype);
 
@@ -605,14 +605,14 @@ lldp_private_8021_print(const u_char *tptr, u_int tlv_len)
         if (tlv_len < 6) {
             return hexdump;
         }
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    port vlan id (PVID): %u",
+        ARGUSBUF_APPEND("\n\t    port vlan id (PVID): %u",
                EXTRACT_16BITS(tptr+4));
         break;
     case LLDP_PRIVATE_8021_SUBTYPE_PROTOCOL_VLAN_ID:
         if (tlv_len < 7) {
             return hexdump;
         }
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    port and protocol vlan id (PPVID): %u, flags [%s] (0x%02x)",
+        ARGUSBUF_APPEND("\n\t    port and protocol vlan id (PPVID): %u, flags [%s] (0x%02x)",
                EXTRACT_16BITS(tptr+5),
 	       bittok2str(lldp_8021_port_protocol_id_values, "none", *(tptr+4)),
 	       *(tptr+4));
@@ -621,7 +621,7 @@ lldp_private_8021_print(const u_char *tptr, u_int tlv_len)
         if (tlv_len < 6) {
             return hexdump;
         }
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    vlan id (VID): %u",
+        ARGUSBUF_APPEND("\n\t    vlan id (VID): %u",
                EXTRACT_16BITS(tptr+4));
         if (tlv_len < 7) {
             return hexdump;
@@ -630,7 +630,7 @@ lldp_private_8021_print(const u_char *tptr, u_int tlv_len)
         if (tlv_len < 7+sublen) {
             return hexdump;
         }
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    vlan name: ");
+        ARGUSBUF_APPEND("\n\t    vlan name: ");
         safeputs((const char *)tptr+7, sublen);
         break;
     case LLDP_PRIVATE_8021_SUBTYPE_PROTOCOL_IDENTITY:
@@ -641,7 +641,7 @@ lldp_private_8021_print(const u_char *tptr, u_int tlv_len)
         if (tlv_len < 5+sublen) {
             return hexdump;
         }
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    protocol identity: ");
+        ARGUSBUF_APPEND("\n\t    protocol identity: ");
         safeputs((const char *)tptr+5, sublen);
         break;
 
@@ -666,7 +666,7 @@ lldp_private_8023_print(const u_char *tptr, u_int tlv_len)
     }
     subtype = *(tptr+3);
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s Subtype (%u)",
+    ARGUSBUF_APPEND("\n\t  %s Subtype (%u)",
            tok2str(lldp_8023_subtype_values, "unknown", subtype),
            subtype);
 
@@ -675,13 +675,13 @@ lldp_private_8023_print(const u_char *tptr, u_int tlv_len)
         if (tlv_len < 9) {
             return hexdump;
         }
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    autonegotiation [%s] (0x%02x)",
+        ARGUSBUF_APPEND("\n\t    autonegotiation [%s] (0x%02x)",
                bittok2str(lldp_8023_autonegotiation_values, "none", *(tptr+4)),
                *(tptr+4));
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    PMD autoneg capability [%s] (0x%04x)",
+        ARGUSBUF_APPEND("\n\t    PMD autoneg capability [%s] (0x%04x)",
                bittok2str(lldp_pmd_capability_values,"unknown", EXTRACT_16BITS(tptr+5)),
                EXTRACT_16BITS(tptr+5));
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    MAU type %s (0x%04x)",
+        ARGUSBUF_APPEND("\n\t    MAU type %s (0x%04x)",
                tok2str(lldp_mau_types_values, "unknown", EXTRACT_16BITS(tptr+7)),
                EXTRACT_16BITS(tptr+7));
         break;
@@ -690,7 +690,7 @@ lldp_private_8023_print(const u_char *tptr, u_int tlv_len)
         if (tlv_len < 7) {
             return hexdump;
         }
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    MDI power support [%s], power pair %s, power class %s",
+        ARGUSBUF_APPEND("\n\t    MDI power support [%s], power pair %s, power class %s",
                bittok2str(lldp_mdi_values, "none", *(tptr+4)),
                tok2str(lldp_mdi_power_pairs_values, "unknown", *(tptr+5)),
                tok2str(lldp_mdi_power_class_values, "unknown", *(tptr+6)));
@@ -700,13 +700,13 @@ lldp_private_8023_print(const u_char *tptr, u_int tlv_len)
         if (tlv_len < 9) {
             return hexdump;
         }
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    aggregation status [%s], aggregation port ID %u",
+        ARGUSBUF_APPEND("\n\t    aggregation status [%s], aggregation port ID %u",
                bittok2str(lldp_aggregation_values, "none", *(tptr+4)),
                EXTRACT_32BITS(tptr+5));
         break;
 
     case LLDP_PRIVATE_8023_SUBTYPE_MTU:
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    MTU size %u", EXTRACT_16BITS(tptr+4));
+        ARGUSBUF_APPEND("\n\t    MTU size %u", EXTRACT_16BITS(tptr+4));
         break;
 
     default:
@@ -748,7 +748,7 @@ lldp_private_tia_print(const u_char *tptr, u_int tlv_len)
     }
     subtype = *(tptr+3);
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s Subtype (%u)",
+    ARGUSBUF_APPEND("\n\t  %s Subtype (%u)",
            tok2str(lldp_tia_subtype_values, "unknown", subtype),
            subtype);
 
@@ -757,10 +757,10 @@ lldp_private_tia_print(const u_char *tptr, u_int tlv_len)
         if (tlv_len < 7) {
             return hexdump;
         }
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Media capabilities [%s] (0x%04x)",
+        ARGUSBUF_APPEND("\n\t    Media capabilities [%s] (0x%04x)",
                bittok2str(lldp_tia_capabilities_values, "none",
                           EXTRACT_16BITS(tptr+4)), EXTRACT_16BITS(tptr+4));
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Device type [%s] (0x%02x)",
+        ARGUSBUF_APPEND("\n\t    Device type [%s] (0x%02x)",
                tok2str(lldp_tia_device_type_values, "unknown", *(tptr+6)),
                *(tptr+6));
         break;
@@ -769,16 +769,16 @@ lldp_private_tia_print(const u_char *tptr, u_int tlv_len)
         if (tlv_len < 8) {
             return hexdump;
         }
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Application type [%s] (0x%02x)",
+        ARGUSBUF_APPEND("\n\t    Application type [%s] (0x%02x)",
                tok2str(lldp_tia_application_type_values, "none", *(tptr+4)),
                *(tptr+4));
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],", Flags [%s]", bittok2str(
+        ARGUSBUF_APPEND(", Flags [%s]", bittok2str(
                    lldp_tia_network_policy_bits_values, "none", *(tptr+5)));
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Vlan id %u",
+        ARGUSBUF_APPEND("\n\t    Vlan id %u",
                LLDP_EXTRACT_NETWORK_POLICY_VLAN(EXTRACT_16BITS(tptr+5)));
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],", L2 priority %u",
+        ARGUSBUF_APPEND(", L2 priority %u",
                LLDP_EXTRACT_NETWORK_POLICY_L2_PRIORITY(EXTRACT_16BITS(tptr+6)));
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],", DSCP value %u",
+        ARGUSBUF_APPEND(", DSCP value %u",
                LLDP_EXTRACT_NETWORK_POLICY_DSCP(EXTRACT_16BITS(tptr+6)));
         break;
 
@@ -787,7 +787,7 @@ lldp_private_tia_print(const u_char *tptr, u_int tlv_len)
             return hexdump;
         }
         location_format = *(tptr+4);
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Location data format %s (0x%02x)",
+        ARGUSBUF_APPEND("\n\t    Location data format %s (0x%02x)",
                tok2str(lldp_tia_location_data_format_values, "unknown", location_format),
                location_format);
 
@@ -796,17 +796,17 @@ lldp_private_tia_print(const u_char *tptr, u_int tlv_len)
             if (tlv_len < 21) {
                 return hexdump;
             }
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Latitude resolution %u, latitude value %" PRIu64,
+            ARGUSBUF_APPEND("\n\t    Latitude resolution %u, latitude value %" PRIu64,
                    (*(tptr+5)>>2), lldp_extract_latlon(tptr+5));
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Longitude resolution %u, longitude value %" PRIu64,
+            ARGUSBUF_APPEND("\n\t    Longitude resolution %u, longitude value %" PRIu64,
                    (*(tptr+10)>>2), lldp_extract_latlon(tptr+10));
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Altitude type %s (%u)",
+            ARGUSBUF_APPEND("\n\t    Altitude type %s (%u)",
                    tok2str(lldp_tia_location_altitude_type_values, "unknown",(*(tptr+15)>>4)),
                    (*(tptr+15)>>4));
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Altitude resolution %u, altitude value 0x%x",
+            ARGUSBUF_APPEND("\n\t    Altitude resolution %u, altitude value 0x%x",
                    (EXTRACT_16BITS(tptr+15)>>6)&0x3f,
                    ((EXTRACT_32BITS(tptr+16)&0x3fffffff)));
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Datum %s (0x%02x)",
+            ARGUSBUF_APPEND("\n\t    Datum %s (0x%02x)",
                    tok2str(lldp_tia_location_datum_type_values, "unknown", *(tptr+20)),
                    *(tptr+20));
             break;
@@ -822,7 +822,7 @@ lldp_private_tia_print(const u_char *tptr, u_int tlv_len)
             if (tlv_len < 7+lci_len) {
                 return hexdump;
             }
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    LCI length %u, LCI what %s (0x%02x), Country-code ",
+            ARGUSBUF_APPEND("\n\t    LCI length %u, LCI what %s (0x%02x), Country-code ",
                    lci_len,
                    tok2str(lldp_tia_location_lci_what_values, "unknown", *(tptr+6)),
                    *(tptr+6));
@@ -844,7 +844,7 @@ lldp_private_tia_print(const u_char *tptr, u_int tlv_len)
 		tptr += 2;
                 lci_len -= 2; 
 
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      CA type \'%s\' (%u), length %u: ",
+                ARGUSBUF_APPEND("\n\t      CA type \'%s\' (%u), length %u: ",
                        tok2str(lldp_tia_location_lci_catype_values, "unknown", ca_type),
                        ca_type, ca_len);
 
@@ -863,12 +863,12 @@ lldp_private_tia_print(const u_char *tptr, u_int tlv_len)
             break;
 
         case LLDP_TIA_LOCATION_DATA_FORMAT_ECS_ELIN:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    ECS ELIN id ");
+            ARGUSBUF_APPEND("\n\t    ECS ELIN id ");
             safeputs((const char *)tptr+5, tlv_len-5);       
             break;
 
         default:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Location ID ");
+            ARGUSBUF_APPEND("\n\t    Location ID ");
             print_unknown_data(tptr+5, "\n\t      ", tlv_len-5);
         }
         break;
@@ -877,18 +877,18 @@ lldp_private_tia_print(const u_char *tptr, u_int tlv_len)
         if (tlv_len < 7) {
             return hexdump;
         }
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Power type [%s]",
+        ARGUSBUF_APPEND("\n\t    Power type [%s]",
                (*(tptr+4)&0xC0>>6) ? "PD device" : "PSE device");
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],", Power source [%s]",
+        ARGUSBUF_APPEND(", Power source [%s]",
                tok2str(lldp_tia_power_source_values, "none", (*(tptr+4)&0x30)>>4));
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Power priority [%s] (0x%02x)",
+        ARGUSBUF_APPEND("\n\t    Power priority [%s] (0x%02x)",
                tok2str(lldp_tia_power_priority_values, "none", *(tptr+4)&0x0f),
                *(tptr+4)&0x0f);
         power_val = EXTRACT_16BITS(tptr+5);
         if (power_val < LLDP_TIA_POWER_VAL_MAX) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],", Power %.1f Watts", ((float)power_val)/10);
+            ARGUSBUF_APPEND(", Power %.1f Watts", ((float)power_val)/10);
         } else {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],", Power %u (Reserved)", power_val);
+            ARGUSBUF_APPEND(", Power %u (Reserved)", power_val);
         }
         break;
 
@@ -899,7 +899,7 @@ lldp_private_tia_print(const u_char *tptr, u_int tlv_len)
     case LLDP_PRIVATE_TIA_SUBTYPE_INVENTORY_MANUFACTURER_NAME:
     case LLDP_PRIVATE_TIA_SUBTYPE_INVENTORY_MODEL_NAME:
     case LLDP_PRIVATE_TIA_SUBTYPE_INVENTORY_ASSET_ID:
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s ",
+        ARGUSBUF_APPEND("\n\t  %s ",
                tok2str(lldp_tia_inventory_values, "unknown", subtype));
         safeputs((const char *)tptr+4, tlv_len-4);
         break;
@@ -930,7 +930,7 @@ lldp_private_dcbx_print(const u_char *pptr, u_int len)
     }
     subtype = *(pptr+3);
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s Subtype (%u)",
+    ARGUSBUF_APPEND("\n\t  %s Subtype (%u)",
            tok2str(lldp_dcbx_subtype_values, "unknown", subtype),
            subtype);
 
@@ -970,89 +970,89 @@ lldp_private_dcbx_print(const u_char *pptr, u_int len)
             if (tlv_len < 10) {
                 goto trunc;
             }
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Control - Protocol Control (type 0x%x, length %d)",
+	    ARGUSBUF_APPEND("\n\t    Control - Protocol Control (type 0x%x, length %d)",
 		LLDP_DCBX_CONTROL_TLV, tlv_len);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Oper_Version: %d", *tptr);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Max_Version: %d", *(tptr+1));
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Sequence Number: %d", EXTRACT_32BITS(tptr+2));
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Acknowledgement Number: %d",
+	    ARGUSBUF_APPEND("\n\t      Oper_Version: %d", *tptr);
+	    ARGUSBUF_APPEND("\n\t      Max_Version: %d", *(tptr+1));
+	    ARGUSBUF_APPEND("\n\t      Sequence Number: %d", EXTRACT_32BITS(tptr+2));
+	    ARGUSBUF_APPEND("\n\t      Acknowledgement Number: %d",
 					EXTRACT_32BITS(tptr+6));
 	    break;
         case LLDP_DCBX_PRIORITY_GROUPS_TLV:
             if (tlv_len < 17) {
                 goto trunc;
             }
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Feature - Priority Group (type 0x%x, length %d)",
+	    ARGUSBUF_APPEND("\n\t    Feature - Priority Group (type 0x%x, length %d)",
 		LLDP_DCBX_PRIORITY_GROUPS_TLV, tlv_len);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Oper_Version: %d", *tptr);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Max_Version: %d", *(tptr+1));
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Info block(0x%02X): ", *(tptr+2));
+	    ARGUSBUF_APPEND("\n\t      Oper_Version: %d", *tptr);
+	    ARGUSBUF_APPEND("\n\t      Max_Version: %d", *(tptr+1));
+	    ARGUSBUF_APPEND("\n\t      Info block(0x%02X): ", *(tptr+2));
 	    tval = *(tptr+2);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Enable bit: %d, Willing bit: %d, Error Bit: %d",
+	    ARGUSBUF_APPEND("Enable bit: %d, Willing bit: %d, Error Bit: %d",
 		(tval &  0x80) ? 1 : 0, (tval &  0x40) ? 1 : 0,
 		(tval &  0x20) ? 1 : 0);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      SubType: %d", *(tptr+3));
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Priority Allocation");
+	    ARGUSBUF_APPEND("\n\t      SubType: %d", *(tptr+3));
+	    ARGUSBUF_APPEND("\n\t      Priority Allocation");
 
 	    pgval = EXTRACT_32BITS(tptr+4);
 	    for (i = 0; i <= 7; i++) {
 		tval = *(tptr+4+(i/2));
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t          PgId_%d: %d",
+		ARGUSBUF_APPEND("\n\t          PgId_%d: %d",
 			i, (pgval >> (28-4*i)) & 0xF);
 	    }
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Priority Group Allocation");
+	    ARGUSBUF_APPEND("\n\t      Priority Group Allocation");
 	    for (i = 0; i <= 7; i++)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t          Pg percentage[%d]: %d", i, *(tptr+8+i));
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      NumTCsSupported: %d", *(tptr+8+8));
+		ARGUSBUF_APPEND("\n\t          Pg percentage[%d]: %d", i, *(tptr+8+i));
+	    ARGUSBUF_APPEND("\n\t      NumTCsSupported: %d", *(tptr+8+8));
 	    break;
         case LLDP_DCBX_PRIORITY_FLOW_CONTROL_TLV:
             if (tlv_len < 6) {
                 goto trunc;
             }
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Feature - Priority Flow Control");
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)]," (type 0x%x, length %d)",
+	    ARGUSBUF_APPEND("\n\t    Feature - Priority Flow Control");
+	    ARGUSBUF_APPEND(" (type 0x%x, length %d)",
 		LLDP_DCBX_PRIORITY_FLOW_CONTROL_TLV, tlv_len);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Oper_Version: %d", *tptr);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Max_Version: %d", *(tptr+1));
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Info block(0x%02X): ", *(tptr+2));
+	    ARGUSBUF_APPEND("\n\t      Oper_Version: %d", *tptr);
+	    ARGUSBUF_APPEND("\n\t      Max_Version: %d", *(tptr+1));
+	    ARGUSBUF_APPEND("\n\t      Info block(0x%02X): ", *(tptr+2));
 	    tval = *(tptr+2);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Enable bit: %d, Willing bit: %d, Error Bit: %d",
+	    ARGUSBUF_APPEND("Enable bit: %d, Willing bit: %d, Error Bit: %d",
 		(tval &  0x80) ? 1 : 0, (tval &  0x40) ? 1 : 0,
 		(tval &  0x20) ? 1 : 0);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      SubType: %d", *(tptr+3));
+	    ARGUSBUF_APPEND("\n\t      SubType: %d", *(tptr+3));
 	    tval = *(tptr+4);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      PFC Config (0x%02X)", *(tptr+4));
+	    ARGUSBUF_APPEND("\n\t      PFC Config (0x%02X)", *(tptr+4));
 	    for (i = 0; i <= 7; i++)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t          Priority Bit %d: %s",
+		ARGUSBUF_APPEND("\n\t          Priority Bit %d: %s",
 		    i, (tval & (1 << i)) ? "Enabled" : "Disabled");
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      NumTCPFCSupported: %d", *(tptr+5));
+	    ARGUSBUF_APPEND("\n\t      NumTCPFCSupported: %d", *(tptr+5));
 	    break;
         case LLDP_DCBX_APPLICATION_TLV:
             if (tlv_len < 4) {
                 goto trunc;
             }
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Feature - Application (type 0x%x, length %d)",
+	    ARGUSBUF_APPEND("\n\t    Feature - Application (type 0x%x, length %d)",
 		LLDP_DCBX_APPLICATION_TLV, tlv_len);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Oper_Version: %d", *tptr);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Max_Version: %d", *(tptr+1));
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Info block(0x%02X): ", *(tptr+2));
+	    ARGUSBUF_APPEND("\n\t      Oper_Version: %d", *tptr);
+	    ARGUSBUF_APPEND("\n\t      Max_Version: %d", *(tptr+1));
+	    ARGUSBUF_APPEND("\n\t      Info block(0x%02X): ", *(tptr+2));
 	    tval = *(tptr+2);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Enable bit: %d, Willing bit: %d, Error Bit: %d",
+	    ARGUSBUF_APPEND("Enable bit: %d, Willing bit: %d, Error Bit: %d",
 		(tval &  0x80) ? 1 : 0, (tval &  0x40) ? 1 : 0,
 		(tval &  0x20) ? 1 : 0);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      SubType: %d", *(tptr+3));
+	    ARGUSBUF_APPEND("\n\t      SubType: %d", *(tptr+3));
 	    tval = tlv_len - 4;
 	    mptr = tptr + 4;
 	    while (tval >= 6) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t      Application Value");
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t          Application Protocol ID: 0x%04x",
+		ARGUSBUF_APPEND("\n\t      Application Value");
+		ARGUSBUF_APPEND("\n\t          Application Protocol ID: 0x%04x",
 			EXTRACT_16BITS(mptr));
 		uval = EXTRACT_24BITS(mptr+2);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t          SF (0x%x) Application Protocol ID is %s",
+		ARGUSBUF_APPEND("\n\t          SF (0x%x) Application Protocol ID is %s",
 			(uval >> 22),
 			(uval >> 22) ? "Socket Number" : "L2 EtherType");
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t          OUI: 0x%06x", uval & 0x3fffff);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t          User Priority Map: 0x%02x", *(mptr+5));
+		ARGUSBUF_APPEND("\n\t          OUI: 0x%06x", uval & 0x3fffff);
+		ARGUSBUF_APPEND("\n\t          User Priority Map: 0x%02x", *(mptr+5));
 		tval = tval - 6;
 		mptr = mptr + 6;
 	    }
@@ -1112,10 +1112,10 @@ lldp_network_addr_print(const u_char *tptr, u_int len) {
     }
 
     if (!pfunc) {
-        snsprintf(&ArgusBuf[strlen(ArgusBuf)],buf, sizeof(buf), "AFI %s (%u), no AF printer !",
+        snARGUSBUF_APPEND(buf, sizeof(buf), "AFI %s (%u), no AF printer !",
                  tok2str(af_values, "Unknown", af), af);
     } else {
-        snsprintf(&ArgusBuf[strlen(ArgusBuf)],buf, sizeof(buf), "AFI %s (%u): %s",
+        snARGUSBUF_APPEND(buf, sizeof(buf), "AFI %s (%u): %s",
                  tok2str(af_values, "Unknown", af), af, (*pfunc)(tptr+1));
     }
 
@@ -1147,7 +1147,7 @@ lldp_mgmt_addr_tlv_print(const u_char *pptr, u_int len) {
     if (mgmt_addr == NULL) {
         return 0;
     }
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  Management Address length %u, %s",
+    ARGUSBUF_APPEND("\n\t  Management Address length %u, %s",
            mgmt_addr_len, mgmt_addr);
     tptr += mgmt_addr_len;
     tlen -= mgmt_addr_len;
@@ -1157,7 +1157,7 @@ lldp_mgmt_addr_tlv_print(const u_char *pptr, u_int len) {
     }
 
     intf_num_subtype = *tptr;
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s Interface Numbering (%u): %u",
+    ARGUSBUF_APPEND("\n\t  %s Interface Numbering (%u): %u",
            tok2str(lldp_intf_numb_subtype_values, "Unknown", intf_num_subtype),
            intf_num_subtype,
            EXTRACT_32BITS(tptr+1));
@@ -1175,7 +1175,7 @@ lldp_mgmt_addr_tlv_print(const u_char *pptr, u_int len) {
             return 0;
         }
         if (oid_len) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  OID length %u", oid_len);
+            ARGUSBUF_APPEND("\n\t  OID length %u", oid_len);
             safeputs((const char *)tptr+1, oid_len);
         }
     }
@@ -1196,7 +1196,7 @@ lldp_print(register const u_char *pptr, register u_int len) {
     tlen = len;
 
     if (ArgusParser->vflag) {
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"LLDP, length %u", len);
+        ARGUSBUF_APPEND("LLDP, length %u", len);
     }
 
     while (tlen >= sizeof(tlv)) {
@@ -1213,7 +1213,7 @@ lldp_print(register const u_char *pptr, register u_int len) {
         tptr += sizeof(tlv);
 
         if (ArgusParser->vflag) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t%s TLV (%u), length %u",
+            ARGUSBUF_APPEND("\n\t%s TLV (%u), length %u",
                    tok2str(lldp_tlv_values, "Unknown", tlv_type),
                    tlv_type, tlv_len);
         }
@@ -1236,7 +1236,7 @@ lldp_print(register const u_char *pptr, register u_int len) {
                     goto trunc;
                 }
                 subtype = *tptr;
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  Subtype %s (%u): ",
+                ARGUSBUF_APPEND("\n\t  Subtype %s (%u): ",
                        tok2str(lldp_chassis_subtype_values, "Unknown", subtype),
                        subtype);
 
@@ -1245,7 +1245,7 @@ lldp_print(register const u_char *pptr, register u_int len) {
                     if (tlv_len < 1+6) {
                         goto trunc;
                     }
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", etheraddr_string(tptr+1));
+                    ARGUSBUF_APPEND("%s", etheraddr_string(tptr+1));
                     break;
 
                 case LLDP_CHASSIS_INTF_NAME_SUBTYPE: /* fall through */
@@ -1261,7 +1261,7 @@ lldp_print(register const u_char *pptr, register u_int len) {
                     if (network_addr == NULL) {
                         goto trunc;
                     }
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", network_addr);
+                    ARGUSBUF_APPEND("%s", network_addr);
                     break;
 
                 default:
@@ -1277,7 +1277,7 @@ lldp_print(register const u_char *pptr, register u_int len) {
                     goto trunc;
                 }
                 subtype = *tptr;
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  Subtype %s (%u): ",
+                ARGUSBUF_APPEND("\n\t  Subtype %s (%u): ",
                        tok2str(lldp_port_subtype_values, "Unknown", subtype),
                        subtype);
 
@@ -1286,7 +1286,7 @@ lldp_print(register const u_char *pptr, register u_int len) {
                     if (tlv_len < 1+6) {
                         goto trunc;
                     }
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", etheraddr_string(tptr+1));
+                    ARGUSBUF_APPEND("%s", etheraddr_string(tptr+1));
                     break;
 
                 case LLDP_PORT_INTF_NAME_SUBTYPE: /* fall through */
@@ -1302,7 +1302,7 @@ lldp_print(register const u_char *pptr, register u_int len) {
                     if (network_addr == NULL) {
                         goto trunc;
                     }
-                    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", network_addr);
+                    ARGUSBUF_APPEND("%s", network_addr);
                     break;
 
                 default:
@@ -1317,13 +1317,13 @@ lldp_print(register const u_char *pptr, register u_int len) {
                 if (tlv_len < 2) {
                     goto trunc;
                 }
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],": TTL %us", EXTRACT_16BITS(tptr));
+                ARGUSBUF_APPEND(": TTL %us", EXTRACT_16BITS(tptr));
             }
             break;
 
         case LLDP_PORT_DESCR_TLV:
             if (ArgusParser->vflag) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],": ");
+                ARGUSBUF_APPEND(": ");
                 safeputs((const char *)tptr, tlv_len);
             }
             break;
@@ -1334,18 +1334,18 @@ lldp_print(register const u_char *pptr, register u_int len) {
              * similar to the CDP printer.
              */
             if (ArgusParser->vflag) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],": ");
+                ARGUSBUF_APPEND(": ");
                 safeputs((const char *)tptr, tlv_len);
             } else {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"LLDP, name ");
+                ARGUSBUF_APPEND("LLDP, name ");
                 safeputs((const char *)tptr, tlv_len);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],", length %u", len);
+                ARGUSBUF_APPEND(", length %u", len);
             }
             break;
 
         case LLDP_SYSTEM_DESCR_TLV:
             if (ArgusParser->vflag) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  ");
+                ARGUSBUF_APPEND("\n\t  ");
                 safeputs((const char *)tptr, tlv_len);
             }
             break;
@@ -1363,9 +1363,9 @@ lldp_print(register const u_char *pptr, register u_int len) {
                 }
                 cap = EXTRACT_16BITS(tptr);
                 ena_cap = EXTRACT_16BITS(tptr+2);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  System  Capabilities [%s] (0x%04x)",
+                ARGUSBUF_APPEND("\n\t  System  Capabilities [%s] (0x%04x)",
                        bittok2str(lldp_cap_values, "none", cap), cap);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  Enabled Capabilities [%s] (0x%04x)",
+                ARGUSBUF_APPEND("\n\t  Enabled Capabilities [%s] (0x%04x)",
                        bittok2str(lldp_cap_values, "none", ena_cap), ena_cap);
             }
             break;
@@ -1384,7 +1384,7 @@ lldp_print(register const u_char *pptr, register u_int len) {
                     goto trunc;
                 }
                 oui = EXTRACT_24BITS(tptr);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],": OUI %s (0x%06x)", tok2str(oui_values, "Unknown", oui), oui);
+                ARGUSBUF_APPEND(": OUI %s (0x%06x)", tok2str(oui_values, "Unknown", oui), oui);
                 
                 switch (oui) {
                 case OUI_IEEE_8021_PRIVATE:
@@ -1421,7 +1421,7 @@ lldp_print(register const u_char *pptr, register u_int len) {
     }
     return;
  trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t[|LLDP]");
+    ARGUSBUF_APPEND("\n\t[|LLDP]");
 }
 
 /*

--- a/examples/radump/print-lmp.c
+++ b/examples/radump/print-lmp.c
@@ -390,14 +390,14 @@ lmp_print(register const u_char *pptr, register u_int len) {
      * Sanity checking of the header.
      */
     if (LMP_EXTRACT_VERSION(lmp_com_header->version_res[0]) != LMP_VERSION) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"LMP version %u packet not supported",
+	ARGUSBUF_APPEND("LMP version %u packet not supported",
                LMP_EXTRACT_VERSION(lmp_com_header->version_res[0]));
 	return ArgusBuf;
     }
 
     /* in non-verbose mode just lets print the basic Message Type*/
     if (ArgusParser->vflag < 1) {
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"LMPv%u %s Message, length: %u",
+        ARGUSBUF_APPEND("LMPv%u %s Message, length: %u",
                LMP_EXTRACT_VERSION(lmp_com_header->version_res[0]),
                tok2str(lmp_msg_type_values, "unknown (%u)",lmp_com_header->msg_type),
                len);
@@ -408,7 +408,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
 
     tlen=EXTRACT_16BITS(lmp_com_header->length);
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\tLMPv%u, msg-type: %s, Flags: [%s], length: %u",
+    ARGUSBUF_APPEND("\n\tLMPv%u, msg-type: %s, Flags: [%s], length: %u",
            LMP_EXTRACT_VERSION(lmp_com_header->version_res[0]),
            tok2str(lmp_msg_type_values, "unknown, type: %u",lmp_com_header->msg_type),
            bittok2str(lmp_header_flag_values,"none",lmp_com_header->flags),
@@ -429,7 +429,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
         if(lmp_obj_len % 4 || lmp_obj_len < 4)
             return ArgusBuf;
 
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s Object (%u), Class-Type: %s (%u) Flags: [%snegotiable], length: %u",
+        ARGUSBUF_APPEND("\n\t  %s Object (%u), Class-Type: %s (%u) Flags: [%snegotiable], length: %u",
                tok2str(lmp_obj_values,
                        "Unknown",
                        lmp_obj_header->class_num),
@@ -455,7 +455,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
             switch(lmp_obj_ctype) {
             case LMP_CTYPE_LOC:
             case LMP_CTYPE_RMT:
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Control Channel ID: %u (0x%08x)",
+                ARGUSBUF_APPEND("\n\t    Control Channel ID: %u (0x%08x)",
                        EXTRACT_32BITS(obj_tptr),
                        EXTRACT_32BITS(obj_tptr));
                 break;
@@ -470,21 +470,21 @@ lmp_print(register const u_char *pptr, register u_int len) {
             switch(lmp_obj_ctype) {
             case LMP_CTYPE_IPV4_LOC:
             case LMP_CTYPE_IPV4_RMT:
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    IPv4 Link ID: %s (0x%08x)",
+                ARGUSBUF_APPEND("\n\t    IPv4 Link ID: %s (0x%08x)",
                        ipaddr_string(obj_tptr),
                        EXTRACT_32BITS(obj_tptr));
                 break;
 #ifdef INET6
             case LMP_CTYPE_IPV6_LOC:
             case LMP_CTYPE_IPV6_RMT:
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    IPv6 Link ID: %s (0x%08x)",
+                ARGUSBUF_APPEND("\n\t    IPv6 Link ID: %s (0x%08x)",
                        ip6addr_string(obj_tptr),
                        EXTRACT_32BITS(obj_tptr));
                 break;
 #endif
             case LMP_CTYPE_UNMD_LOC:
             case LMP_CTYPE_UNMD_RMT:
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Link ID: %u (0x%08x)",
+                ARGUSBUF_APPEND("\n\t    Link ID: %u (0x%08x)",
                        EXTRACT_32BITS(obj_tptr),
                        EXTRACT_32BITS(obj_tptr));
                 break;
@@ -496,12 +496,12 @@ lmp_print(register const u_char *pptr, register u_int len) {
         case LMP_OBJ_MESSAGE_ID:
             switch(lmp_obj_ctype) {
             case LMP_CTYPE_1:
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Message ID: %u (0x%08x)",
+                ARGUSBUF_APPEND("\n\t    Message ID: %u (0x%08x)",
                        EXTRACT_32BITS(obj_tptr),
                        EXTRACT_32BITS(obj_tptr));
                 break;
             case LMP_CTYPE_2:
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Message ID Ack: %u (0x%08x)",
+                ARGUSBUF_APPEND("\n\t    Message ID Ack: %u (0x%08x)",
                        EXTRACT_32BITS(obj_tptr),
                        EXTRACT_32BITS(obj_tptr));
                 break;
@@ -514,7 +514,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
             switch(lmp_obj_ctype) {
             case LMP_CTYPE_LOC:
             case LMP_CTYPE_RMT:
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Node ID: %s (0x%08x)",
+                ARGUSBUF_APPEND("\n\t    Node ID: %s (0x%08x)",
                        ipaddr_string(obj_tptr),
                        EXTRACT_32BITS(obj_tptr));
                 break;
@@ -527,7 +527,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
         case LMP_OBJ_CONFIG:
             switch(lmp_obj_ctype) {
             case LMP_CTYPE_HELLO_CONFIG:
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Hello Interval: %u\n\t    Hello Dead Interval: %u",
+                ARGUSBUF_APPEND("\n\t    Hello Interval: %u\n\t    Hello Dead Interval: %u",
                        EXTRACT_16BITS(obj_tptr),
                        EXTRACT_16BITS(obj_tptr+2));
                 break;
@@ -540,7 +540,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
         case LMP_OBJ_HELLO:
             switch(lmp_obj_ctype) {
 	    case LMP_CTYPE_HELLO:
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    TxSeqNum: %u\n\t    RcvSeqNum: %u",
+                ARGUSBUF_APPEND("\n\t    TxSeqNum: %u\n\t    RcvSeqNum: %u",
                        EXTRACT_32BITS(obj_tptr),
                        EXTRACT_32BITS(obj_tptr+4));
                 break;
@@ -551,14 +551,14 @@ lmp_print(register const u_char *pptr, register u_int len) {
             break;      
 	    
         case LMP_OBJ_TE_LINK:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Flags: [%s]",
+		ARGUSBUF_APPEND("\n\t    Flags: [%s]",
 		bittok2str(lmp_obj_te_link_flag_values,
 			"none",
 			EXTRACT_16BITS(obj_tptr)>>8));
             
 	    switch(lmp_obj_ctype) {
 	    case LMP_CTYPE_IPV4:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Local Link-ID: %s (0x%08x) \
+		ARGUSBUF_APPEND("\n\t    Local Link-ID: %s (0x%08x) \
 			\n\t    Remote Link-ID: %s (0x%08x)",
                        ipaddr_string(obj_tptr+4),
                        EXTRACT_32BITS(obj_tptr+4),
@@ -576,7 +576,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
             break;
 	
         case LMP_OBJ_DATA_LINK:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Flags: [%s]",
+		ARGUSBUF_APPEND("\n\t    Flags: [%s]",
 		bittok2str(lmp_obj_data_link_flag_values,
 			"none",
 			EXTRACT_16BITS(obj_tptr)>>8));
@@ -584,7 +584,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
 	    switch(lmp_obj_ctype) {
 	    case LMP_CTYPE_IPV4:
 	    case LMP_CTYPE_UNMD:
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Local Interface ID: %s (0x%08x) \
+                ARGUSBUF_APPEND("\n\t    Local Interface ID: %s (0x%08x) \
 			\n\t    Remote Interface ID: %s (0x%08x)",
                        ipaddr_string(obj_tptr+4),
                        EXTRACT_32BITS(obj_tptr+4),
@@ -596,7 +596,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
 		while (total_subobj_len > 0 && hexdump == FALSE ) {
 			subobj_type = EXTRACT_16BITS(obj_tptr+offset)>>8;
 			subobj_len  = EXTRACT_16BITS(obj_tptr+offset)&0x00FF;
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Subobject, Type: %s (%u), Length: %u",
+			ARGUSBUF_APPEND("\n\t    Subobject, Type: %s (%u), Length: %u",
 				tok2str(lmp_data_link_subobj,
 					"Unknown",
 					subobj_type),
@@ -604,25 +604,25 @@ lmp_print(register const u_char *pptr, register u_int len) {
 					subobj_len);
 			switch(subobj_type) {
 			case INT_SWITCHING_TYPE_SUBOBJ:
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t    Switching Type: %s (%u)",
+				ARGUSBUF_APPEND("\n\t\t    Switching Type: %s (%u)",
 					tok2str(gmpls_switch_cap_values, 
 						"Unknown", 
 						EXTRACT_16BITS(obj_tptr+offset+2)>>8),
 					EXTRACT_16BITS(obj_tptr+offset+2)>>8);
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t    Encoding Type: %s (%u)",
+				ARGUSBUF_APPEND("\n\t\t    Encoding Type: %s (%u)",
 					tok2str(gmpls_encoding_values, 
 						"Unknown", 
 						EXTRACT_16BITS(obj_tptr+offset+2)&0x00FF),
 					EXTRACT_16BITS(obj_tptr+offset+2)&0x00FF);
 				bw.i = EXTRACT_32BITS(obj_tptr+offset+4);
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t    Min Reservable Bandwidth: %.3f Mbps",
+				ARGUSBUF_APPEND("\n\t\t    Min Reservable Bandwidth: %.3f Mbps",
 					bw.f);
 				bw.i = EXTRACT_32BITS(obj_tptr+offset+8);
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t    Max Reservable Bandwidth: %.3f Mbps",
+				ARGUSBUF_APPEND("\n\t\t    Max Reservable Bandwidth: %.3f Mbps",
 					bw.f);
 				break;	
 			case WAVELENGTH_SUBOBJ:
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t    Wavelength: %u",
+				ARGUSBUF_APPEND("\n\t\t    Wavelength: %u",
 					EXTRACT_32BITS(obj_tptr+offset+4));
 				break;
 			default:
@@ -646,23 +646,23 @@ lmp_print(register const u_char *pptr, register u_int len) {
         case LMP_OBJ_VERIFY_BEGIN:
 	    switch(lmp_obj_ctype) {
             case LMP_CTYPE_1:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Flags: %s",
+		ARGUSBUF_APPEND("\n\t    Flags: %s",
 		bittok2str(lmp_obj_begin_verify_flag_values,
 			"none",
 			EXTRACT_16BITS(obj_tptr)));
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Verify Interval: %u",
+		ARGUSBUF_APPEND("\n\t    Verify Interval: %u",
 			EXTRACT_16BITS(obj_tptr+2));
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Data links: %u",
+		ARGUSBUF_APPEND("\n\t    Data links: %u",
 			EXTRACT_32BITS(obj_tptr+4));
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Encoding type: %s",
+                ARGUSBUF_APPEND("\n\t    Encoding type: %s",
 			tok2str(gmpls_encoding_values, "Unknown", *(obj_tptr+8)));
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Verify Tranport Mechanism: %u (0x%x) %s",
+                ARGUSBUF_APPEND("\n\t    Verify Tranport Mechanism: %u (0x%x) %s",
 			EXTRACT_16BITS(obj_tptr+10),
 			EXTRACT_16BITS(obj_tptr+10),
 			EXTRACT_16BITS(obj_tptr+10)&8000 ? "(Payload test messages capable)" : "");
                 bw.i = EXTRACT_32BITS(obj_tptr+12);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Transmission Rate: %.3f Mbps",bw.f);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Wavelength: %u",
+		ARGUSBUF_APPEND("\n\t    Transmission Rate: %.3f Mbps",bw.f);
+		ARGUSBUF_APPEND("\n\t    Wavelength: %u",
 			EXTRACT_32BITS(obj_tptr+16));
 		break;
 		
@@ -674,7 +674,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
         case LMP_OBJ_VERIFY_BEGIN_ACK:
 	    switch(lmp_obj_ctype) {
             case LMP_CTYPE_1:
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Verify Dead Interval: %u 	\
+                ARGUSBUF_APPEND("\n\t    Verify Dead Interval: %u 	\
 			\n\t    Verify Transport Response: %u",
                        EXTRACT_16BITS(obj_tptr),
                        EXTRACT_16BITS(obj_tptr+2));
@@ -688,7 +688,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
 	case LMP_OBJ_VERIFY_ID:
 	    switch(lmp_obj_ctype) {
             case LMP_CTYPE_1:
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Verify ID: %u",
+                ARGUSBUF_APPEND("\n\t    Verify ID: %u",
                        EXTRACT_32BITS(obj_tptr));
                 break;
 		
@@ -704,19 +704,19 @@ lmp_print(register const u_char *pptr, register u_int len) {
 		offset = 0;
 		/* Decode pairs: <Interface_ID (4 bytes), Channel_status (4 bytes)> */
 		while (offset < (lmp_obj_len-(int)sizeof(struct lmp_object_header)) ) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Interface ID: %s (0x%08x)",
+			ARGUSBUF_APPEND("\n\t    Interface ID: %s (0x%08x)",
 			ipaddr_string(obj_tptr+offset),
 			EXTRACT_32BITS(obj_tptr+offset));
 			
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t    Active: %s (%u)", 		(EXTRACT_32BITS(obj_tptr+offset+4)>>31) ? 
+			ARGUSBUF_APPEND("\n\t\t    Active: %s (%u)", 		(EXTRACT_32BITS(obj_tptr+offset+4)>>31) ? 
 						"Allocated" : "Non-allocated",
 				(EXTRACT_32BITS(obj_tptr+offset+4)>>31));
 			
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t    Direction: %s (%u)", (EXTRACT_32BITS(obj_tptr+offset+4)>>30)&0x1 ? 
+			ARGUSBUF_APPEND("\n\t\t    Direction: %s (%u)", (EXTRACT_32BITS(obj_tptr+offset+4)>>30)&0x1 ? 
 						"Transmit" : "Receive",
 				(EXTRACT_32BITS(obj_tptr+offset+4)>>30)&0x1);	
 						
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t    Channel Status: %s (%u)",
+			ARGUSBUF_APPEND("\n\t\t    Channel Status: %s (%u)",
 					tok2str(lmp_obj_channel_status_values,
 			 		"Unknown",
 					EXTRACT_32BITS(obj_tptr+offset+4)&0x3FFFFFF),
@@ -738,7 +738,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
 	    case LMP_CTYPE_UNMD:
 		offset = 0;
 		while (offset < (lmp_obj_len-(int)sizeof(struct lmp_object_header)) ) {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Interface ID: %s (0x%08x)",
+			ARGUSBUF_APPEND("\n\t    Interface ID: %s (0x%08x)",
 			ipaddr_string(obj_tptr+offset),
 			EXTRACT_32BITS(obj_tptr+offset));
 			offset+=4;
@@ -755,14 +755,14 @@ lmp_print(register const u_char *pptr, register u_int len) {
         case LMP_OBJ_ERROR_CODE:
 	    switch(lmp_obj_ctype) {
             case LMP_CTYPE_BEGIN_VERIFY_ERROR:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Error Code: %s",
+		ARGUSBUF_APPEND("\n\t    Error Code: %s",
 		bittok2str(lmp_obj_begin_verify_error_values,
 			"none",
 			EXTRACT_32BITS(obj_tptr)));
                 break;
 		
             case LMP_CTYPE_LINK_SUMMARY_ERROR:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Error Code: %s",
+		ARGUSBUF_APPEND("\n\t    Error Code: %s",
 		bittok2str(lmp_obj_link_summary_error_values,
 			"none",
 			EXTRACT_32BITS(obj_tptr)));
@@ -776,12 +776,12 @@ lmp_print(register const u_char *pptr, register u_int len) {
 	    switch (lmp_obj_ctype) {
 	    case LMP_CTYPE_SERVICE_CONFIG_SP:
 		
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t Flags: %s",
+		ARGUSBUF_APPEND("\n\t Flags: %s",
 		       bittok2str(lmp_obj_service_config_sp_flag_values,
 				  "none", 
 				  EXTRACT_16BITS(obj_tptr)>>8));
 
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  UNI Version: %u",
+		ARGUSBUF_APPEND("\n\t  UNI Version: %u",
 		       EXTRACT_16BITS(obj_tptr) & 0x00FF);
 
 		break;
@@ -790,13 +790,13 @@ lmp_print(register const u_char *pptr, register u_int len) {
 		
 		link_type = EXTRACT_16BITS(obj_tptr)>>8;
 		
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t Link Type: %s (%u)",
+		ARGUSBUF_APPEND("\n\t Link Type: %s (%u)",
 		       tok2str(lmp_sd_service_config_cpsa_link_type_values,
 			       "Unknown", link_type),
 		       link_type);
 		
 		if (link_type == LMP_SD_SERVICE_CONFIG_CPSA_LINK_TYPE_SDH) {
-		    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t Signal Type: %s (%u)",
+		    ARGUSBUF_APPEND("\n\t Signal Type: %s (%u)",
 			   tok2str(lmp_sd_service_config_cpsa_signal_type_sdh_values,
 				   "Unknown",
 				   EXTRACT_16BITS(obj_tptr) & 0x00FF),
@@ -804,36 +804,36 @@ lmp_print(register const u_char *pptr, register u_int len) {
 		}
 		
 		if (link_type == LMP_SD_SERVICE_CONFIG_CPSA_LINK_TYPE_SONET) {
-		    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t Signal Type: %s (%u)",
+		    ARGUSBUF_APPEND("\n\t Signal Type: %s (%u)",
 			   tok2str(lmp_sd_service_config_cpsa_signal_type_sonet_values,
 				   "Unknown",
 				   EXTRACT_16BITS(obj_tptr) & 0x00FF),
 			   EXTRACT_16BITS(obj_tptr) & 0x00FF);
 		}
 		
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t Transparency: %s",
+		ARGUSBUF_APPEND("\n\t Transparency: %s",
 		       bittok2str(lmp_obj_service_config_cpsa_tp_flag_values,
 				  "none",
 				  EXTRACT_16BITS(obj_tptr+2)>>8));
 		
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t Contiguous Concatenation Types: %s",
+		ARGUSBUF_APPEND("\n\t Contiguous Concatenation Types: %s",
 		       bittok2str(lmp_obj_service_config_cpsa_cct_flag_values,
 				  "none",
 				  EXTRACT_16BITS(obj_tptr+2)>>8 & 0x00FF));
 		
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t Minimum NCC: %u",
+		ARGUSBUF_APPEND("\n\t Minimum NCC: %u",
 		       EXTRACT_16BITS(obj_tptr+4));
 		
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t Maximum NCC: %u",
+		ARGUSBUF_APPEND("\n\t Maximum NCC: %u",
 		       EXTRACT_16BITS(obj_tptr+6));
 		
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t Minimum NVC:%u",
+		ARGUSBUF_APPEND("\n\t Minimum NVC:%u",
 		       EXTRACT_16BITS(obj_tptr+8));
 		
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t Maximum NVC:%u",
+		ARGUSBUF_APPEND("\n\t Maximum NVC:%u",
 		       EXTRACT_16BITS(obj_tptr+10));
 		
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Local Interface ID: %s (0x%08x)",
+		ARGUSBUF_APPEND("\n\t    Local Interface ID: %s (0x%08x)",
 		       ipaddr_string(obj_tptr+12),
 		       EXTRACT_32BITS(obj_tptr+12));
 		
@@ -841,13 +841,13 @@ lmp_print(register const u_char *pptr, register u_int len) {
 		
 	    case LMP_CTYPE_SERVICE_CONFIG_TRANSPARENCY_TCM:
 		
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t Transparency Flags: %s",
+		ARGUSBUF_APPEND("\n\t Transparency Flags: %s",
 		       bittok2str(
 			   lmp_obj_service_config_nsa_transparency_flag_values,
 			   "none",
 			   EXTRACT_32BITS(obj_tptr)));
 
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t TCM Monitoring Flags: %s",
+		ARGUSBUF_APPEND("\n\t TCM Monitoring Flags: %s",
 		       bittok2str(
 			   lmp_obj_service_config_nsa_tcm_flag_values,
 			   "none",
@@ -857,7 +857,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
 		
 	    case LMP_CTYPE_SERVICE_CONFIG_NETWORK_DIVERSITY:
 		
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t Diversity: Flags: %s",
+		ARGUSBUF_APPEND("\n\t Diversity: Flags: %s",
 		       bittok2str(
 			   lmp_obj_service_config_nsa_network_diversity_flag_values,
 			   "none",
@@ -885,7 +885,7 @@ lmp_print(register const u_char *pptr, register u_int len) {
     }
     return ArgusBuf;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t packet exceeded snapshot");
+    ARGUSBUF_APPEND("\n\t\t packet exceeded snapshot");
 
    return ArgusBuf;
 }

--- a/examples/radump/print-msdp.c
+++ b/examples/radump/print-msdp.c
@@ -52,13 +52,13 @@ msdp_print(const unsigned char *sp, u_int length)
    len = EXTRACT_16BITS(sp + 1);
    if (len > 1500 || len < 3 || type == 0 || type > MSDP_TYPE_MAX)
       goto trunc;   /* not really truncated, but still not decodable */
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," msdp:");
+   ARGUSBUF_APPEND(" msdp:");
    while (length > 0) {
       TCHECK2(*sp, 3);
       type = *sp;
       len = EXTRACT_16BITS(sp + 1);
       if (len > 1400 || ArgusParser->vflag)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," [len %u]", len);
+         ARGUSBUF_APPEND(" [len %u]", len);
       if (len < 3)
          goto trunc;
       sp += 3;
@@ -67,15 +67,15 @@ msdp_print(const unsigned char *sp, u_int length)
       case 1:   /* IPv4 Source-Active */
       case 3: /* IPv4 Source-Active Response */
          if (type == 1)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," SA");
+            ARGUSBUF_APPEND(" SA");
          else
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," SA-Response");
+            ARGUSBUF_APPEND(" SA-Response");
          TCHECK(*sp);
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u entries", *sp);
+         ARGUSBUF_APPEND(" %u entries", *sp);
          if ((u_int)((*sp * 12) + 8) < len) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [w/data]");
+            ARGUSBUF_APPEND(" [w/data]");
             if (ArgusParser->vflag > 1) {
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+               ARGUSBUF_APPEND(" ");
 /*
                ip_print(gndo, sp + *sp * 12 + 8 - 3,
                         len - (*sp * 12 + 8));
@@ -84,20 +84,20 @@ msdp_print(const unsigned char *sp, u_int length)
          }
          break;
       case 2:
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," SA-Request");
+         ARGUSBUF_APPEND(" SA-Request");
          TCHECK2(*sp, 5);
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," for %s", ipaddr_string(sp + 1));
+         ARGUSBUF_APPEND(" for %s", ipaddr_string(sp + 1));
          break;
       case 4:
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Keepalive");
+         ARGUSBUF_APPEND(" Keepalive");
          if (len != 3)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"[len=%d] ", len);
+            ARGUSBUF_APPEND("[len=%d] ", len);
          break;
       case 5:
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Notification");
+         ARGUSBUF_APPEND(" Notification");
          break;
       default:
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [type=%d len=%d]", type, len);
+         ARGUSBUF_APPEND(" [type=%d len=%d]", type, len);
          break;
       }
       sp += (len - 3);
@@ -105,7 +105,7 @@ msdp_print(const unsigned char *sp, u_int length)
    }
    return ArgusBuf;
 trunc:
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|msdp]");
+   ARGUSBUF_APPEND(" [|msdp]");
 
    return ArgusBuf;
 }

--- a/examples/radump/print-ntp.c
+++ b/examples/radump/print-ntp.c
@@ -91,110 +91,110 @@ ntp_print(register const u_char *cp, u_int length)
    TCHECK(bp->status);
 
    version = (int)(bp->status & VERSIONMASK) >> 3;
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"NTPv%d", version);
+   ARGUSBUF_APPEND("NTPv%d", version);
 
    mode = bp->status & MODEMASK;
    if (ArgusParser->vflag == 0) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", %s, length %u",
+      ARGUSBUF_APPEND(", %s, length %u",
          tok2str(ntp_mode_values, "Unknown mode", mode), length);
       return ArgusBuf;
    }
         
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],", length %u %s", length, tok2str(ntp_mode_values, "Unknown mode", mode));
+   ARGUSBUF_APPEND(", length %u %s", length, tok2str(ntp_mode_values, "Unknown mode", mode));
 
    if ((leapind = bp->status & LEAPMASK) || (ArgusParser->vflag > 1)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", Leap indicator: %s (%u)",
+      ARGUSBUF_APPEND(", Leap indicator: %s (%u)",
          tok2str(ntp_leapind_values, "Unknown", leapind), leapind);
    }
    TCHECK(bp->stratum);
    if (bp->stratum || (ArgusParser->vflag > 1)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", Stratum %u", bp->stratum);
+      ARGUSBUF_APPEND(", Stratum %u", bp->stratum);
    }
    TCHECK(bp->ppoll);
    if (bp->ppoll || (ArgusParser->vflag > 1)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", poll %us", bp->ppoll);
+      ARGUSBUF_APPEND(", poll %us", bp->ppoll);
    }
    /* Can't TCHECK bp->precision bitfield so bp->distance + 0 instead */
    if (bp->precision || (ArgusParser->vflag > 1)) {
       TCHECK2(bp->root_delay, 0);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", precision %d", bp->precision);
+      ARGUSBUF_APPEND(", precision %d", bp->precision);
    }
    TCHECK(bp->root_delay);
    if (bp->root_delay.int_part || (ArgusParser->vflag > 1)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Root Delay: ");
+      ARGUSBUF_APPEND(" Root Delay: ");
       p_sfix(&bp->root_delay);
    }
    TCHECK(bp->root_dispersion);
    if (bp->root_dispersion.int_part || (ArgusParser->vflag > 1)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", Root dispersion: ");
+      ARGUSBUF_APPEND(", Root dispersion: ");
       p_sfix(&bp->root_dispersion);
    }
    TCHECK(bp->refid);
    if (bp->refid || (ArgusParser->vflag > 1)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],", Reference-ID: ");
+      ARGUSBUF_APPEND(", Reference-ID: ");
 
       /* Interpretation depends on stratum */
       switch (bp->stratum) {
          case UNSPECIFIED:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"(unspec)");
+            ARGUSBUF_APPEND("(unspec)");
             break;
 
          case PRIM_REF:
-            if (fn_printn((u_char *)&(bp->refid), 4, snapend, &ArgusBuf[strlen(ArgusBuf)]) == NULL)
+            if (fn_printn((u_char *)&(bp->refid), 4, snapend, &ArgusBuf[strlen(ArgusBuf)], MAXSTRLEN - strlen(ArgusBuf)) == NULL)
                goto trunc;
             break;
 
          case INFO_QUERY:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s INFO_QUERY", ipaddr_string(&(bp->refid)));
+            ARGUSBUF_APPEND("%s INFO_QUERY", ipaddr_string(&(bp->refid)));
             /* this doesn't have more content */
             return ArgusBuf;
 
          case INFO_REPLY:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s INFO_REPLY", ipaddr_string(&(bp->refid)));
+            ARGUSBUF_APPEND("%s INFO_REPLY", ipaddr_string(&(bp->refid)));
             /* this is too complex to be worth printing */
             return ArgusBuf;
 
          default:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ipaddr_string(&(bp->refid)));
+            ARGUSBUF_APPEND("%s", ipaddr_string(&(bp->refid)));
             break;
       }
    }
    TCHECK(bp->ref_timestamp);
    if (bp->ref_timestamp.int_part || (ArgusParser->vflag > 1)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Reference Timestamp: ");
+      ARGUSBUF_APPEND(" Reference Timestamp: ");
       p_ntp_time(&(bp->ref_timestamp));
    }
 
    TCHECK(bp->org_timestamp);
    if (bp->org_timestamp.int_part || (ArgusParser->vflag > 1)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Originator Timestamp: ");
+      ARGUSBUF_APPEND(" Originator Timestamp: ");
       p_ntp_time(&(bp->org_timestamp));
    }
 
    TCHECK(bp->rec_timestamp);
    if (bp->rec_timestamp.int_part || (ArgusParser->vflag > 1)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Receive Timestamp: ");
+      ARGUSBUF_APPEND(" Receive Timestamp: ");
       p_ntp_time(&(bp->rec_timestamp));
    }
 
    TCHECK(bp->xmt_timestamp);
    if (bp->xmt_timestamp.int_part || (ArgusParser->vflag > 1)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Transmit Timestamp: ");
+      ARGUSBUF_APPEND(" Transmit Timestamp: ");
       p_ntp_time(&(bp->xmt_timestamp));
    }
 
    if (bp->org_timestamp.int_part || (ArgusParser->vflag > 1)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Delta Receive Timestamp:  ");
+      ARGUSBUF_APPEND(" Delta Receive Timestamp:  ");
       p_ntp_delta(&(bp->org_timestamp), &(bp->rec_timestamp));
 
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Delta Transmit Timestamp: ");
+      ARGUSBUF_APPEND(" Delta Transmit Timestamp: ");
       p_ntp_delta(&(bp->org_timestamp), &(bp->xmt_timestamp));
    }
 
    return ArgusBuf;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|ntp]");
+   ARGUSBUF_APPEND(" [|ntp]");
    return ArgusBuf;
 }
 
@@ -209,7 +209,7 @@ p_sfix(register const struct s_fixedpt *sfp)
    f = EXTRACT_16BITS(&sfp->fraction);
    ff = f / 65536.0;   /* shift radix point by 16 bits */
    f = ff * 1000000.0;   /* Treat fraction as parts per million */
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d.%06d", i, f);
+   ARGUSBUF_APPEND("%d.%06d", i, f);
 }
 
 #define   FMAXINT   (4294967296.0)   /* floating point rep. of MAXINT */
@@ -229,7 +229,7 @@ p_ntp_time(register const struct l_fixedpt *lfp)
       ff += FMAXINT;
    ff = ff / FMAXINT;   /* shift radix point by 32 bits */
    f = ff * 1000000000.0;   /* treat fraction as parts per billion */
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u.%09d", i, f);
+   ARGUSBUF_APPEND("%u.%09d", i, f);
 
 #ifdef HAVE_STRFTIME
    /*
@@ -242,7 +242,7 @@ p_ntp_time(register const struct l_fixedpt *lfp)
 
        tm = localtime(&seconds);
        strftime(time_buf, sizeof (time_buf), "%Y/%m/%d %H:%M:%S", tm);
-       sprintf(&ArgusBuf[strlen(ArgusBuf)]," (%s)", time_buf);
+       ARGUSBUF_APPEND(" (%s)", time_buf);
    }
 #endif
 }
@@ -297,9 +297,9 @@ p_ntp_delta(register const struct l_fixedpt *olfp,
    ff = ff / FMAXINT;   /* shift radix point by 32 bits */
    f = ff * 1000000000.0;   /* treat fraction as parts per billion */
    if (signbit)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"-");
+      ARGUSBUF_APPEND("-");
    else
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"+");
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d.%09d", i, f);
+      ARGUSBUF_APPEND("+");
+   ARGUSBUF_APPEND("%d.%09d", i, f);
 }
 

--- a/examples/radump/print-pim.c
+++ b/examples/radump/print-pim.c
@@ -127,18 +127,18 @@ pimv1_join_prune_print(register const u_char *bp, register u_int len)
       int hold;
 
       haddr = EXTRACT_32BITS(bp);
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," RPF %s ", ipaddr_string(&haddr));
+      ARGUSBUF_APPEND(" RPF %s ", ipaddr_string(&haddr));
       hold = EXTRACT_16BITS(&bp[6]);
       if (hold != 180) {
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"Hold ");
+         ARGUSBUF_APPEND("Hold ");
          relts_print(&ArgusBuf[strlen(ArgusBuf)],hold);
       }
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s (%s/%d, %s", njoin ? "Join" : "Prune",
+      ARGUSBUF_APPEND("%s (%s/%d, %s", njoin ? "Join" : "Prune",
       ipaddr_string(&bp[26]), bp[25] & 0x3f,
       ipaddr_string(&bp[12]));
       if ((haddr = EXTRACT_32BITS(&bp[16])) != 0xffffffff)
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"/%s", ipaddr_string(&haddr));
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],") %s%s %s",
+         ARGUSBUF_APPEND("/%s", ipaddr_string(&haddr));
+      ARGUSBUF_APPEND(") %s%s %s",
           (bp[24] & 0x01) ? "Sparse" : "Dense",
           (bp[25] & 0x80) ? " WC" : "",
           (bp[25] & 0x40) ? "RP" : "SPT");
@@ -147,9 +147,9 @@ pimv1_join_prune_print(register const u_char *bp, register u_int len)
 
    TCHECK2(bp[0], sizeof(struct in_addr));
    haddr = EXTRACT_32BITS(bp);
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Upstream Nbr: %s", ipaddr_string(&haddr));
+   ARGUSBUF_APPEND(" Upstream Nbr: %s", ipaddr_string(&haddr));
    TCHECK2(bp[6], 2);
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Hold time: ");
+   ARGUSBUF_APPEND(" Hold time: ");
    relts_print(&ArgusBuf[strlen(ArgusBuf)],EXTRACT_16BITS(&bp[6]));
    if (ArgusParser->vflag < 2)
       return;
@@ -169,14 +169,14 @@ pimv1_join_prune_print(register const u_char *bp, register u_int len)
        */
       TCHECK2(bp[0], sizeof(struct in_addr));
       haddr = EXTRACT_32BITS(bp);
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Group: %s", ipaddr_string(&haddr));
+      ARGUSBUF_APPEND(" Group: %s", ipaddr_string(&haddr));
       TCHECK2(bp[4], sizeof(struct in_addr));
       if ((haddr = EXTRACT_32BITS(&bp[4])) != 0xffffffff)
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"/%s", ipaddr_string(&haddr));
+         ARGUSBUF_APPEND("/%s", ipaddr_string(&haddr));
       TCHECK2(bp[8], 4);
       njoin = EXTRACT_16BITS(&bp[8]);
       nprune = EXTRACT_16BITS(&bp[10]);
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," joined: %d pruned: %d", njoin, nprune);
+      ARGUSBUF_APPEND(" joined: %d pruned: %d", njoin, nprune);
       bp += 12;
       len -= 12;
       for (njp = 0; njp < (njoin + nprune); njp++) {
@@ -188,7 +188,7 @@ pimv1_join_prune_print(register const u_char *bp, register u_int len)
             type = "Prune";
          TCHECK2(bp[0], 6);
          haddr = EXTRACT_32BITS(&bp[2]);
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s %s%s%s%s/%d", type,
+         ARGUSBUF_APPEND(" %s %s%s%s%s/%d", type,
              (bp[0] & 0x01) ? "Sparse " : "Dense ",
              (bp[1] & 0x80) ? "WC " : "",
              (bp[1] & 0x40) ? "RP " : "SPT ",
@@ -199,7 +199,7 @@ pimv1_join_prune_print(register const u_char *bp, register u_int len)
    }
    return;
 trunc:
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|pim]");
+   ARGUSBUF_APPEND("[|pim]");
    return;
 }
 
@@ -220,101 +220,101 @@ pimv1_print(register const u_char *bp, register u_int len)
 
    switch (type) {
    case 0:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Query");
+      ARGUSBUF_APPEND(" Query");
       if (TTEST(bp[8])) {
          switch (bp[8] >> 4) {
          case 0:
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Dense-mode");
+            ARGUSBUF_APPEND(" Dense-mode");
             break;
          case 1:
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Sparse-mode");
+            ARGUSBUF_APPEND(" Sparse-mode");
             break;
          case 2:
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Sparse-Dense-mode");
+            ARGUSBUF_APPEND(" Sparse-Dense-mode");
             break;
          default:
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," mode-%d", bp[8] >> 4);
+            ARGUSBUF_APPEND(" mode-%d", bp[8] >> 4);
             break;
          }
       }
       if (ArgusParser->vflag) {
          TCHECK2(bp[10],2);
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," (Hold-time ");
+         ARGUSBUF_APPEND(" (Hold-time ");
          relts_print(&ArgusBuf[strlen(ArgusBuf)],EXTRACT_16BITS(&bp[10]));
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+         ARGUSBUF_APPEND(")");
       }
       break;
 
    case 1:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Register");
+      ARGUSBUF_APPEND(" Register");
       TCHECK2(bp[8], 20);         /* ip header */
       haddr = EXTRACT_32BITS(&bp[20]);
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," for %s > %s", ipaddr_string(&haddr),
+      ARGUSBUF_APPEND(" for %s > %s", ipaddr_string(&haddr),
           ipaddr_string(&bp[24]));
       break;
    case 2:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Register-Stop");
+      ARGUSBUF_APPEND(" Register-Stop");
       TCHECK2(bp[12], sizeof(struct in_addr));
       saddr = EXTRACT_32BITS(&bp[8]);
       daddr = EXTRACT_32BITS(&bp[12]);
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," for %s > %s", ipaddr_string(&saddr),
+      ARGUSBUF_APPEND(" for %s > %s", ipaddr_string(&saddr),
           ipaddr_string(&daddr));
       break;
    case 3:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Join/Prune");
+      ARGUSBUF_APPEND(" Join/Prune");
       if (ArgusParser->vflag)
          pimv1_join_prune_print(&bp[8], len - 8);
       break;
    case 4:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," RP-reachable");
+      ARGUSBUF_APPEND(" RP-reachable");
       if (ArgusParser->vflag) {
          TCHECK2(bp[22], 2);
          haddr = EXTRACT_32BITS(&bp[8]);
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," group %s", ipaddr_string(&haddr));
+         ARGUSBUF_APPEND(" group %s", ipaddr_string(&haddr));
          if ((haddr = EXTRACT_32BITS(&bp[12])) != 0xffffffff)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"/%s", ipaddr_string(&haddr));
+            ARGUSBUF_APPEND("/%s", ipaddr_string(&haddr));
          haddr = EXTRACT_32BITS(&bp[16]);
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," RP %s hold ", ipaddr_string(&haddr));
+         ARGUSBUF_APPEND(" RP %s hold ", ipaddr_string(&haddr));
          relts_print(&ArgusBuf[strlen(ArgusBuf)],EXTRACT_16BITS(&bp[22]));
       }
       break;
    case 5:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Assert");
+      ARGUSBUF_APPEND(" Assert");
       TCHECK2(bp[16], sizeof(struct in_addr));
       saddr = EXTRACT_32BITS(&bp[16]);
       daddr = EXTRACT_32BITS(&bp[8]);
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," for %s > %s", ipaddr_string(&saddr), ipaddr_string(&daddr));
+      ARGUSBUF_APPEND(" for %s > %s", ipaddr_string(&saddr), ipaddr_string(&daddr));
       if ((haddr = EXTRACT_32BITS(&bp[12])) != 0xffffffff)
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"/%s", ipaddr_string(&haddr));
+         ARGUSBUF_APPEND("/%s", ipaddr_string(&haddr));
       TCHECK2(bp[24], 4);
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s pref %d metric %d",
+      ARGUSBUF_APPEND(" %s pref %d metric %d",
           (bp[20] & 0x80) ? "RP-tree" : "SPT",
       EXTRACT_32BITS(&bp[20]) & 0x7fffffff,
       EXTRACT_32BITS(&bp[24]));
       break;
    case 6:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Graft");
+      ARGUSBUF_APPEND(" Graft");
       if (ArgusParser->vflag)
          pimv1_join_prune_print(&bp[8], len - 8);
       break;
    case 7:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Graft-ACK");
+      ARGUSBUF_APPEND(" Graft-ACK");
       if (ArgusParser->vflag)
          pimv1_join_prune_print(&bp[8], len - 8);
       break;
    case 8:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Mode");
+      ARGUSBUF_APPEND(" Mode");
       break;
    default:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [type %d]", type);
+      ARGUSBUF_APPEND(" [type %d]", type);
       break;
    }
    if ((bp[4] >> 4) != 1)
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [v%d]", bp[4] >> 4);
+      ARGUSBUF_APPEND(" [v%d]", bp[4] >> 4);
    return ArgusBuf;
 
 trunc:
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|pim]");
+   ARGUSBUF_APPEND("[|pim]");
    return ArgusBuf;
 }
 
@@ -335,17 +335,17 @@ cisco_autorp_print(register const u_char *bp, register u_int len)
    int hold;
 
    TCHECK(bp[0]);
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," auto-rp ");
+   ARGUSBUF_APPEND(" auto-rp ");
    type = bp[0];
    switch (type) {
    case 0x11:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"candidate-advert");
+      ARGUSBUF_APPEND("candidate-advert");
       break;
    case 0x12:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"mapping");
+      ARGUSBUF_APPEND("mapping");
       break;
    default:
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"type-0x%02x", type);
+      ARGUSBUF_APPEND("type-0x%02x", type);
       break;
    }
 
@@ -353,12 +353,12 @@ cisco_autorp_print(register const u_char *bp, register u_int len)
    numrps = bp[1];
 
    TCHECK2(bp[2], 2);
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Hold ");
+   ARGUSBUF_APPEND(" Hold ");
    hold = EXTRACT_16BITS(&bp[2]);
    if (hold)
       relts_print(&ArgusBuf[strlen(ArgusBuf)],EXTRACT_16BITS(&bp[2]));
    else
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"FOREVER");
+      ARGUSBUF_APPEND("FOREVER");
 
    /* Next 4 bytes are reserved. */
 
@@ -384,20 +384,20 @@ cisco_autorp_print(register const u_char *bp, register u_int len)
 
       TCHECK2(bp[0], 4);
       haddr = EXTRACT_32BITS(bp);
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," RP %s", ipaddr_string(&haddr));
+      ARGUSBUF_APPEND(" RP %s", ipaddr_string(&haddr));
       TCHECK(bp[4]);
       switch (bp[4] & 0x3) {
-      case 0: sprintf(&ArgusBuf[strlen(ArgusBuf)]," PIMv?");
+      case 0: ARGUSBUF_APPEND(" PIMv?");
          break;
-      case 1:   sprintf(&ArgusBuf[strlen(ArgusBuf)]," PIMv1");
+      case 1:   ARGUSBUF_APPEND(" PIMv1");
          break;
-      case 2:   sprintf(&ArgusBuf[strlen(ArgusBuf)]," PIMv2");
+      case 2:   ARGUSBUF_APPEND(" PIMv2");
          break;
-      case 3:   sprintf(&ArgusBuf[strlen(ArgusBuf)]," PIMv1+2");
+      case 3:   ARGUSBUF_APPEND(" PIMv1+2");
          break;
       }
       if (bp[4] & 0xfc)
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [rsvd=0x%02x]", bp[4] & 0xfc);
+         ARGUSBUF_APPEND(" [rsvd=0x%02x]", bp[4] & 0xfc);
       TCHECK(bp[5]);
       nentries = bp[5];
       bp += 6; len -= 6;
@@ -405,10 +405,10 @@ cisco_autorp_print(register const u_char *bp, register u_int len)
       for (; nentries; nentries--) {
          TCHECK2(bp[0], 6);
          haddr = EXTRACT_32BITS(bp);
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"%c%s%s/%d", s, bp[0] & 1 ? "!" : "",
+         ARGUSBUF_APPEND("%c%s%s/%d", s, bp[0] & 1 ? "!" : "",
              ipaddr_string(&haddr), bp[1]);
          if (bp[0] & 0xfe)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"[rsvd=0x%02x]", bp[0] & 0xfe);
+            ARGUSBUF_APPEND("[rsvd=0x%02x]", bp[0] & 0xfe);
          s = ',';
          bp += 6; len -= 6;
       }
@@ -416,7 +416,7 @@ cisco_autorp_print(register const u_char *bp, register u_int len)
    return;
 
 trunc:
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|autorp]");
+   ARGUSBUF_APPEND("[|autorp]");
    return;
 }
 
@@ -436,18 +436,18 @@ pim_print(register const u_char *bp, register u_int len)
    switch (PIM_VER(pim->pim_typever)) {
       case 2:
          if (!ArgusParser->vflag) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"PIMv%u, %s, length: %u", PIM_VER(pim->pim_typever),
+            ARGUSBUF_APPEND("PIMv%u, %s, length: %u", PIM_VER(pim->pim_typever),
                tok2str(pimv2_type_values,"Unknown Type",PIM_TYPE(pim->pim_typever)),
                len);
             return ArgusBuf;
          } else {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"PIMv%u, length: %u %s", PIM_VER(pim->pim_typever), len,
+            ARGUSBUF_APPEND("PIMv%u, length: %u %s", PIM_VER(pim->pim_typever), len,
                tok2str(pimv2_type_values,"Unknown Type",PIM_TYPE(pim->pim_typever)));
             pimv2_print(bp, len);
          }
             break;
       default:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"PIMv%u, length: %u", PIM_VER(pim->pim_typever), len);
+         ARGUSBUF_APPEND("PIMv%u, length: %u", PIM_VER(pim->pim_typever), len);
          break;
    }
    return ArgusBuf;
@@ -572,12 +572,12 @@ pimv2_addr_print(const u_char *bp, enum pimv2_addrtype at, int silent)
       haddr = EXTRACT_32BITS(bp);
       if (af == AF_INET) {
          if (!silent)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ipaddr_string(&haddr));
+            ARGUSBUF_APPEND("%s", ipaddr_string(&haddr));
       }
 #ifdef INET6
       else if (af == AF_INET6) {
          if (!silent)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ip6addr_string(bp));
+            ARGUSBUF_APPEND("%s", ip6addr_string(bp));
       }
 #endif
       return hdrlen + len;
@@ -587,32 +587,32 @@ pimv2_addr_print(const u_char *bp, enum pimv2_addrtype at, int silent)
       haddr = EXTRACT_32BITS(bp + 2);
       if (af == AF_INET) {
          if (!silent) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ipaddr_string(&haddr));
+            ARGUSBUF_APPEND("%s", ipaddr_string(&haddr));
             if (bp[1] != 32)
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"/%u", bp[1]);
+               ARGUSBUF_APPEND("/%u", bp[1]);
          }
       }
 #ifdef INET6
       else if (af == AF_INET6) {
          if (!silent) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ip6addr_string(bp + 2));
+            ARGUSBUF_APPEND("%s", ip6addr_string(bp + 2));
             if (bp[1] != 128)
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"/%u", bp[1]);
+               ARGUSBUF_APPEND("/%u", bp[1]);
          }
       }
 #endif
       if (bp[0] && !silent) {
          if (at == pimv2_group) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"(0x%02x)", bp[0]);
+            ARGUSBUF_APPEND("(0x%02x)", bp[0]);
          } else {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"(%s%s%s",
+            ARGUSBUF_APPEND("(%s%s%s",
                bp[0] & 0x04 ? "S" : "",
                bp[0] & 0x02 ? "W" : "",
                bp[0] & 0x01 ? "R" : "");
             if (bp[0] & 0xf8) {
-               (void) sprintf(&ArgusBuf[strlen(ArgusBuf)],"+0x%02x", bp[0] & 0xf8);
+               ARGUSBUF_APPEND("+0x%02x", bp[0] & 0xf8);
             }
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+            ARGUSBUF_APPEND(")");
          }
       }
       return hdrlen + 2 + len;
@@ -638,7 +638,7 @@ pimv2_print(register const u_char *bp, register u_int len)
    TCHECK(pim->pim_rsv);
    pimv2_addr_len = pim->pim_rsv;
    if (pimv2_addr_len != 0)
-      (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", RFC2117-encoding");
+      ARGUSBUF_APPEND(", RFC2117-encoding");
 
    switch (PIM_TYPE(pim->pim_typever)) {
       case PIMV2_TYPE_HELLO: {
@@ -650,7 +650,7 @@ pimv2_print(register const u_char *bp, register u_int len)
             olen = EXTRACT_16BITS(&bp[2]);
             TCHECK2(bp[0], 4 + olen);
 
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s Option (%u), length: %u, Value: ",
+            ARGUSBUF_APPEND(" %s Option (%u), length: %u, Value: ",
                  tok2str( pimv2_hello_option_values,"Unknown",otype),
                  otype, olen);
             bp += 4;
@@ -662,7 +662,7 @@ pimv2_print(register const u_char *bp, register u_int len)
 
                case PIMV2_HELLO_OPTION_LANPRUNEDELAY:
                   if (olen != 4) {
-                     (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"ERROR: Option Lenght != 4 Bytes (%u)", olen);
+                     ARGUSBUF_APPEND("ERROR: Option Lenght != 4 Bytes (%u)", olen);
                   } else {
                      char t_bit;
                      u_int16_t lan_delay, override_interval;
@@ -670,7 +670,7 @@ pimv2_print(register const u_char *bp, register u_int len)
                      override_interval = EXTRACT_16BITS(bp+2);
                      t_bit = (lan_delay & 0x8000)? 1 : 0;
                      lan_delay &= ~0x8000;
-                     (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," T-bit=%d, LAN delay %dms, Override interval %dms",
+                     ARGUSBUF_APPEND(" T-bit=%d, LAN delay %dms, Override interval %dms",
                      t_bit, lan_delay, override_interval);
                   }
                   break;
@@ -679,29 +679,29 @@ pimv2_print(register const u_char *bp, register u_int len)
                case PIMV2_HELLO_OPTION_DR_PRIORITY:
                   switch (olen) {
                      case 0:
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],"Bi-Directional Capability (Old)");
+                        ARGUSBUF_APPEND("Bi-Directional Capability (Old)");
                         break;
                      case 4:
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", EXTRACT_32BITS(bp));
+                        ARGUSBUF_APPEND("%u", EXTRACT_32BITS(bp));
                         break;
                      default:
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)],"ERROR: Option Lenght != 4 Bytes (%u)", olen);
+                        ARGUSBUF_APPEND("ERROR: Option Lenght != 4 Bytes (%u)", olen);
                         break;
                   }
                   break;
 
                case PIMV2_HELLO_OPTION_GENID:
-                  (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"0x%08x", EXTRACT_32BITS(bp));
+                  ARGUSBUF_APPEND("0x%08x", EXTRACT_32BITS(bp));
                   break;
 
                case PIMV2_HELLO_OPTION_REFRESH_CAP:
-                  (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"v%d", *bp);
+                  ARGUSBUF_APPEND("v%d", *bp);
                   if (*(bp+1) != 0) {
-                     (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", interval ");
+                     ARGUSBUF_APPEND(", interval ");
                      relts_print(&ArgusBuf[strlen(ArgusBuf)],*(bp+1));
                   }
                   if (EXTRACT_16BITS(bp+2) != 0) {
-                     (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," ?0x%04x?", EXTRACT_16BITS(bp+2));
+                     ARGUSBUF_APPEND(" ?0x%04x?", EXTRACT_16BITS(bp+2));
                   }
                   break;
 
@@ -714,10 +714,10 @@ pimv2_print(register const u_char *bp, register u_int len)
                      const u_char *ptr = bp;
                      while (ptr < (bp+olen)) {
                         int advance;
-                        sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+                        ARGUSBUF_APPEND(" ");
                         advance = pimv2_addr_print(ptr, pimv2_unicast, 0);
                         if (advance < 0) {
-                           sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+                           ARGUSBUF_APPEND("...");
                            break;
                         }
                         ptr += advance;
@@ -743,7 +743,7 @@ pimv2_print(register const u_char *bp, register u_int len)
          struct ip *ip;
 */
          if (ArgusParser->vflag && bp + 8 <= ep) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s%s", bp[4] & 0x80 ? "B" : "",
+            ARGUSBUF_APPEND(" %s%s", bp[4] & 0x80 ? "B" : "",
                bp[4] & 0x40 ? "N" : "");
          }
          bp += 8; len -= 8;
@@ -755,17 +755,17 @@ pimv2_print(register const u_char *bp, register u_int len)
          ip = (struct ip *)bp;
          switch (IP_V(ip)) {
             case 4:
-               sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+               ARGUSBUF_APPEND(" ");
                ip_print(bp, len);
                break;
 #ifdef INET6
             case 6:
-               sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+               ARGUSBUF_APPEND(" ");
                ip6_print(bp, len);
                break;
 #endif
             default:
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," IP ver %d", IP_V(ip));
+               ARGUSBUF_APPEND(" IP ver %d", IP_V(ip));
                break;
          }
 */
@@ -776,17 +776,17 @@ pimv2_print(register const u_char *bp, register u_int len)
          bp += 4; len -= 4;
          if (bp >= ep)
             break;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," group=");
+         ARGUSBUF_APPEND(" group=");
          if ((advance = pimv2_addr_print(bp, pimv2_group, 0)) < 0) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+            ARGUSBUF_APPEND("...");
             break;
          }
          bp += advance; len -= advance;
          if (bp >= ep)
             break;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," source=");
+         ARGUSBUF_APPEND(" source=");
          if ((advance = pimv2_addr_print(bp, pimv2_unicast, 0)) < 0) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+            ARGUSBUF_APPEND("...");
             break;
          }
          bp += advance; len -= advance;
@@ -842,9 +842,9 @@ pimv2_print(register const u_char *bp, register u_int len)
          if (PIM_TYPE(pim->pim_typever) != 7) {   /*not for Graft-ACK*/
             if (bp >= ep)
                break;
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", upstream-neighbor: ");
+            ARGUSBUF_APPEND(", upstream-neighbor: ");
             if ((advance = pimv2_addr_print(bp, pimv2_unicast, 0)) < 0) {
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+               ARGUSBUF_APPEND("...");
                break;
             }
             bp += advance; len -= advance;
@@ -853,11 +853,11 @@ pimv2_print(register const u_char *bp, register u_int len)
             break;
          ngroup = bp[1];
          holdtime = EXTRACT_16BITS(&bp[2]);
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %u group(s)", ngroup);
+         ARGUSBUF_APPEND(" %u group(s)", ngroup);
          if (PIM_TYPE(pim->pim_typever) != 7) {   /*not for Graft-ACK*/
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", holdtime: ");
+            ARGUSBUF_APPEND(", holdtime: ");
             if (holdtime == 0xffff)
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"infinite");
+               ARGUSBUF_APPEND("infinite");
             else
                relts_print(&ArgusBuf[strlen(ArgusBuf)],holdtime);
          }
@@ -865,32 +865,32 @@ pimv2_print(register const u_char *bp, register u_int len)
          for (i = 0; i < ngroup; i++) {
             if (bp >= ep)
                goto jp_done;
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," group #%u: ", i+1);
+            ARGUSBUF_APPEND(" group #%u: ", i+1);
             if ((advance = pimv2_addr_print(bp, pimv2_group, 0)) < 0) {
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...)");
+               ARGUSBUF_APPEND("...)");
                goto jp_done;
             }
             bp += advance; len -= advance;
             if (bp + 4 > ep) {
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...)");
+               ARGUSBUF_APPEND("...)");
                goto jp_done;
             }
             njoin = EXTRACT_16BITS(&bp[0]);
             nprune = EXTRACT_16BITS(&bp[2]);
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],", joined sources: %u, pruned sources: %u", njoin,nprune);
+            ARGUSBUF_APPEND(", joined sources: %u, pruned sources: %u", njoin,nprune);
             bp += 4; len -= 4;
             for (j = 0; j < njoin; j++) {
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," joined source #%u: ",j+1);
+               ARGUSBUF_APPEND(" joined source #%u: ",j+1);
                if ((advance = pimv2_addr_print(bp, pimv2_source, 0)) < 0) {
-                  (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...)");
+                  ARGUSBUF_APPEND("...)");
                   goto jp_done;
                }
                bp += advance; len -= advance;
             }
             for (j = 0; j < nprune; j++) {
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," pruned source #%u: ",j+1);
+               ARGUSBUF_APPEND(" pruned source #%u: ",j+1);
                if ((advance = pimv2_addr_print(bp, pimv2_source, 0)) < 0) {
-                  (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...)");
+                  ARGUSBUF_APPEND("...)");
                   goto jp_done;
                }
                bp += advance; len -= advance;
@@ -906,71 +906,71 @@ pimv2_print(register const u_char *bp, register u_int len)
 
          /* Fragment Tag, Hash Mask len, and BSR-priority */
          if (bp + sizeof(u_int16_t) >= ep) break;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," tag=%x", EXTRACT_16BITS(bp));
+         ARGUSBUF_APPEND(" tag=%x", EXTRACT_16BITS(bp));
          bp += sizeof(u_int16_t);
          if (bp >= ep) break;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," hashmlen=%d", bp[0]);
+         ARGUSBUF_APPEND(" hashmlen=%d", bp[0]);
          if (bp + 1 >= ep) break;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," BSRprio=%d", bp[1]);
+         ARGUSBUF_APPEND(" BSRprio=%d", bp[1]);
          bp += 2;
 
          /* Encoded-Unicast-BSR-Address */
          if (bp >= ep) break;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," BSR=");
+         ARGUSBUF_APPEND(" BSR=");
          if ((advance = pimv2_addr_print(bp, pimv2_unicast, 0)) < 0) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+            ARGUSBUF_APPEND("...");
             break;
          }
          bp += advance;
 
          for (i = 0; bp < ep; i++) {
             /* Encoded-Group Address */
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," (group%d: ", i);
+            ARGUSBUF_APPEND(" (group%d: ", i);
             if ((advance = pimv2_addr_print(bp, pimv2_group, 0))
                 < 0) {
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...)");
+               ARGUSBUF_APPEND("...)");
                goto bs_done;
             }
             bp += advance;
 
             /* RP-Count, Frag RP-Cnt, and rsvd */
             if (bp >= ep) {
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...)");
+               ARGUSBUF_APPEND("...)");
                goto bs_done;
             }
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," RPcnt=%d", bp[0]);
+            ARGUSBUF_APPEND(" RPcnt=%d", bp[0]);
             if (bp + 1 >= ep) {
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...)");
+               ARGUSBUF_APPEND("...)");
                goto bs_done;
             }
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," FRPcnt=%d", frpcnt = bp[1]);
+            ARGUSBUF_APPEND(" FRPcnt=%d", frpcnt = bp[1]);
             bp += 4;
 
             for (j = 0; j < frpcnt && bp < ep; j++) {
                /* each RP info */
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," RP%d=", j);
+               ARGUSBUF_APPEND(" RP%d=", j);
                if ((advance = pimv2_addr_print(bp,
                            pimv2_unicast,
                            0)) < 0) {
-                  (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...)");
+                  ARGUSBUF_APPEND("...)");
                   goto bs_done;
                }
                bp += advance;
 
                if (bp + 1 >= ep) {
-                  (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...)");
+                  ARGUSBUF_APPEND("...)");
                   goto bs_done;
                }
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],",holdtime=");
+               ARGUSBUF_APPEND(",holdtime=");
                relts_print(&ArgusBuf[strlen(ArgusBuf)],EXTRACT_16BITS(bp));
                if (bp + 2 >= ep) {
-                  (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...)");
+                  ARGUSBUF_APPEND("...)");
                   goto bs_done;
                }
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],",prio=%d", bp[2]);
+               ARGUSBUF_APPEND(",prio=%d", bp[2]);
                bp += 4;
             }
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+            ARGUSBUF_APPEND(")");
          }
          bs_done:
          break;
@@ -980,26 +980,26 @@ pimv2_print(register const u_char *bp, register u_int len)
          bp += 4; len -= 4;
          if (bp >= ep)
             break;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," group=");
+         ARGUSBUF_APPEND(" group=");
          if ((advance = pimv2_addr_print(bp, pimv2_group, 0)) < 0) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+            ARGUSBUF_APPEND("...");
             break;
          }
          bp += advance; len -= advance;
          if (bp >= ep)
             break;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," src=");
+         ARGUSBUF_APPEND(" src=");
          if ((advance = pimv2_addr_print(bp, pimv2_unicast, 0)) < 0) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+            ARGUSBUF_APPEND("...");
             break;
          }
          bp += advance; len -= advance;
          if (bp + 8 > ep)
             break;
          if (bp[0] & 0x80)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," RPT");
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," pref=%u", EXTRACT_32BITS(&bp[0]) & 0x7fffffff);
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," metric=%u", EXTRACT_32BITS(&bp[4]));
+            ARGUSBUF_APPEND(" RPT");
+         ARGUSBUF_APPEND(" pref=%u", EXTRACT_32BITS(&bp[0]) & 0x7fffffff);
+         ARGUSBUF_APPEND(" metric=%u", EXTRACT_32BITS(&bp[4]));
          break;
 
       case PIMV2_TYPE_CANDIDATE_RP: {
@@ -1008,30 +1008,30 @@ pimv2_print(register const u_char *bp, register u_int len)
 
          /* Prefix-Cnt, Priority, and Holdtime */
          if (bp >= ep) break;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," prefix-cnt=%d", bp[0]);
+         ARGUSBUF_APPEND(" prefix-cnt=%d", bp[0]);
          pfxcnt = bp[0];
          if (bp + 1 >= ep) break;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," prio=%d", bp[1]);
+         ARGUSBUF_APPEND(" prio=%d", bp[1]);
          if (bp + 3 >= ep) break;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," holdtime=");
+         ARGUSBUF_APPEND(" holdtime=");
          relts_print(&ArgusBuf[strlen(ArgusBuf)],EXTRACT_16BITS(&bp[2]));
          bp += 4;
 
          /* Encoded-Unicast-RP-Address */
          if (bp >= ep) break;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," RP=");
+         ARGUSBUF_APPEND(" RP=");
          if ((advance = pimv2_addr_print(bp, pimv2_unicast, 0)) < 0) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+            ARGUSBUF_APPEND("...");
             break;
          }
          bp += advance;
 
          /* Encoded-Group Addresses */
          for (i = 0; i < pfxcnt && bp < ep; i++) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," Group%d=", i);
+            ARGUSBUF_APPEND(" Group%d=", i);
             if ((advance = pimv2_addr_print(bp, pimv2_group, 0))
                 < 0) {
-               (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+               ARGUSBUF_APPEND("...");
                break;
             }
             bp += advance;
@@ -1040,37 +1040,37 @@ pimv2_print(register const u_char *bp, register u_int len)
       }
 
       case PIMV2_TYPE_PRUNE_REFRESH:
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," src=");
+         ARGUSBUF_APPEND(" src=");
          if ((advance = pimv2_addr_print(bp, pimv2_unicast, 0)) < 0) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+            ARGUSBUF_APPEND("...");
             break;
          }
          bp += advance;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," grp=");
+         ARGUSBUF_APPEND(" grp=");
          if ((advance = pimv2_addr_print(bp, pimv2_group, 0)) < 0) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+            ARGUSBUF_APPEND("...");
             break;
          }
          bp += advance;
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," forwarder=");
+         ARGUSBUF_APPEND(" forwarder=");
          if ((advance = pimv2_addr_print(bp, pimv2_unicast, 0)) < 0) {
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"...");
+            ARGUSBUF_APPEND("...");
             break;
          }
          bp += advance;
          TCHECK2(bp[0], 2);
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," TUNR ");
+         ARGUSBUF_APPEND(" TUNR ");
          relts_print(&ArgusBuf[strlen(ArgusBuf)],EXTRACT_16BITS(bp));
          break;
 
       default:
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," [type %d]", PIM_TYPE(pim->pim_typever));
+         ARGUSBUF_APPEND(" [type %d]", PIM_TYPE(pim->pim_typever));
          break;
    }
    return;
 
 trunc:
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|pim]");
+   ARGUSBUF_APPEND("[|pim]");
 }
 
 /*

--- a/examples/radump/print-pptp.c
+++ b/examples/radump/print-pptp.c
@@ -292,176 +292,176 @@ struct pptp_msg_sli {
 static void
 pptp_bearer_cap_print(const u_int32_t *bearer_cap)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," BEARER_CAP(");
+   ARGUSBUF_APPEND(" BEARER_CAP(");
    if (EXTRACT_32BITS(bearer_cap) & PPTP_BEARER_CAP_DIGITAL_MASK) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"D");
+                ARGUSBUF_APPEND("D");
         }
         if (EXTRACT_32BITS(bearer_cap) & PPTP_BEARER_CAP_ANALOG_MASK) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"A");
+                ARGUSBUF_APPEND("A");
         }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+   ARGUSBUF_APPEND(")");
 }
 
 static void
 pptp_bearer_type_print(const u_int32_t *bearer_type)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," BEARER_TYPE(");
+   ARGUSBUF_APPEND(" BEARER_TYPE(");
    switch (EXTRACT_32BITS(bearer_type)) {
    case 1:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"A");   /* Analog */
+      ARGUSBUF_APPEND("A");   /* Analog */
       break;
    case 2:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"D");   /* Digital */
+      ARGUSBUF_APPEND("D");   /* Digital */
       break;
    case 3:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"Any");
+      ARGUSBUF_APPEND("Any");
       break;
    default:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"?");
+      ARGUSBUF_APPEND("?");
       break;
         }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+   ARGUSBUF_APPEND(")");
 }
 
 static void
 pptp_call_id_print(const u_int16_t *call_id)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," CALL_ID(%u)", EXTRACT_16BITS(call_id));
+   ARGUSBUF_APPEND(" CALL_ID(%u)", EXTRACT_16BITS(call_id));
 }
 
 static void
 pptp_call_ser_print(const u_int16_t *call_ser)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," CALL_SER_NUM(%u)", EXTRACT_16BITS(call_ser));
+   ARGUSBUF_APPEND(" CALL_SER_NUM(%u)", EXTRACT_16BITS(call_ser));
 }
 
 static void
 pptp_cause_code_print(const u_int16_t *cause_code)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," CAUSE_CODE(%u)", EXTRACT_16BITS(cause_code));
+   ARGUSBUF_APPEND(" CAUSE_CODE(%u)", EXTRACT_16BITS(cause_code));
 }
 
 static void
 pptp_conn_speed_print(const u_int32_t *conn_speed)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," CONN_SPEED(%u)", EXTRACT_32BITS(conn_speed));
+   ARGUSBUF_APPEND(" CONN_SPEED(%u)", EXTRACT_32BITS(conn_speed));
 }
 
 static void
 pptp_err_code_print(const u_int8_t *err_code)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," ERR_CODE(%u", *err_code);
+   ARGUSBUF_APPEND(" ERR_CODE(%u", *err_code);
    if (ArgusParser->vflag) {
       switch (*err_code) {
       case 0:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],":None");
+         ARGUSBUF_APPEND(":None");
          break;
       case 1:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],":Not-Connected");
+         ARGUSBUF_APPEND(":Not-Connected");
          break;
       case 2:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],":Bad-Format");
+         ARGUSBUF_APPEND(":Bad-Format");
          break;
       case 3:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],":Bad-Valude");
+         ARGUSBUF_APPEND(":Bad-Valude");
          break;
       case 4:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],":No-Resource");
+         ARGUSBUF_APPEND(":No-Resource");
          break;
       case 5:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],":Bad-Call-ID");
+         ARGUSBUF_APPEND(":Bad-Call-ID");
          break;
       case 6:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],":PAC-Error");
+         ARGUSBUF_APPEND(":PAC-Error");
          break;
       default:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],":?");
+         ARGUSBUF_APPEND(":?");
          break;
       }
    }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+   ARGUSBUF_APPEND(")");
 }
 
 static void
 pptp_firm_rev_print(const u_int16_t *firm_rev)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," FIRM_REV(%u)", EXTRACT_16BITS(firm_rev));
+   ARGUSBUF_APPEND(" FIRM_REV(%u)", EXTRACT_16BITS(firm_rev));
 }
 
 static void
 pptp_framing_cap_print(const u_int32_t *framing_cap)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," FRAME_CAP(");
+   ARGUSBUF_APPEND(" FRAME_CAP(");
    if (EXTRACT_32BITS(framing_cap) & PPTP_FRAMING_CAP_ASYNC_MASK) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"A");      /* Async */
+                ARGUSBUF_APPEND("A");      /* Async */
         }
         if (EXTRACT_32BITS(framing_cap) & PPTP_FRAMING_CAP_SYNC_MASK) {
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"S");      /* Sync */
+                ARGUSBUF_APPEND("S");      /* Sync */
         }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+   ARGUSBUF_APPEND(")");
 }
 
 static void
 pptp_framing_type_print(const u_int32_t *framing_type)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," FRAME_TYPE(");
+   ARGUSBUF_APPEND(" FRAME_TYPE(");
    switch (EXTRACT_32BITS(framing_type)) {
    case 1:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"A");      /* Async */
+      ARGUSBUF_APPEND("A");      /* Async */
       break;
    case 2:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"S");      /* Sync */
+      ARGUSBUF_APPEND("S");      /* Sync */
       break;
    case 3:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"E");      /* Either */
+      ARGUSBUF_APPEND("E");      /* Either */
       break;
    default:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"?");
+      ARGUSBUF_APPEND("?");
       break;
    }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+   ARGUSBUF_APPEND(")");
 }
 
 static void
 pptp_hostname_print(const u_char *hostname)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," HOSTNAME(%.64s)", hostname);
+   ARGUSBUF_APPEND(" HOSTNAME(%.64s)", hostname);
 }
 
 static void
 pptp_id_print(const u_int32_t *id)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," ID(%u)", EXTRACT_32BITS(id));
+   ARGUSBUF_APPEND(" ID(%u)", EXTRACT_32BITS(id));
 }
 
 static void
 pptp_max_channel_print(const u_int16_t *max_channel)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," MAX_CHAN(%u)", EXTRACT_16BITS(max_channel));
+   ARGUSBUF_APPEND(" MAX_CHAN(%u)", EXTRACT_16BITS(max_channel));
 }
 
 static void
 pptp_peer_call_id_print(const u_int16_t *peer_call_id)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," PEER_CALL_ID(%u)", EXTRACT_16BITS(peer_call_id));
+   ARGUSBUF_APPEND(" PEER_CALL_ID(%u)", EXTRACT_16BITS(peer_call_id));
 }
 
 static void
 pptp_phy_chan_id_print(const u_int32_t *phy_chan_id)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," PHY_CHAN_ID(%u)", EXTRACT_32BITS(phy_chan_id));
+   ARGUSBUF_APPEND(" PHY_CHAN_ID(%u)", EXTRACT_32BITS(phy_chan_id));
 }
 
 static void
 pptp_pkt_proc_delay_print(const u_int16_t *pkt_proc_delay)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," PROC_DELAY(%u)", EXTRACT_16BITS(pkt_proc_delay));
+   ARGUSBUF_APPEND(" PROC_DELAY(%u)", EXTRACT_16BITS(pkt_proc_delay));
 }
 
 static void
 pptp_proto_ver_print(const u_int16_t *proto_ver)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," PROTO_VER(%u.%u)",   /* Version.Revision */
+   ARGUSBUF_APPEND(" PROTO_VER(%u.%u)",   /* Version.Revision */
           EXTRACT_16BITS(proto_ver) >> 8,
           EXTRACT_16BITS(proto_ver) & 0xff);
 }
@@ -469,34 +469,34 @@ pptp_proto_ver_print(const u_int16_t *proto_ver)
 static void
 pptp_recv_winsiz_print(const u_int16_t *recv_winsiz)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," RECV_WIN(%u)", EXTRACT_16BITS(recv_winsiz));
+   ARGUSBUF_APPEND(" RECV_WIN(%u)", EXTRACT_16BITS(recv_winsiz));
 }
 
 static void
 pptp_result_code_print(const u_int8_t *result_code, int ctrl_msg_type)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," RESULT_CODE(%u", *result_code);
+   ARGUSBUF_APPEND(" RESULT_CODE(%u", *result_code);
    if (ArgusParser->vflag) {
       switch (ctrl_msg_type) {
       case PPTP_CTRL_MSG_TYPE_SCCRP:
          switch (*result_code) {
          case 1:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":Successful channel establishment");
+            ARGUSBUF_APPEND(":Successful channel establishment");
             break;
          case 2:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":General error");
+            ARGUSBUF_APPEND(":General error");
             break;
          case 3:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":Command channel already exists");
+            ARGUSBUF_APPEND(":Command channel already exists");
             break;
          case 4:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":Requester is not authorized to establish a command channel");
+            ARGUSBUF_APPEND(":Requester is not authorized to establish a command channel");
             break;
          case 5:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":The protocol version of the requester is not supported");
+            ARGUSBUF_APPEND(":The protocol version of the requester is not supported");
             break;
          default:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":?");
+            ARGUSBUF_APPEND(":?");
             break;
          }
          break;
@@ -504,75 +504,75 @@ pptp_result_code_print(const u_int8_t *result_code, int ctrl_msg_type)
       case PPTP_CTRL_MSG_TYPE_ECHORP:
          switch (*result_code) {
          case 1:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":OK");
+            ARGUSBUF_APPEND(":OK");
             break;
          case 2:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":General Error");
+            ARGUSBUF_APPEND(":General Error");
             break;
          default:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":?");
+            ARGUSBUF_APPEND(":?");
             break;
          }
          break;
       case PPTP_CTRL_MSG_TYPE_OCRP:
          switch (*result_code) {
          case 1:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":Connected");
+            ARGUSBUF_APPEND(":Connected");
             break;
          case 2:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":General Error");
+            ARGUSBUF_APPEND(":General Error");
             break;
          case 3:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":No Carrier");
+            ARGUSBUF_APPEND(":No Carrier");
             break;
          case 4:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":Busy");
+            ARGUSBUF_APPEND(":Busy");
             break;
          case 5:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":No Dial Tone");
+            ARGUSBUF_APPEND(":No Dial Tone");
             break;
          case 6:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":Time-out");
+            ARGUSBUF_APPEND(":Time-out");
             break;
          case 7:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":Do Not Accept");
+            ARGUSBUF_APPEND(":Do Not Accept");
             break;
          default:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":?");
+            ARGUSBUF_APPEND(":?");
             break;
          }
          break;
       case PPTP_CTRL_MSG_TYPE_ICRP:
          switch (*result_code) {
          case 1:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":Connect");
+            ARGUSBUF_APPEND(":Connect");
             break;
          case 2:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":General Error");
+            ARGUSBUF_APPEND(":General Error");
             break;
          case 3:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":Do Not Accept");
+            ARGUSBUF_APPEND(":Do Not Accept");
             break;
          default:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":?");
+            ARGUSBUF_APPEND(":?");
             break;
          }
          break;
       case PPTP_CTRL_MSG_TYPE_CDN:
          switch (*result_code) {
          case 1:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":Lost Carrier");
+            ARGUSBUF_APPEND(":Lost Carrier");
             break;
          case 2:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":General Error");
+            ARGUSBUF_APPEND(":General Error");
             break;
          case 3:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":Admin Shutdown");
+            ARGUSBUF_APPEND(":Admin Shutdown");
             break;
          case 4:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":Request");
+            ARGUSBUF_APPEND(":Request");
          default:
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],":?");
+            ARGUSBUF_APPEND(":?");
             break;
          break;
          }
@@ -581,19 +581,19 @@ pptp_result_code_print(const u_int8_t *result_code, int ctrl_msg_type)
          break;
       }
    }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+   ARGUSBUF_APPEND(")");
 }
 
 static void
 pptp_subaddr_print(const u_char *subaddr)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," SUB_ADDR(%.64s)", subaddr);
+   ARGUSBUF_APPEND(" SUB_ADDR(%.64s)", subaddr);
 }
 
 static void
 pptp_vendor_print(const u_char *vendor)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," VENDOR(%.64s)", vendor);
+   ARGUSBUF_APPEND(" VENDOR(%.64s)", vendor);
 }
 
 /************************************/
@@ -623,7 +623,7 @@ pptp_sccrq_print(const u_char *dat)
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -653,7 +653,7 @@ pptp_sccrp_print(const u_char *dat)
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -662,31 +662,31 @@ pptp_stopccrq_print(const u_char *dat)
    struct pptp_msg_stopccrq *ptr = (struct pptp_msg_stopccrq *)dat;
 
    TCHECK(ptr->reason);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," REASON(%u", ptr->reason);
+   ARGUSBUF_APPEND(" REASON(%u", ptr->reason);
    if (ArgusParser->vflag) {
       switch (ptr->reason) {
       case 1:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],":None");
+         ARGUSBUF_APPEND(":None");
          break;
       case 2:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],":Stop-Protocol");
+         ARGUSBUF_APPEND(":Stop-Protocol");
          break;
       case 3:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],":Stop-Local-Shutdown");
+         ARGUSBUF_APPEND(":Stop-Local-Shutdown");
          break;
       default:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],":?");
+         ARGUSBUF_APPEND(":?");
          break;
       }
    }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+   ARGUSBUF_APPEND(")");
    TCHECK(ptr->reserved1);
    TCHECK(ptr->reserved2);
 
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -703,7 +703,7 @@ pptp_stopccrp_print(const u_char *dat)
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -717,7 +717,7 @@ pptp_echorq_print(const u_char *dat)
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -736,7 +736,7 @@ pptp_echorp_print(const u_char *dat)
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -749,9 +749,9 @@ pptp_ocrq_print(const u_char *dat)
    TCHECK(ptr->call_ser);
    pptp_call_ser_print(&ptr->call_ser);
    TCHECK(ptr->min_bps);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," MIN_BPS(%u)", EXTRACT_32BITS(&ptr->min_bps));
+   ARGUSBUF_APPEND(" MIN_BPS(%u)", EXTRACT_32BITS(&ptr->min_bps));
    TCHECK(ptr->max_bps);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," MAX_BPS(%u)", EXTRACT_32BITS(&ptr->max_bps));
+   ARGUSBUF_APPEND(" MAX_BPS(%u)", EXTRACT_32BITS(&ptr->max_bps));
    TCHECK(ptr->bearer_type);
    pptp_bearer_type_print(&ptr->bearer_type);
    TCHECK(ptr->framing_type);
@@ -761,17 +761,17 @@ pptp_ocrq_print(const u_char *dat)
    TCHECK(ptr->pkt_proc_delay);
    pptp_pkt_proc_delay_print(&ptr->pkt_proc_delay);
    TCHECK(ptr->phone_no_len);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," PHONE_NO_LEN(%u)", EXTRACT_16BITS(&ptr->phone_no_len));
+   ARGUSBUF_APPEND(" PHONE_NO_LEN(%u)", EXTRACT_16BITS(&ptr->phone_no_len));
    TCHECK(ptr->reserved1);
    TCHECK(ptr->phone_no);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," PHONE_NO(%.64s)", ptr->phone_no);
+   ARGUSBUF_APPEND(" PHONE_NO(%.64s)", ptr->phone_no);
    TCHECK(ptr->subaddr);
    pptp_subaddr_print(&ptr->subaddr[0]);
 
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -801,7 +801,7 @@ pptp_ocrp_print(const u_char *dat)
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -818,20 +818,20 @@ pptp_icrq_print(const u_char *dat)
    TCHECK(ptr->phy_chan_id);
    pptp_phy_chan_id_print(&ptr->phy_chan_id);
    TCHECK(ptr->dialed_no_len);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," DIALED_NO_LEN(%u)", EXTRACT_16BITS(&ptr->dialed_no_len));
+   ARGUSBUF_APPEND(" DIALED_NO_LEN(%u)", EXTRACT_16BITS(&ptr->dialed_no_len));
    TCHECK(ptr->dialing_no_len);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," DIALING_NO_LEN(%u)", EXTRACT_16BITS(&ptr->dialing_no_len));
+   ARGUSBUF_APPEND(" DIALING_NO_LEN(%u)", EXTRACT_16BITS(&ptr->dialing_no_len));
    TCHECK(ptr->dialed_no);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," DIALED_NO(%.64s)", ptr->dialed_no);
+   ARGUSBUF_APPEND(" DIALED_NO(%.64s)", ptr->dialed_no);
    TCHECK(ptr->dialing_no);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," DIALING_NO(%.64s)", ptr->dialing_no);
+   ARGUSBUF_APPEND(" DIALING_NO(%.64s)", ptr->dialing_no);
    TCHECK(ptr->subaddr);
    pptp_subaddr_print(&ptr->subaddr[0]);
 
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -856,7 +856,7 @@ pptp_icrp_print(const u_char *dat)
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -879,7 +879,7 @@ pptp_iccn_print(const u_char *dat)
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -894,7 +894,7 @@ pptp_ccrq_print(const u_char *dat)
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -912,12 +912,12 @@ pptp_cdn_print(const u_char *dat)
    pptp_cause_code_print(&ptr->cause_code);
    TCHECK(ptr->reserved1);
    TCHECK(ptr->call_stats);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," CALL_STATS(%.128s)", ptr->call_stats);
+   ARGUSBUF_APPEND(" CALL_STATS(%.128s)", ptr->call_stats);
 
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -929,22 +929,22 @@ pptp_wen_print(const u_char *dat)
    pptp_peer_call_id_print(&ptr->peer_call_id);
    TCHECK(ptr->reserved1);
    TCHECK(ptr->crc_err);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," CRC_ERR(%u)", EXTRACT_32BITS(&ptr->crc_err));
+   ARGUSBUF_APPEND(" CRC_ERR(%u)", EXTRACT_32BITS(&ptr->crc_err));
    TCHECK(ptr->framing_err);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," FRAMING_ERR(%u)", EXTRACT_32BITS(&ptr->framing_err));
+   ARGUSBUF_APPEND(" FRAMING_ERR(%u)", EXTRACT_32BITS(&ptr->framing_err));
    TCHECK(ptr->hardware_overrun);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," HARDWARE_OVERRUN(%u)", EXTRACT_32BITS(&ptr->hardware_overrun));
+   ARGUSBUF_APPEND(" HARDWARE_OVERRUN(%u)", EXTRACT_32BITS(&ptr->hardware_overrun));
    TCHECK(ptr->buffer_overrun);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," BUFFER_OVERRUN(%u)", EXTRACT_32BITS(&ptr->buffer_overrun));
+   ARGUSBUF_APPEND(" BUFFER_OVERRUN(%u)", EXTRACT_32BITS(&ptr->buffer_overrun));
    TCHECK(ptr->timeout_err);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," TIMEOUT_ERR(%u)", EXTRACT_32BITS(&ptr->timeout_err));
+   ARGUSBUF_APPEND(" TIMEOUT_ERR(%u)", EXTRACT_32BITS(&ptr->timeout_err));
    TCHECK(ptr->align_err);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," ALIGN_ERR(%u)", EXTRACT_32BITS(&ptr->align_err));
+   ARGUSBUF_APPEND(" ALIGN_ERR(%u)", EXTRACT_32BITS(&ptr->align_err));
 
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 static void
@@ -956,14 +956,14 @@ pptp_sli_print(const u_char *dat)
    pptp_peer_call_id_print(&ptr->peer_call_id);
    TCHECK(ptr->reserved1);
    TCHECK(ptr->send_accm);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," SEND_ACCM(0x%08x)", EXTRACT_32BITS(&ptr->send_accm));
+   ARGUSBUF_APPEND(" SEND_ACCM(0x%08x)", EXTRACT_32BITS(&ptr->send_accm));
    TCHECK(ptr->recv_accm);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," RECV_ACCM(0x%08x)", EXTRACT_32BITS(&ptr->recv_accm));
+   ARGUSBUF_APPEND(" RECV_ACCM(0x%08x)", EXTRACT_32BITS(&ptr->recv_accm));
 
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
 }
 
 char *
@@ -973,25 +973,25 @@ pptp_print(const u_char *dat, u_int len)
    u_int32_t mc;
    u_int16_t ctrl_msg_type;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],": pptp");
+   ARGUSBUF_APPEND(": pptp");
 
    hdr = (struct pptp_hdr *)dat;
 
    TCHECK(hdr->length);
    if (ArgusParser->vflag) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Length=%u", EXTRACT_16BITS(&hdr->length));
+      ARGUSBUF_APPEND(" Length=%u", EXTRACT_16BITS(&hdr->length));
    }
    TCHECK(hdr->msg_type);
    if (ArgusParser->vflag) {
       switch(EXTRACT_16BITS(&hdr->msg_type)) {
       case PPTP_MSG_TYPE_CTRL:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," CTRL-MSG");
+         ARGUSBUF_APPEND(" CTRL-MSG");
          break;
       case PPTP_MSG_TYPE_MGMT:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," MGMT-MSG");
+         ARGUSBUF_APPEND(" MGMT-MSG");
          break;
       default:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," UNKNOWN-MSG-TYPE");
+         ARGUSBUF_APPEND(" UNKNOWN-MSG-TYPE");
          break;
       }
    }
@@ -999,18 +999,18 @@ pptp_print(const u_char *dat, u_int len)
    TCHECK(hdr->magic_cookie);
    mc = EXTRACT_32BITS(&hdr->magic_cookie);
    if (mc != PPTP_MAGIC_COOKIE) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," UNEXPECTED Magic-Cookie!!(%08x)", mc);
+      ARGUSBUF_APPEND(" UNEXPECTED Magic-Cookie!!(%08x)", mc);
    }
    if (ArgusParser->vflag || mc != PPTP_MAGIC_COOKIE) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," Magic-Cookie=%08x", mc);
+      ARGUSBUF_APPEND(" Magic-Cookie=%08x", mc);
    }
    TCHECK(hdr->ctrl_msg_type);
    ctrl_msg_type = EXTRACT_16BITS(&hdr->ctrl_msg_type);
    if (ctrl_msg_type < PPTP_MAX_MSGTYPE_INDEX) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," CTRL_MSGTYPE=%s",
+      ARGUSBUF_APPEND(" CTRL_MSGTYPE=%s",
              pptp_message_type_string[ctrl_msg_type]);
    } else {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," UNKNOWN_CTRL_MSGTYPE(%u)", ctrl_msg_type);
+      ARGUSBUF_APPEND(" UNKNOWN_CTRL_MSGTYPE(%u)", ctrl_msg_type);
    }
    TCHECK(hdr->reserved0);
 
@@ -1070,6 +1070,6 @@ pptp_print(const u_char *dat, u_int len)
    return ArgusBuf;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+   ARGUSBUF_APPEND("%s", tstr);
    return ArgusBuf;
 }

--- a/examples/radump/print-radius.c
+++ b/examples/radump/print-radius.c
@@ -73,7 +73,7 @@ extern char ArgusBuf[];
 #define PRINT_HEX(bytes_len, ptr_data)                               \
            while(bytes_len)                                          \
            {                                                         \
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02X", *ptr_data );                            \
+              ARGUSBUF_APPEND("%02X", *ptr_data );                            \
               ptr_data++;                                            \
               bytes_len--;                                           \
            }
@@ -462,14 +462,14 @@ print_attr_string(register u_char *data, u_int length, u_short attr_code )
       case TUNNEL_PASS:
            if (length < 3)
            {
-              sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|radius]");
+              ARGUSBUF_APPEND(" [|radius]");
               return;
            }
            if (*data && (*data <=0x1F) )
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],"Tag %u, ",*data);
+              ARGUSBUF_APPEND("Tag %u, ",*data);
            data++;
            length--;
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],"Salt %u ",EXTRACT_16BITS(data) );
+           ARGUSBUF_APPEND("Salt %u ",EXTRACT_16BITS(data) );
            data+=2;
            length-=2;
         break;
@@ -483,10 +483,10 @@ print_attr_string(register u_char *data, u_int length, u_short attr_code )
            {
               if (length < 1)
               {
-                 sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|radius]");
+                 ARGUSBUF_APPEND(" [|radius]");
                  return;
               }
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],"Tag %u",*data);
+              ARGUSBUF_APPEND("Tag %u",*data);
               data++;
               length--;
            }
@@ -494,12 +494,12 @@ print_attr_string(register u_char *data, u_int length, u_short attr_code )
    }
 
    for (i=0; *data && i < length ; i++, data++)
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"%c",(*data < 32 || *data > 128) ? '.' : *data );
+       ARGUSBUF_APPEND("%c",(*data < 32 || *data > 128) ? '.' : *data );
 
    return;
 
    trunc:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|radius]");
+      ARGUSBUF_APPEND(" [|radius]");
 }
 
 /*
@@ -521,7 +521,7 @@ print_vendor_attr(register u_char *data, u_int length, u_short attr_code)
     data+=4;
     length-=4;
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Vendor: %s (%u)",
+    ARGUSBUF_APPEND("Vendor: %s (%u)",
            tok2str(smi_values,"Unknown",vendor_id),
            vendor_id);
 
@@ -533,14 +533,14 @@ print_vendor_attr(register u_char *data, u_int length, u_short attr_code)
 
         if (vendor_length < 2)
         {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Vendor Attribute: %u, Length: %u (bogus, must be >= 2)",
+            ARGUSBUF_APPEND("\n\t    Vendor Attribute: %u, Length: %u (bogus, must be >= 2)",
                    vendor_type,
                    vendor_length);
             return;
         }
         if (vendor_length > length)
         {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Vendor Attribute: %u, Length: %u (bogus, goes past end of vendor-specific attribute)",
+            ARGUSBUF_APPEND("\n\t    Vendor Attribute: %u, Length: %u (bogus, goes past end of vendor-specific attribute)",
                    vendor_type,
                    vendor_length);
             return;
@@ -550,17 +550,17 @@ print_vendor_attr(register u_char *data, u_int length, u_short attr_code)
         length-=2;
 	TCHECK2(*data, vendor_length);
 
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t    Vendor Attribute: %u, Length: %u, Value: ",
+        ARGUSBUF_APPEND("\n\t    Vendor Attribute: %u, Length: %u, Value: ",
                vendor_type,
                vendor_length);
         for (idx = 0; idx < vendor_length ; idx++, data++)
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%c",(*data < 32 || *data > 128) ? '.' : *data );
+            ARGUSBUF_APPEND("%c",(*data < 32 || *data > 128) ? '.' : *data );
         length-=vendor_length;
     }
     return;
 
    trunc:
-     sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|radius]");
+     ARGUSBUF_APPEND(" [|radius]");
 }
 
 
@@ -580,7 +580,7 @@ print_attr_num(register u_char *data, u_int length, u_short attr_code )
 
    if (length != 4)
    {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"ERROR: length %u != 4", length);
+       ARGUSBUF_APPEND("ERROR: length %u != 4", length);
        return;
    }
 
@@ -595,9 +595,9 @@ print_attr_num(register u_char *data, u_int length, u_short attr_code )
       if ( (attr_code == TUNNEL_TYPE) || (attr_code == TUNNEL_MEDIUM) )
       {
          if (!*data)
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"Tag[Unused]");
+            ARGUSBUF_APPEND("Tag[Unused]");
          else
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"Tag[%d]", *data);
+            ARGUSBUF_APPEND("Tag[%d]", *data);
          data++;
          data_value = EXTRACT_24BITS(data);
       }
@@ -608,9 +608,9 @@ print_attr_num(register u_char *data, u_int length, u_short attr_code )
       if ( data_value <= (u_int32_t)(attr_type[attr_code].siz_subtypes - 1 +
             attr_type[attr_code].first_subtype) &&
 	   data_value >= attr_type[attr_code].first_subtype )
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s",table[data_value]);
+         ARGUSBUF_APPEND("%s",table[data_value]);
       else
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"#%u",data_value);
+         ARGUSBUF_APPEND("#%u",data_value);
    }
    else
    {
@@ -618,9 +618,9 @@ print_attr_num(register u_char *data, u_int length, u_short attr_code )
       {
         case FRM_IPX:
              if (EXTRACT_32BITS( data) == 0xFFFFFFFE )
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"NAS Select");
+                ARGUSBUF_APPEND("NAS Select");
              else
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d",EXTRACT_32BITS( data) );
+                ARGUSBUF_APPEND("%d",EXTRACT_32BITS( data) );
           break;
 
         case SESSION_TIMEOUT:
@@ -630,14 +630,14 @@ print_attr_num(register u_char *data, u_int length, u_short attr_code )
         case ACCT_INT_INTERVAL:
              timeout = EXTRACT_32BITS( data);
              if ( timeout < 60 )
-                sprintf(&ArgusBuf[strlen(ArgusBuf)], "%02d secs", timeout);
+                ARGUSBUF_APPEND("%02d secs", timeout);
              else
              {
                 if ( timeout < 3600 )
-                   sprintf(&ArgusBuf[strlen(ArgusBuf)], "%02d:%02d min",
+                   ARGUSBUF_APPEND("%02d:%02d min",
                           timeout / 60, timeout % 60);
                 else
-                   sprintf(&ArgusBuf[strlen(ArgusBuf)], "%02d:%02d:%02d hours",
+                   ARGUSBUF_APPEND("%02d:%02d:%02d hours",
                           timeout / 3600, (timeout % 3600) / 60,
                           timeout % 60);
              }
@@ -645,29 +645,29 @@ print_attr_num(register u_char *data, u_int length, u_short attr_code )
 
         case FRM_ATALK_LINK:
              if (EXTRACT_32BITS(data) )
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d",EXTRACT_32BITS(data) );
+                ARGUSBUF_APPEND("%d",EXTRACT_32BITS(data) );
              else
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"Unnumbered" );
+                ARGUSBUF_APPEND("Unnumbered" );
           break;
 
         case FRM_ATALK_NETWORK:
              if (EXTRACT_32BITS(data) )
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d",EXTRACT_32BITS(data) );
+                ARGUSBUF_APPEND("%d",EXTRACT_32BITS(data) );
              else
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"NAS assigned" );
+                ARGUSBUF_APPEND("NAS assigned" );
           break;
 
         case TUNNEL_PREFERENCE:
             tag = *data;
             data++;
             if (tag == 0)
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"Tag (Unused) %d",EXTRACT_24BITS(data) );
+               ARGUSBUF_APPEND("Tag (Unused) %d",EXTRACT_24BITS(data) );
             else
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"Tag (%d) %d", tag, EXTRACT_24BITS(data) );
+               ARGUSBUF_APPEND("Tag (%d) %d", tag, EXTRACT_24BITS(data) );
           break;
 
         default:
-             sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d",EXTRACT_32BITS( data) );
+             ARGUSBUF_APPEND("%d",EXTRACT_32BITS( data) );
           break;
 
       } /* switch */
@@ -677,7 +677,7 @@ print_attr_num(register u_char *data, u_int length, u_short attr_code )
    return;
 
    trunc:
-     sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|radius]");
+     ARGUSBUF_APPEND(" [|radius]");
 }
 
 
@@ -693,7 +693,7 @@ print_attr_address(register u_char *data, u_int length, u_short attr_code )
 {
    if (length != 4)
    {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"ERROR: length %u != 4", length);
+       ARGUSBUF_APPEND("ERROR: length %u != 4", length);
        return;
    }
 
@@ -704,23 +704,23 @@ print_attr_address(register u_char *data, u_int length, u_short attr_code )
       case FRM_IPADDR:
       case LOG_IPHOST:
            if (EXTRACT_32BITS(data) == 0xFFFFFFFF )
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],"User Selected");
+              ARGUSBUF_APPEND("User Selected");
            else
               if (EXTRACT_32BITS(data) == 0xFFFFFFFE )
-                 sprintf(&ArgusBuf[strlen(ArgusBuf)],"NAS Select");
+                 ARGUSBUF_APPEND("NAS Select");
               else
-                 sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s",ipaddr_string(data));
+                 ARGUSBUF_APPEND("%s",ipaddr_string(data));
       break;
 
       default:
-          sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s",ipaddr_string(data) );
+          ARGUSBUF_APPEND("%s",ipaddr_string(data) );
       break;
    }
 
    return;
 
    trunc:
-     sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|radius]");
+     ARGUSBUF_APPEND(" [|radius]");
 }
 
 
@@ -739,7 +739,7 @@ static void print_attr_time(register u_char *data, u_int length, u_short attr_co
 
    if (length != 4)
    {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"ERROR: length %u != 4", length);
+       ARGUSBUF_APPEND("ERROR: length %u != 4", length);
        return;
    }
 
@@ -749,11 +749,11 @@ static void print_attr_time(register u_char *data, u_int length, u_short attr_co
    strncpy(string, ctime(&attr_time), sizeof(string));
    /* Get rid of the newline */
    string[24] = '\0';
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%.24s", string);
+   ARGUSBUF_APPEND("%.24s", string);
    return;
 
    trunc:
-     sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|radius]");
+     ARGUSBUF_APPEND(" [|radius]");
 }
 
 
@@ -773,44 +773,44 @@ static void print_attr_strange(register u_char *data, u_int length, u_short attr
       case ARAP_PASS:
            if (length != 16)
            {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"ERROR: length %u != 16", length);
+               ARGUSBUF_APPEND("ERROR: length %u != 16", length);
                return;
            }
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],"User_challenge (");
+           ARGUSBUF_APPEND("User_challenge (");
            TCHECK2(data[0],8);
            len_data = 8;
            PRINT_HEX(len_data, data);
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],") User_resp(");
+           ARGUSBUF_APPEND(") User_resp(");
            TCHECK2(data[0],8);
            len_data = 8;
            PRINT_HEX(len_data, data);
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],")");
+           ARGUSBUF_APPEND(")");
         break;
 
       case ARAP_FEATURES:
            if (length != 14)
            {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"ERROR: length %u != 14", length);
+               ARGUSBUF_APPEND("ERROR: length %u != 14", length);
                return;
            }
            TCHECK2(data[0],1);
            if (*data)
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],"User can change password");
+              ARGUSBUF_APPEND("User can change password");
            else
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],"User cannot change password");
+              ARGUSBUF_APPEND("User cannot change password");
            data++;
            TCHECK2(data[0],1);
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],", Min password length: %d",*data);
+           ARGUSBUF_APPEND(", Min password length: %d",*data);
            data++;
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],", created at: ");
+           ARGUSBUF_APPEND(", created at: ");
            TCHECK2(data[0],4);
            len_data = 4;
            PRINT_HEX(len_data, data);
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],", expires in: ");
+           ARGUSBUF_APPEND(", expires in: ");
            TCHECK2(data[0],4);
            len_data = 4;
            PRINT_HEX(len_data, data);
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],", Current Time: ");
+           ARGUSBUF_APPEND(", Current Time: ");
            TCHECK2(data[0],4);
            len_data = 4;
            PRINT_HEX(len_data, data);
@@ -819,7 +819,7 @@ static void print_attr_strange(register u_char *data, u_int length, u_short attr
       case ARAP_CHALLENGE_RESP:
            if (length < 8)
            {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"ERROR: length %u != 8", length);
+               ARGUSBUF_APPEND("ERROR: length %u != 8", length);
                return;
            }
            TCHECK2(data[0],8);
@@ -830,7 +830,7 @@ static void print_attr_strange(register u_char *data, u_int length, u_short attr
    return;
 
    trunc:
-     sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|radius]");
+     ARGUSBUF_APPEND(" [|radius]");
 }
 
 
@@ -853,7 +853,7 @@ radius_attrs_print(register const u_char *attr, u_int length)
 	attr_string = "Unknown";
      if (rad_attr->len < 2)
      {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s Attribute (%u), length: %u (bogus, must be >= 2)",
+	ARGUSBUF_APPEND("\n\t  %s Attribute (%u), length: %u (bogus, must be >= 2)",
                attr_string,
                rad_attr->type,
                rad_attr->len);
@@ -861,13 +861,13 @@ radius_attrs_print(register const u_char *attr, u_int length)
      }
      if (rad_attr->len > length)
      {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s Attribute (%u), length: %u (bogus, goes past end of packet)",
+	ARGUSBUF_APPEND("\n\t  %s Attribute (%u), length: %u (bogus, goes past end of packet)",
                attr_string,
                rad_attr->type,
                rad_attr->len);
         return;
      }
-     sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t  %s Attribute (%u), length: %u, Value: ",
+     ARGUSBUF_APPEND("\n\t  %s Attribute (%u), length: %u, Value: ",
             attr_string,
             rad_attr->type,
             rad_attr->len);
@@ -892,7 +892,7 @@ radius_attrs_print(register const u_char *attr, u_int length)
    return;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|radius]");
+   ARGUSBUF_APPEND(" [|radius]");
 }
 
 
@@ -908,7 +908,7 @@ radius_print(const u_char *dat, u_int length)
 
    if (len < MIN_RADIUS_LEN)
    {
-	  sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|radius]");
+	  ARGUSBUF_APPEND(" [|radius]");
 	  return ArgusBuf;
    }
 
@@ -916,7 +916,7 @@ radius_print(const u_char *dat, u_int length)
 	  len = length;
 
    if (ArgusParser->vflag < 1) {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"RADIUS, %s (%u), id: 0x%02x length: %u",
+       ARGUSBUF_APPEND("RADIUS, %s (%u), id: 0x%02x length: %u",
               tok2str(radius_command_values,"Unknown Command",rad->code),
               rad->code,
               rad->id,
@@ -924,14 +924,14 @@ radius_print(const u_char *dat, u_int length)
        return ArgusBuf;
    }
    else {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"RADIUS, length: %u\n\t%s (%u), id: 0x%02x, Authenticator: ",
+       ARGUSBUF_APPEND("RADIUS, length: %u\n\t%s (%u), id: 0x%02x, Authenticator: ",
               len,
               tok2str(radius_command_values,"Unknown Command",rad->code),
               rad->code,
               rad->id);
 
        for(auth_idx=0; auth_idx < 16; auth_idx++)
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02x", rad->auth[auth_idx] );
+            ARGUSBUF_APPEND("%02x", rad->auth[auth_idx] );
    }
 
    if (len > MIN_RADIUS_LEN)
@@ -939,6 +939,6 @@ radius_print(const u_char *dat, u_int length)
    return ArgusBuf;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|radius]");
+   ARGUSBUF_APPEND(" [|radius]");
    return ArgusBuf;
 }

--- a/examples/radump/print-rip.c
+++ b/examples/radump/print-rip.c
@@ -106,7 +106,7 @@ rip_entry_print_v1(register const struct rip_netinfo *ni)
    /* RFC 1058 */
    family = EXTRACT_16BITS(&ni->rip_family);
    if (family != AF_INET) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," AFI: %u:", family);
+      ARGUSBUF_APPEND(" AFI: %u:", family);
                 print_unknown_data((u_int8_t *)&ni->rip_family,"  ",RIP_ROUTELEN);
       return;
    }
@@ -117,7 +117,7 @@ rip_entry_print_v1(register const struct rip_netinfo *ni)
                 print_unknown_data((u_int8_t *)&ni->rip_family,"  ",RIP_ROUTELEN);
       return;
    } /* AF_INET */
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"  %s, metric: %u",
+   ARGUSBUF_APPEND("  %s, metric: %u",
                ipaddr_string(&ni->rip_dest),
           EXTRACT_32BITS(&ni->rip_metric));
 }
@@ -138,26 +138,26 @@ rip_entry_print_v2(register const struct rip_netinfo *ni)
             if (!isprint(*p))
                break;
          }
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"  Simple Text Authentication data: %s", buf);
+         ARGUSBUF_APPEND("  Simple Text Authentication data: %s", buf);
       } else {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"  Unknown (%u) Authentication data:",
+         ARGUSBUF_APPEND("  Unknown (%u) Authentication data:",
                 EXTRACT_16BITS(&ni->rip_tag));
          print_unknown_data((u_int8_t *)&ni->rip_dest,"  ",RIP_AUTHLEN);
       }
    } else if (family != AF_INET) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"  AFI: %u", family);
+      ARGUSBUF_APPEND("  AFI: %u", family);
                 print_unknown_data((u_int8_t *)&ni->rip_tag,"  ",RIP_ROUTELEN-2);
       return;
    } else { /* AF_INET */
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"  AFI: IPv4: %15s/%-2d, tag 0x%04x, metric: %u, next-hop: ",
+      ARGUSBUF_APPEND("  AFI: IPv4: %15s/%-2d, tag 0x%04x, metric: %u, next-hop: ",
                         ipaddr_string(&ni->rip_dest),
              mask2plen(EXTRACT_32BITS(&ni->rip_dest_mask)),
                        EXTRACT_16BITS(&ni->rip_tag),
                        EXTRACT_32BITS(&ni->rip_metric));
       if (EXTRACT_32BITS(&ni->rip_router))
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", ipaddr_string(&ni->rip_router));
+         ARGUSBUF_APPEND("%s", ipaddr_string(&ni->rip_router));
       else
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"self");
+         ARGUSBUF_APPEND("self");
    }
 }
 
@@ -170,21 +170,21 @@ rip_print(const u_char *dat, u_int length)
    register int trunc;
 
    if (snapend < dat) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|rip]");
+      ARGUSBUF_APPEND(" [|rip]");
       return ArgusBuf;
    }
    i = snapend - dat;
    if (i > length)
       i = length;
    if (i < sizeof(*rp)) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|rip]");
+      ARGUSBUF_APPEND(" [|rip]");
       return ArgusBuf;
    }
    i -= sizeof(*rp);
 
    rp = (struct rip *)dat;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"%sRIPv%u", (ArgusParser->vflag >= 1) ? "" : "", rp->rip_vers);
+   ARGUSBUF_APPEND("%sRIPv%u", (ArgusParser->vflag >= 1) ? "" : "", rp->rip_vers);
 
    switch (rp->rip_vers) {
       case 0:
@@ -205,7 +205,7 @@ rip_print(const u_char *dat, u_int length)
 
       default:
          /* dump version and lets see if we know the commands name*/
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],", %s, length: %u", tok2str(rip_cmd_values,
+         ARGUSBUF_APPEND(", %s, length: %u", tok2str(rip_cmd_values,
                       "unknown command (%u)", rp->rip_cmd), length);
 
          if (ArgusParser->vflag < 1)
@@ -214,7 +214,7 @@ rip_print(const u_char *dat, u_int length)
          switch (rp->rip_cmd) {
             case RIPCMD_RESPONSE:
                j = length / sizeof(*ni);
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],", routes: %u",j);
+               ARGUSBUF_APPEND(", routes: %u",j);
                trunc = (i / sizeof(*ni)) != j;
                ni = (struct rip_netinfo *)(rp + 1);
                for (; i >= sizeof(*ni); ++ni) {
@@ -227,7 +227,7 @@ rip_print(const u_char *dat, u_int length)
                   i -= sizeof(*ni);
                }
                if (trunc)
-                  sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|rip]");
+                  ARGUSBUF_APPEND("[|rip]");
                break;
 
             case RIPCMD_REQUEST:

--- a/examples/radump/print-rx.c
+++ b/examples/radump/print-rx.c
@@ -419,28 +419,28 @@ rx_print(register const u_char *bp, int length, int sport, int dport)
 	int i;
 
 	if (snapend - bp < (int)sizeof (struct rx_header)) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|rx] (%d)", length);
+		ARGUSBUF_APPEND(" [|rx] (%d)", length);
 		return ArgusBuf;
 	}
 
 	rxh = (struct rx_header *) bp;
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"rx %s", tok2str(rx_types, "type %d", rxh->type));
+	ARGUSBUF_APPEND("rx %s", tok2str(rx_types, "type %d", rxh->type));
 
 	if (ArgusParser->vflag) {
 		int firstflag = 0;
 
 		if (ArgusParser->vflag > 1)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," cid %08x call# %d",
+			ARGUSBUF_APPEND(" cid %08x call# %d",
 			       (int) EXTRACT_32BITS(&rxh->cid),
 			       (int) EXTRACT_32BITS(&rxh->callNumber));
 
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," seq %d ser %d",
+		ARGUSBUF_APPEND(" seq %d ser %d",
 		       (int) EXTRACT_32BITS(&rxh->seq),
 		       (int) EXTRACT_32BITS(&rxh->serial));
 
 		if (ArgusParser->vflag > 2)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," secindex %d serviceid %hu",
+			ARGUSBUF_APPEND(" secindex %d serviceid %hu",
 				(int) rxh->securityIndex,
 				EXTRACT_16BITS(&rxh->serviceId));
 
@@ -451,11 +451,11 @@ rx_print(register const u_char *bp, int length, int sport, int dport)
 				     rxh->type == rx_flags[i].packetType)) {
 					if (!firstflag) {
 						firstflag = 1;
-						sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+						ARGUSBUF_APPEND(" ");
 					} else {
-						sprintf(&ArgusBuf[strlen(ArgusBuf)],",");
+						ARGUSBUF_APPEND(",");
 					}
-					sprintf(&ArgusBuf[strlen(ArgusBuf)],"<%s>", rx_flags[i].s);
+					ARGUSBUF_APPEND("<%s>", rx_flags[i].s);
 				}
 			}
 	}
@@ -551,7 +551,7 @@ rx_print(register const u_char *bp, int length, int sport, int dport)
 		rx_ack_print(bp, length);
 
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," (%d)", length);
+	ARGUSBUF_APPEND(" (%d)", length);
    return ArgusBuf;
 }
 
@@ -567,7 +567,7 @@ rx_print(register const u_char *bp, int length, int sport, int dport)
 			bp += sizeof(int32_t); \
 			n3 = EXTRACT_32BITS(bp); \
 			bp += sizeof(int32_t); \
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," fid %d/%d/%d", (int) n1, (int) n2, (int) n3); \
+			ARGUSBUF_APPEND(" fid %d/%d/%d", (int) n1, (int) n2, (int) n3); \
 		}
 
 #define STROUT(MAX) { unsigned int i; \
@@ -576,10 +576,10 @@ rx_print(register const u_char *bp, int length, int sport, int dport)
 			if (i > (MAX)) \
 				goto trunc; \
 			bp += sizeof(int32_t); \
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," \""); \
-			if (fn_printn(bp, i, snapend, &ArgusBuf[strlen(ArgusBuf)]) == NULL) \
+			ARGUSBUF_APPEND(" \""); \
+			if (fn_printn(bp, i, snapend, &ArgusBuf[strlen(ArgusBuf)], MAXSTRLEN - strlen(ArgusBuf)) == NULL) \
 				goto trunc; \
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"\""); \
+			ARGUSBUF_APPEND("\""); \
 			bp += ((i + sizeof(int32_t) - 1) / sizeof(int32_t)) * sizeof(int32_t); \
 		}
 
@@ -587,14 +587,14 @@ rx_print(register const u_char *bp, int length, int sport, int dport)
 			TCHECK2(bp[0], sizeof(int32_t)); \
 			i = (int) EXTRACT_32BITS(bp); \
 			bp += sizeof(int32_t); \
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," %d", i); \
+			ARGUSBUF_APPEND(" %d", i); \
 		}
 
 #define UINTOUT() { unsigned long i; \
 			TCHECK2(bp[0], sizeof(int32_t)); \
 			i = EXTRACT_32BITS(bp); \
 			bp += sizeof(int32_t); \
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," %lu", i); \
+			ARGUSBUF_APPEND(" %lu", i); \
 		}
 
 #define DATEOUT() { time_t t; struct tm *tm; char str[256]; \
@@ -603,25 +603,25 @@ rx_print(register const u_char *bp, int length, int sport, int dport)
 			bp += sizeof(int32_t); \
 			tm = localtime(&t); \
 			strftime(str, 256, "%Y/%m/%d %T", tm); \
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", str); \
+			ARGUSBUF_APPEND(" %s", str); \
 		}
 
 #define STOREATTROUT() { unsigned long mask, i; \
 			TCHECK2(bp[0], (sizeof(int32_t)*6)); \
 			mask = EXTRACT_32BITS(bp); bp += sizeof(int32_t); \
-			if (mask) sprintf(&ArgusBuf[strlen(ArgusBuf)]," StoreStatus"); \
-		        if (mask & 1) { sprintf(&ArgusBuf[strlen(ArgusBuf)]," date"); DATEOUT(); } \
+			if (mask) ARGUSBUF_APPEND(" StoreStatus"); \
+		        if (mask & 1) { ARGUSBUF_APPEND(" date"); DATEOUT(); } \
 			else bp += sizeof(int32_t); \
 			i = EXTRACT_32BITS(bp); bp += sizeof(int32_t); \
-		        if (mask & 2) sprintf(&ArgusBuf[strlen(ArgusBuf)]," owner %lu", i);  \
+		        if (mask & 2) ARGUSBUF_APPEND(" owner %lu", i);  \
 			i = EXTRACT_32BITS(bp); bp += sizeof(int32_t); \
-		        if (mask & 4) sprintf(&ArgusBuf[strlen(ArgusBuf)]," group %lu", i); \
+		        if (mask & 4) ARGUSBUF_APPEND(" group %lu", i); \
 			i = EXTRACT_32BITS(bp); bp += sizeof(int32_t); \
-		        if (mask & 8) sprintf(&ArgusBuf[strlen(ArgusBuf)]," mode %lo", i & 07777); \
+		        if (mask & 8) ARGUSBUF_APPEND(" mode %lo", i & 07777); \
 			i = EXTRACT_32BITS(bp); bp += sizeof(int32_t); \
-		        if (mask & 16) sprintf(&ArgusBuf[strlen(ArgusBuf)]," segsize %lu", i); \
+		        if (mask & 16) ARGUSBUF_APPEND(" segsize %lu", i); \
 			/* undocumented in 3.3 docu */ \
-		        if (mask & 1024) sprintf(&ArgusBuf[strlen(ArgusBuf)]," fsync");  \
+		        if (mask & 1024) ARGUSBUF_APPEND(" fsync");  \
 		}
 
 #define UBIK_VERSIONOUT() {int32_t epoch; int32_t counter; \
@@ -630,24 +630,24 @@ rx_print(register const u_char *bp, int length, int sport, int dport)
 			bp += sizeof(int32_t); \
 			counter = EXTRACT_32BITS(bp); \
 			bp += sizeof(int32_t); \
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," %d.%d", epoch, counter); \
+			ARGUSBUF_APPEND(" %d.%d", epoch, counter); \
 		}
 
 #define AFSUUIDOUT() {u_int32_t temp; int i; \
 			TCHECK2(bp[0], 11*sizeof(u_int32_t)); \
 			temp = EXTRACT_32BITS(bp); \
 			bp += sizeof(u_int32_t); \
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," %08x", temp); \
+			ARGUSBUF_APPEND(" %08x", temp); \
 			temp = EXTRACT_32BITS(bp); \
 			bp += sizeof(u_int32_t); \
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"%04x", temp); \
+			ARGUSBUF_APPEND("%04x", temp); \
 			temp = EXTRACT_32BITS(bp); \
 			bp += sizeof(u_int32_t); \
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"%04x", temp); \
+			ARGUSBUF_APPEND("%04x", temp); \
 			for (i = 0; i < 8; i++) { \
 				temp = EXTRACT_32BITS(bp); \
 				bp += sizeof(u_int32_t); \
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02x", (unsigned char) temp); \
+				ARGUSBUF_APPEND("%02x", (unsigned char) temp); \
 			} \
 		}
 
@@ -667,9 +667,9 @@ rx_print(register const u_char *bp, int length, int sport, int dport)
 				bp += sizeof(int32_t); \
 			} \
 			s[(MAX)] = '\0'; \
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," \""); \
-			fn_print(s, NULL, ArgusBuf); \
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"\""); \
+			ARGUSBUF_APPEND(" \""); \
+			fn_print(s, NULL, ArgusBuf, MAXSTRLEN - strlen(ArgusBuf)); \
+			ARGUSBUF_APPEND("\""); \
 		}
 
 /*
@@ -696,7 +696,7 @@ fs_print(register const u_char *bp, int length)
 
 	fs_op = EXTRACT_32BITS(bp + sizeof(struct rx_header));
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," fs call %s", tok2str(fs_req, "op#%d", fs_op));
+	ARGUSBUF_APPEND(" fs call %s", tok2str(fs_req, "op#%d", fs_op));
 
 	/*
 	 * Print out arguments to some of the AFS calls.  This stuff is
@@ -712,9 +712,9 @@ fs_print(register const u_char *bp, int length)
 	switch (fs_op) {
 		case 130:	/* Fetch data */
 			FIDOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," offset");
+			ARGUSBUF_APPEND(" offset");
 			UINTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," length");
+			ARGUSBUF_APPEND(" length");
 			UINTOUT();
 			break;
 		case 131:	/* Fetch ACL */
@@ -734,11 +734,11 @@ fs_print(register const u_char *bp, int length)
 		case 133:	/* Store data */
 			FIDOUT();
 			STOREATTROUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," offset");
+			ARGUSBUF_APPEND(" offset");
 			UINTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," length");
+			ARGUSBUF_APPEND(" length");
 			UINTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," flen");
+			ARGUSBUF_APPEND(" flen");
 			UINTOUT();
 			break;
 		case 134:	/* Store ACL */
@@ -767,23 +767,23 @@ fs_print(register const u_char *bp, int length)
 			STROUT(AFSNAMEMAX);
 			break;
 		case 138:	/* Rename file */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," old");
+			ARGUSBUF_APPEND(" old");
 			FIDOUT();
 			STROUT(AFSNAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," new");
+			ARGUSBUF_APPEND(" new");
 			FIDOUT();
 			STROUT(AFSNAMEMAX);
 			break;
 		case 139:	/* Symlink */
 			FIDOUT();
 			STROUT(AFSNAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," link to");
+			ARGUSBUF_APPEND(" link to");
 			STROUT(AFSNAMEMAX);
 			break;
 		case 140:	/* Link */
 			FIDOUT();
 			STROUT(AFSNAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," link to");
+			ARGUSBUF_APPEND(" link to");
 			FIDOUT();
 			break;
 		case 148:	/* Get volume info */
@@ -791,11 +791,11 @@ fs_print(register const u_char *bp, int length)
 			break;
 		case 149:	/* Get volume stats */
 		case 150:	/* Set volume stats */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," volid");
+			ARGUSBUF_APPEND(" volid");
 			UINTOUT();
 			break;
 		case 154:	/* New get volume info */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," volname");
+			ARGUSBUF_APPEND(" volname");
 			STROUT(AFSNAMEMAX);
 			break;
 		case 155:	/* Bulk stat */
@@ -808,10 +808,10 @@ fs_print(register const u_char *bp, int length)
 			for (i = 0; i < j; i++) {
 				FIDOUT();
 				if (i != j - 1)
-					sprintf(&ArgusBuf[strlen(ArgusBuf)],",");
+					ARGUSBUF_APPEND(",");
 			}
 			if (j == 0)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," <none!>");
+				ARGUSBUF_APPEND(" <none!>");
 		}
 		default:
 			;
@@ -820,7 +820,7 @@ fs_print(register const u_char *bp, int length)
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|fs]");
+	ARGUSBUF_APPEND(" [|fs]");
 }
 
 /*
@@ -843,7 +843,7 @@ fs_reply_print(register const u_char *bp, int length, int32_t opcode)
 	 * gleaned from fsint/afsint.xg
 	 */
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," fs reply %s", tok2str(fs_req, "op#%d", opcode));
+	ARGUSBUF_APPEND(" fs reply %s", tok2str(fs_req, "op#%d", opcode));
 
 	bp += sizeof(struct rx_header);
 
@@ -868,11 +868,11 @@ fs_reply_print(register const u_char *bp, int length, int32_t opcode)
 		}
 		case 137:	/* Create file */
 		case 141:	/* MakeDir */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," new");
+			ARGUSBUF_APPEND(" new");
 			FIDOUT();
 			break;
 		case 151:	/* Get root volume */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," root volume");
+			ARGUSBUF_APPEND(" root volume");
 			STROUT(AFSNAMEMAX);
 			break;
 		case 153:	/* Get time */
@@ -891,15 +891,15 @@ fs_reply_print(register const u_char *bp, int length, int32_t opcode)
 		i = (int) EXTRACT_32BITS(bp);
 		bp += sizeof(int32_t);
 
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," error %s", tok2str(afs_fs_errors, "#%d", i));
+		ARGUSBUF_APPEND(" error %s", tok2str(afs_fs_errors, "#%d", i));
 	} else {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," strange fs reply of type %d", rxh->type);
+		ARGUSBUF_APPEND(" strange fs reply of type %d", rxh->type);
 	}
 
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|fs]");
+	ARGUSBUF_APPEND(" [|fs]");
 }
 
 /*
@@ -940,29 +940,29 @@ acl_print(u_char *s, int maxsize, u_char *end)
 
 #define ACLOUT(acl) \
 	if (acl & PRSFS_READ) \
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"r"); \
+		ARGUSBUF_APPEND("r"); \
 	if (acl & PRSFS_LOOKUP) \
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"l"); \
+		ARGUSBUF_APPEND("l"); \
 	if (acl & PRSFS_INSERT) \
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"i"); \
+		ARGUSBUF_APPEND("i"); \
 	if (acl & PRSFS_DELETE) \
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"d"); \
+		ARGUSBUF_APPEND("d"); \
 	if (acl & PRSFS_WRITE) \
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"w"); \
+		ARGUSBUF_APPEND("w"); \
 	if (acl & PRSFS_LOCK) \
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"k"); \
+		ARGUSBUF_APPEND("k"); \
 	if (acl & PRSFS_ADMINISTER) \
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"a");
+		ARGUSBUF_APPEND("a");
 
 	for (i = 0; i < pos; i++) {
 		if (sscanf((char *) s, "%s %d\n%n", user, &acl, &n) != 2)
 			goto finish;
 		s += n;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," +{");
-		fn_print((u_char *)user, NULL, ArgusBuf);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+		ARGUSBUF_APPEND(" +{");
+		fn_print((u_char *)user, NULL, ArgusBuf, MAXSTRLEN - strlen(ArgusBuf));
+		ARGUSBUF_APPEND(" ");
 		ACLOUT(acl);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"}");
+		ARGUSBUF_APPEND("}");
 		if (s > end)
 			goto finish;
 	}
@@ -971,11 +971,11 @@ acl_print(u_char *s, int maxsize, u_char *end)
 		if (sscanf((char *) s, "%s %d\n%n", user, &acl, &n) != 2)
 			goto finish;
 		s += n;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," -{");
-		fn_print((u_char *)user, NULL, ArgusBuf);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+		ARGUSBUF_APPEND(" -{");
+		fn_print((u_char *)user, NULL, ArgusBuf, MAXSTRLEN - strlen(ArgusBuf));
+		ARGUSBUF_APPEND(" ");
 		ACLOUT(acl);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"}");
+		ARGUSBUF_APPEND("}");
 		if (s > end)
 			goto finish;
 	}
@@ -1011,7 +1011,7 @@ cb_print(register const u_char *bp, int length)
 
 	cb_op = EXTRACT_32BITS(bp + sizeof(struct rx_header));
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," cb call %s", tok2str(cb_req, "op#%d", cb_op));
+	ARGUSBUF_APPEND(" cb call %s", tok2str(cb_req, "op#%d", cb_op));
 
 	bp += sizeof(struct rx_header) + 4;
 
@@ -1031,22 +1031,22 @@ cb_print(register const u_char *bp, int length)
 			for (i = 0; i < j; i++) {
 				FIDOUT();
 				if (i != j - 1)
-					sprintf(&ArgusBuf[strlen(ArgusBuf)],",");
+					ARGUSBUF_APPEND(",");
 			}
 
 			if (j == 0)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," <none!>");
+				ARGUSBUF_APPEND(" <none!>");
 
 			j = EXTRACT_32BITS(bp);
 			bp += sizeof(int32_t);
 
 			if (j != 0)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],";");
+				ARGUSBUF_APPEND(";");
 
 			for (i = 0; i < j; i++) {
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," ver");
+				ARGUSBUF_APPEND(" ver");
 				INTOUT();
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," expires");
+				ARGUSBUF_APPEND(" expires");
 				DATEOUT();
 				TCHECK2(bp[0], 4);
 				t = EXTRACT_32BITS(bp);
@@ -1055,7 +1055,7 @@ cb_print(register const u_char *bp, int length)
 			}
 		}
 		case 214: {
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," afsuuid");
+			ARGUSBUF_APPEND(" afsuuid");
 			AFSUUIDOUT();
 			break;
 		}
@@ -1066,7 +1066,7 @@ cb_print(register const u_char *bp, int length)
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|cb]");
+	ARGUSBUF_APPEND(" [|cb]");
 }
 
 /*
@@ -1088,7 +1088,7 @@ cb_reply_print(register const u_char *bp, int length, int32_t opcode)
 	 * gleaned from fsint/afscbint.xg
 	 */
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," cb reply %s", tok2str(cb_req, "op#%d", opcode));
+	ARGUSBUF_APPEND(" cb reply %s", tok2str(cb_req, "op#%d", opcode));
 
 	bp += sizeof(struct rx_header);
 
@@ -1108,14 +1108,14 @@ cb_reply_print(register const u_char *bp, int length, int32_t opcode)
 		/*
 		 * Otherwise, just print out the return code
 		 */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," errcode");
+		ARGUSBUF_APPEND(" errcode");
 		INTOUT();
 	}
 
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|cb]");
+	ARGUSBUF_APPEND(" [|cb]");
 }
 
 /*
@@ -1142,14 +1142,14 @@ prot_print(register const u_char *bp, int length)
 
 	pt_op = EXTRACT_32BITS(bp + sizeof(struct rx_header));
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," pt");
+	ARGUSBUF_APPEND(" pt");
 
 	if (is_ubik(pt_op)) {
 		ubik_print(bp);
 		return;
 	}
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," call %s", tok2str(pt_req, "op#%d", pt_op));
+	ARGUSBUF_APPEND(" call %s", tok2str(pt_req, "op#%d", pt_op));
 
 	/*
 	 * Decode some of the arguments to the PT calls
@@ -1160,9 +1160,9 @@ prot_print(register const u_char *bp, int length)
 	switch (pt_op) {
 		case 500:	/* I New User */
 			STROUT(PRNAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," id");
+			ARGUSBUF_APPEND(" id");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," oldid");
+			ARGUSBUF_APPEND(" oldid");
 			INTOUT();
 			break;
 		case 501:	/* Where is it */
@@ -1173,19 +1173,19 @@ prot_print(register const u_char *bp, int length)
 		case 517:	/* List owned */
 		case 518:	/* Get CPS2 */
 		case 519:	/* Get host CPS */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," id");
+			ARGUSBUF_APPEND(" id");
 			INTOUT();
 			break;
 		case 502:	/* Dump entry */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," pos");
+			ARGUSBUF_APPEND(" pos");
 			INTOUT();
 			break;
 		case 503:	/* Add to group */
 		case 507:	/* Remove from group */
 		case 515:	/* Is a member of? */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," uid");
+			ARGUSBUF_APPEND(" uid");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," gid");
+			ARGUSBUF_APPEND(" gid");
 			INTOUT();
 			break;
 		case 504:	/* Name to ID */
@@ -1206,46 +1206,46 @@ prot_print(register const u_char *bp, int length)
 				VECOUT(PRNAMEMAX);
 			}
 			if (j == 0)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," <none!>");
+				ARGUSBUF_APPEND(" <none!>");
 		}
 			break;
 		case 505:	/* Id to name */
 		{
 			unsigned long j;
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," ids:");
+			ARGUSBUF_APPEND(" ids:");
 			TCHECK2(bp[0], 4);
 			i = EXTRACT_32BITS(bp);
 			bp += sizeof(int32_t);
 			for (j = 0; j < i; j++)
 				INTOUT();
 			if (j == 0)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," <none!>");
+				ARGUSBUF_APPEND(" <none!>");
 		}
 			break;
 		case 509:	/* New entry */
 			STROUT(PRNAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," flag");
+			ARGUSBUF_APPEND(" flag");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," oid");
+			ARGUSBUF_APPEND(" oid");
 			INTOUT();
 			break;
 		case 511:	/* Set max */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," id");
+			ARGUSBUF_APPEND(" id");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," gflag");
+			ARGUSBUF_APPEND(" gflag");
 			INTOUT();
 			break;
 		case 513:	/* Change entry */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," id");
+			ARGUSBUF_APPEND(" id");
 			INTOUT();
 			STROUT(PRNAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," oldid");
+			ARGUSBUF_APPEND(" oldid");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," newid");
+			ARGUSBUF_APPEND(" newid");
 			INTOUT();
 			break;
 		case 520:	/* Update entry */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," id");
+			ARGUSBUF_APPEND(" id");
 			INTOUT();
 			STROUT(PRNAMEMAX);
 			break;
@@ -1257,7 +1257,7 @@ prot_print(register const u_char *bp, int length)
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|pt]");
+	ARGUSBUF_APPEND(" [|pt]");
 }
 
 /*
@@ -1281,14 +1281,14 @@ prot_reply_print(register const u_char *bp, int length, int32_t opcode)
 	 * Ubik call, however.
 	 */
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," pt");
+	ARGUSBUF_APPEND(" pt");
 
 	if (is_ubik(opcode)) {
 		ubik_reply_print(bp, length, opcode);
 		return;
 	}
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," reply %s", tok2str(pt_req, "op#%d", opcode));
+	ARGUSBUF_APPEND(" reply %s", tok2str(pt_req, "op#%d", opcode));
 
 	bp += sizeof(struct rx_header);
 
@@ -1301,14 +1301,14 @@ prot_reply_print(register const u_char *bp, int length, int32_t opcode)
 		case 504:		/* Name to ID */
 		{
 			unsigned long j;
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," ids:");
+			ARGUSBUF_APPEND(" ids:");
 			TCHECK2(bp[0], 4);
 			i = EXTRACT_32BITS(bp);
 			bp += sizeof(int32_t);
 			for (j = 0; j < i; j++)
 				INTOUT();
 			if (j == 0)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," <none!>");
+				ARGUSBUF_APPEND(" <none!>");
 		}
 			break;
 		case 505:		/* ID to name */
@@ -1329,7 +1329,7 @@ prot_reply_print(register const u_char *bp, int length, int32_t opcode)
 				VECOUT(PRNAMEMAX);
 			}
 			if (j == 0)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," <none!>");
+				ARGUSBUF_APPEND(" <none!>");
 		}
 			break;
 		case 508:		/* Get CPS */
@@ -1346,13 +1346,13 @@ prot_reply_print(register const u_char *bp, int length, int32_t opcode)
 				INTOUT();
 			}
 			if (j == 0)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," <none!>");
+				ARGUSBUF_APPEND(" <none!>");
 		}
 			break;
 		case 510:		/* List max */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," maxuid");
+			ARGUSBUF_APPEND(" maxuid");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," maxgid");
+			ARGUSBUF_APPEND(" maxgid");
 			INTOUT();
 			break;
 		default:
@@ -1362,14 +1362,14 @@ prot_reply_print(register const u_char *bp, int length, int32_t opcode)
 		/*
 		 * Otherwise, just print out the return code
 		 */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," errcode");
+		ARGUSBUF_APPEND(" errcode");
 		INTOUT();
 	}
 
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|pt]");
+	ARGUSBUF_APPEND(" [|pt]");
 }
 
 /*
@@ -1396,13 +1396,13 @@ vldb_print(register const u_char *bp, int length)
 
 	vldb_op = EXTRACT_32BITS(bp + sizeof(struct rx_header));
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," vldb");
+	ARGUSBUF_APPEND(" vldb");
 
 	if (is_ubik(vldb_op)) {
 		ubik_print(bp);
 		return;
 	}
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," call %s", tok2str(vldb_req, "op#%d", vldb_op));
+	ARGUSBUF_APPEND(" call %s", tok2str(vldb_req, "op#%d", vldb_op));
 
 	/*
 	 * Decode some of the arguments to the VLDB calls
@@ -1421,13 +1421,13 @@ vldb_print(register const u_char *bp, int length)
 		case 508:	/* Set lock */
 		case 509:	/* Release lock */
 		case 518:	/* Get entry by ID N */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," volid");
+			ARGUSBUF_APPEND(" volid");
 			INTOUT();
 			TCHECK2(bp[0], sizeof(int32_t));
 			i = EXTRACT_32BITS(bp);
 			bp += sizeof(int32_t);
 			if (i <= 2)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," type %s", voltype[i]);
+				ARGUSBUF_APPEND(" type %s", voltype[i]);
 			break;
 		case 504:	/* Get entry by name */
 		case 519:	/* Get entry by name N */
@@ -1436,23 +1436,23 @@ vldb_print(register const u_char *bp, int length)
 			STROUT(VLNAMEMAX);
 			break;
 		case 505:	/* Get new vol id */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," bump");
+			ARGUSBUF_APPEND(" bump");
 			INTOUT();
 			break;
 		case 506:	/* Replace entry */
 		case 520:	/* Replace entry N */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," volid");
+			ARGUSBUF_APPEND(" volid");
 			INTOUT();
 			TCHECK2(bp[0], sizeof(int32_t));
 			i = EXTRACT_32BITS(bp);
 			bp += sizeof(int32_t);
 			if (i <= 2)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)]," type %s", voltype[i]);
+				ARGUSBUF_APPEND(" type %s", voltype[i]);
 			VECOUT(VLNAMEMAX);
 			break;
 		case 510:	/* List entry */
 		case 521:	/* List entry N */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," index");
+			ARGUSBUF_APPEND(" index");
 			INTOUT();
 			break;
 		default:
@@ -1462,7 +1462,7 @@ vldb_print(register const u_char *bp, int length)
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|vldb]");
+	ARGUSBUF_APPEND(" [|vldb]");
 }
 
 /*
@@ -1486,14 +1486,14 @@ vldb_reply_print(register const u_char *bp, int length, int32_t opcode)
 	 * Ubik call, however.
 	 */
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," vldb");
+	ARGUSBUF_APPEND(" vldb");
 
 	if (is_ubik(opcode)) {
 		ubik_reply_print(bp, length, opcode);
 		return;
 	}
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," reply %s", tok2str(vldb_req, "op#%d", opcode));
+	ARGUSBUF_APPEND(" reply %s", tok2str(vldb_req, "op#%d", opcode));
 
 	bp += sizeof(struct rx_header);
 
@@ -1504,9 +1504,9 @@ vldb_reply_print(register const u_char *bp, int length, int32_t opcode)
 	if (rxh->type == RX_PACKET_TYPE_DATA)
 		switch (opcode) {
 		case 510:	/* List entry */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," count");
+			ARGUSBUF_APPEND(" count");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," nextindex");
+			ARGUSBUF_APPEND(" nextindex");
 			INTOUT();
 		case 503:	/* Get entry by id */
 		case 504:	/* Get entry by name */
@@ -1514,83 +1514,83 @@ vldb_reply_print(register const u_char *bp, int length, int32_t opcode)
 			VECOUT(VLNAMEMAX);
 			TCHECK2(bp[0], sizeof(int32_t));
 			bp += sizeof(int32_t);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," numservers");
+			ARGUSBUF_APPEND(" numservers");
 			TCHECK2(bp[0], sizeof(int32_t));
 			nservers = EXTRACT_32BITS(bp);
 			bp += sizeof(int32_t);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," %lu", nservers);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," servers");
+			ARGUSBUF_APPEND(" %lu", nservers);
+			ARGUSBUF_APPEND(" servers");
 			for (i = 0; i < 8; i++) {
 				TCHECK2(bp[0], sizeof(int32_t));
 				if (i < nservers)
-					sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s",
+					ARGUSBUF_APPEND(" %s",
 					   intoa(((struct in_addr *) bp)->s_addr));
 				bp += sizeof(int32_t);
 			}
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," partitions");
+			ARGUSBUF_APPEND(" partitions");
 			for (i = 0; i < 8; i++) {
 				TCHECK2(bp[0], sizeof(int32_t));
 				j = EXTRACT_32BITS(bp);
 				if (i < nservers && j <= 26)
-					sprintf(&ArgusBuf[strlen(ArgusBuf)]," %c", 'a' + (int)j);
+					ARGUSBUF_APPEND(" %c", 'a' + (int)j);
 				else if (i < nservers)
-					sprintf(&ArgusBuf[strlen(ArgusBuf)]," %lu", j);
+					ARGUSBUF_APPEND(" %lu", j);
 				bp += sizeof(int32_t);
 			}
 			TCHECK2(bp[0], 8 * sizeof(int32_t));
 			bp += 8 * sizeof(int32_t);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," rwvol");
+			ARGUSBUF_APPEND(" rwvol");
 			UINTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," rovol");
+			ARGUSBUF_APPEND(" rovol");
 			UINTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," backup");
+			ARGUSBUF_APPEND(" backup");
 			UINTOUT();
 		}
 			break;
 		case 505:	/* Get new volume ID */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," newvol");
+			ARGUSBUF_APPEND(" newvol");
 			UINTOUT();
 			break;
 		case 521:	/* List entry */
 		case 529:	/* List entry U */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," count");
+			ARGUSBUF_APPEND(" count");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," nextindex");
+			ARGUSBUF_APPEND(" nextindex");
 			INTOUT();
 		case 518:	/* Get entry by ID N */
 		case 519:	/* Get entry by name N */
 		{	unsigned long nservers, j;
 			VECOUT(VLNAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," numservers");
+			ARGUSBUF_APPEND(" numservers");
 			TCHECK2(bp[0], sizeof(int32_t));
 			nservers = EXTRACT_32BITS(bp);
 			bp += sizeof(int32_t);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," %lu", nservers);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," servers");
+			ARGUSBUF_APPEND(" %lu", nservers);
+			ARGUSBUF_APPEND(" servers");
 			for (i = 0; i < 13; i++) {
 				TCHECK2(bp[0], sizeof(int32_t));
 				if (i < nservers)
-					sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s",
+					ARGUSBUF_APPEND(" %s",
 					   intoa(((struct in_addr *) bp)->s_addr));
 				bp += sizeof(int32_t);
 			}
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," partitions");
+			ARGUSBUF_APPEND(" partitions");
 			for (i = 0; i < 13; i++) {
 				TCHECK2(bp[0], sizeof(int32_t));
 				j = EXTRACT_32BITS(bp);
 				if (i < nservers && j <= 26)
-					sprintf(&ArgusBuf[strlen(ArgusBuf)]," %c", 'a' + (int)j);
+					ARGUSBUF_APPEND(" %c", 'a' + (int)j);
 				else if (i < nservers)
-					sprintf(&ArgusBuf[strlen(ArgusBuf)]," %lu", j);
+					ARGUSBUF_APPEND(" %lu", j);
 				bp += sizeof(int32_t);
 			}
 			TCHECK2(bp[0], 13 * sizeof(int32_t));
 			bp += 13 * sizeof(int32_t);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," rwvol");
+			ARGUSBUF_APPEND(" rwvol");
 			UINTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," rovol");
+			ARGUSBUF_APPEND(" rovol");
 			UINTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," backup");
+			ARGUSBUF_APPEND(" backup");
 			UINTOUT();
 		}
 			break;
@@ -1598,15 +1598,15 @@ vldb_reply_print(register const u_char *bp, int length, int32_t opcode)
 		case 527:	/* Get entry by name U */
 		{	unsigned long nservers, j;
 			VECOUT(VLNAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," numservers");
+			ARGUSBUF_APPEND(" numservers");
 			TCHECK2(bp[0], sizeof(int32_t));
 			nservers = EXTRACT_32BITS(bp);
 			bp += sizeof(int32_t);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," %lu", nservers);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," servers");
+			ARGUSBUF_APPEND(" %lu", nservers);
+			ARGUSBUF_APPEND(" servers");
 			for (i = 0; i < 13; i++) {
 				if (i < nservers) {
-					sprintf(&ArgusBuf[strlen(ArgusBuf)]," afsuuid");
+					ARGUSBUF_APPEND(" afsuuid");
 					AFSUUIDOUT();
 				} else {
 					TCHECK2(bp[0], 44);
@@ -1615,23 +1615,23 @@ vldb_reply_print(register const u_char *bp, int length, int32_t opcode)
 			}
 			TCHECK2(bp[0], 4 * 13);
 			bp += 4 * 13;
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," partitions");
+			ARGUSBUF_APPEND(" partitions");
 			for (i = 0; i < 13; i++) {
 				TCHECK2(bp[0], sizeof(int32_t));
 				j = EXTRACT_32BITS(bp);
 				if (i < nservers && j <= 26)
-					sprintf(&ArgusBuf[strlen(ArgusBuf)]," %c", 'a' + (int)j);
+					ARGUSBUF_APPEND(" %c", 'a' + (int)j);
 				else if (i < nservers)
-					sprintf(&ArgusBuf[strlen(ArgusBuf)]," %lu", j);
+					ARGUSBUF_APPEND(" %lu", j);
 				bp += sizeof(int32_t);
 			}
 			TCHECK2(bp[0], 13 * sizeof(int32_t));
 			bp += 13 * sizeof(int32_t);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," rwvol");
+			ARGUSBUF_APPEND(" rwvol");
 			UINTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," rovol");
+			ARGUSBUF_APPEND(" rovol");
 			UINTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," backup");
+			ARGUSBUF_APPEND(" backup");
 			UINTOUT();
 		}
 		default:
@@ -1642,14 +1642,14 @@ vldb_reply_print(register const u_char *bp, int length, int32_t opcode)
 		/*
 		 * Otherwise, just print out the return code
 		 */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," errcode");
+		ARGUSBUF_APPEND(" errcode");
 		INTOUT();
 	}
 
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|vldb]");
+	ARGUSBUF_APPEND(" [|vldb]");
 }
 
 /*
@@ -1675,7 +1675,7 @@ kauth_print(register const u_char *bp, int length)
 
 	kauth_op = EXTRACT_32BITS(bp + sizeof(struct rx_header));
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," kauth");
+	ARGUSBUF_APPEND(" kauth");
 
 	if (is_ubik(kauth_op)) {
 		ubik_print(bp);
@@ -1683,7 +1683,7 @@ kauth_print(register const u_char *bp, int length)
 	}
 
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," call %s", tok2str(kauth_req, "op#%d", kauth_op));
+	ARGUSBUF_APPEND(" call %s", tok2str(kauth_req, "op#%d", kauth_op));
 
 	/*
 	 * Decode some of the arguments to the KA calls
@@ -1702,7 +1702,7 @@ kauth_print(register const u_char *bp, int length)
 		case 8:		/* Get entry */
 		case 14:	/* Unlock */
 		case 15:	/* Lock status */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," principal");
+			ARGUSBUF_APPEND(" principal");
 			STROUT(KANAMEMAX);
 			STROUT(KANAMEMAX);
 			break;
@@ -1710,29 +1710,29 @@ kauth_print(register const u_char *bp, int length)
 		case 23:	/* GetTicket */
 		{
 			int i;
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," kvno");
+			ARGUSBUF_APPEND(" kvno");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," domain");
+			ARGUSBUF_APPEND(" domain");
 			STROUT(KANAMEMAX);
 			TCHECK2(bp[0], sizeof(int32_t));
 			i = (int) EXTRACT_32BITS(bp);
 			bp += sizeof(int32_t);
 			TCHECK2(bp[0], i);
 			bp += i;
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," principal");
+			ARGUSBUF_APPEND(" principal");
 			STROUT(KANAMEMAX);
 			STROUT(KANAMEMAX);
 			break;
 		}
 		case 4:		/* Set Password */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," principal");
+			ARGUSBUF_APPEND(" principal");
 			STROUT(KANAMEMAX);
 			STROUT(KANAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," kvno");
+			ARGUSBUF_APPEND(" kvno");
 			INTOUT();
 			break;
 		case 12:	/* Get password */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," name");
+			ARGUSBUF_APPEND(" name");
 			STROUT(KANAMEMAX);
 			break;
 		default:
@@ -1742,7 +1742,7 @@ kauth_print(register const u_char *bp, int length)
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|kauth]");
+	ARGUSBUF_APPEND(" [|kauth]");
 }
 
 /*
@@ -1764,14 +1764,14 @@ kauth_reply_print(register const u_char *bp, int length, int32_t opcode)
 	 * gleaned from kauth/kauth.rg
 	 */
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," kauth");
+	ARGUSBUF_APPEND(" kauth");
 
 	if (is_ubik(opcode)) {
 		ubik_reply_print(bp, length, opcode);
 		return;
 	}
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," reply %s", tok2str(kauth_req, "op#%d", opcode));
+	ARGUSBUF_APPEND(" reply %s", tok2str(kauth_req, "op#%d", opcode));
 
 	bp += sizeof(struct rx_header);
 
@@ -1786,14 +1786,14 @@ kauth_reply_print(register const u_char *bp, int length, int32_t opcode)
 		/*
 		 * Otherwise, just print out the return code
 		 */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," errcode");
+		ARGUSBUF_APPEND(" errcode");
 		INTOUT();
 	}
 
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|kauth]");
+	ARGUSBUF_APPEND(" [|kauth]");
 }
 
 /*
@@ -1819,7 +1819,7 @@ vol_print(register const u_char *bp, int length)
 
 	vol_op = EXTRACT_32BITS(bp + sizeof(struct rx_header));
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," vol call %s", tok2str(vol_req, "op#%d", vol_op));
+	ARGUSBUF_APPEND(" vol call %s", tok2str(vol_req, "op#%d", vol_op));
 
 	/*
 	 * Normally there would be a switch statement here to decode the
@@ -1831,7 +1831,7 @@ vol_print(register const u_char *bp, int length)
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|vol]");
+	ARGUSBUF_APPEND(" [|vol]");
 }
 
 /*
@@ -1853,7 +1853,7 @@ vol_reply_print(register const u_char *bp, int length, int32_t opcode)
 	 * gleaned from volser/volint.xg
 	 */
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," vol reply %s", tok2str(vol_req, "op#%d", opcode));
+	ARGUSBUF_APPEND(" vol reply %s", tok2str(vol_req, "op#%d", opcode));
 
 	bp += sizeof(struct rx_header);
 
@@ -1868,14 +1868,14 @@ vol_reply_print(register const u_char *bp, int length, int32_t opcode)
 		/*
 		 * Otherwise, just print out the return code
 		 */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," errcode");
+		ARGUSBUF_APPEND(" errcode");
 		INTOUT();
 	}
 
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|vol]");
+	ARGUSBUF_APPEND(" [|vol]");
 }
 
 /*
@@ -1901,7 +1901,7 @@ bos_print(register const u_char *bp, int length)
 
 	bos_op = EXTRACT_32BITS(bp + sizeof(struct rx_header));
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," bos call %s", tok2str(bos_req, "op#%d", bos_op));
+	ARGUSBUF_APPEND(" bos call %s", tok2str(bos_req, "op#%d", bos_op));
 
 	/*
 	 * Decode some of the arguments to the BOS calls
@@ -1911,9 +1911,9 @@ bos_print(register const u_char *bp, int length)
 
 	switch (bos_op) {
 		case 80:	/* Create B node */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," type");
+			ARGUSBUF_APPEND(" type");
 			STROUT(BOSNAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," instance");
+			ARGUSBUF_APPEND(" instance");
 			STROUT(BOSNAMEMAX);
 			break;
 		case 81:	/* Delete B node */
@@ -1934,12 +1934,12 @@ bos_print(register const u_char *bp, int length)
 		case 82:	/* Set status */
 		case 98:	/* Set T status */
 			STROUT(BOSNAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," status");
+			ARGUSBUF_APPEND(" status");
 			INTOUT();
 			break;
 		case 86:	/* Get instance parm */
 			STROUT(BOSNAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," num");
+			ARGUSBUF_APPEND(" num");
 			INTOUT();
 			break;
 		case 84:	/* Enumerate instance */
@@ -1952,11 +1952,11 @@ bos_print(register const u_char *bp, int length)
 			break;
 		case 105:	/* Install */
 			STROUT(BOSNAMEMAX);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," size");
+			ARGUSBUF_APPEND(" size");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," flags");
+			ARGUSBUF_APPEND(" flags");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," date");
+			ARGUSBUF_APPEND(" date");
 			INTOUT();
 			break;
 		default:
@@ -1966,7 +1966,7 @@ bos_print(register const u_char *bp, int length)
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|bos]");
+	ARGUSBUF_APPEND(" [|bos]");
 }
 
 /*
@@ -1988,7 +1988,7 @@ bos_reply_print(register const u_char *bp, int length, int32_t opcode)
 	 * gleaned from volser/volint.xg
 	 */
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," bos reply %s", tok2str(bos_req, "op#%d", opcode));
+	ARGUSBUF_APPEND(" bos reply %s", tok2str(bos_req, "op#%d", opcode));
 
 	bp += sizeof(struct rx_header);
 
@@ -2003,14 +2003,14 @@ bos_reply_print(register const u_char *bp, int length, int32_t opcode)
 		/*
 		 * Otherwise, just print out the return code
 		 */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," errcode");
+		ARGUSBUF_APPEND(" errcode");
 		INTOUT();
 	}
 
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|bos]");
+	ARGUSBUF_APPEND(" [|bos]");
 }
 
 /*
@@ -2044,7 +2044,7 @@ ubik_print(register const u_char *bp)
 
 	ubik_op = EXTRACT_32BITS(bp + sizeof(struct rx_header));
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," ubik call %s", tok2str(ubik_req, "op#%d", ubik_op));
+	ARGUSBUF_APPEND(" ubik call %s", tok2str(ubik_req, "op#%d", ubik_op));
 
 	/*
 	 * Decode some of the arguments to the Ubik calls
@@ -2057,16 +2057,16 @@ ubik_print(register const u_char *bp)
 			TCHECK2(bp[0], 4);
 			temp = EXTRACT_32BITS(bp);
 			bp += sizeof(int32_t);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," syncsite %s", temp ? "yes" : "no");
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," votestart");
+			ARGUSBUF_APPEND(" syncsite %s", temp ? "yes" : "no");
+			ARGUSBUF_APPEND(" votestart");
 			DATEOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," dbversion");
+			ARGUSBUF_APPEND(" dbversion");
 			UBIK_VERSIONOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," tid");
+			ARGUSBUF_APPEND(" tid");
 			UBIK_VERSIONOUT();
 			break;
 		case 10003:		/* Get sync site */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," site");
+			ARGUSBUF_APPEND(" site");
 			UINTOUT();
 			break;
 		case 20000:		/* Begin */
@@ -2074,56 +2074,56 @@ ubik_print(register const u_char *bp)
 		case 20007:		/* Abort */
 		case 20008:		/* Release locks */
 		case 20010:		/* Writev */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," tid");
+			ARGUSBUF_APPEND(" tid");
 			UBIK_VERSIONOUT();
 			break;
 		case 20002:		/* Lock */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," tid");
+			ARGUSBUF_APPEND(" tid");
 			UBIK_VERSIONOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," file");
+			ARGUSBUF_APPEND(" file");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," pos");
+			ARGUSBUF_APPEND(" pos");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," length");
+			ARGUSBUF_APPEND(" length");
 			INTOUT();
 			temp = EXTRACT_32BITS(bp);
 			bp += sizeof(int32_t);
 			tok2str(ubik_lock_types, "type %d", temp);
 			break;
 		case 20003:		/* Write */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," tid");
+			ARGUSBUF_APPEND(" tid");
 			UBIK_VERSIONOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," file");
+			ARGUSBUF_APPEND(" file");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," pos");
+			ARGUSBUF_APPEND(" pos");
 			INTOUT();
 			break;
 		case 20005:		/* Get file */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," file");
+			ARGUSBUF_APPEND(" file");
 			INTOUT();
 			break;
 		case 20006:		/* Send file */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," file");
+			ARGUSBUF_APPEND(" file");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," length");
+			ARGUSBUF_APPEND(" length");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," dbversion");
+			ARGUSBUF_APPEND(" dbversion");
 			UBIK_VERSIONOUT();
 			break;
 		case 20009:		/* Truncate */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," tid");
+			ARGUSBUF_APPEND(" tid");
 			UBIK_VERSIONOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," file");
+			ARGUSBUF_APPEND(" file");
 			INTOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," length");
+			ARGUSBUF_APPEND(" length");
 			INTOUT();
 			break;
 		case 20012:		/* Set version */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," tid");
+			ARGUSBUF_APPEND(" tid");
 			UBIK_VERSIONOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," oldversion");
+			ARGUSBUF_APPEND(" oldversion");
 			UBIK_VERSIONOUT();
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," newversion");
+			ARGUSBUF_APPEND(" newversion");
 			UBIK_VERSIONOUT();
 			break;
 		default:
@@ -2133,7 +2133,7 @@ ubik_print(register const u_char *bp)
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|ubik]");
+	ARGUSBUF_APPEND(" [|ubik]");
 }
 
 /*
@@ -2155,7 +2155,7 @@ ubik_reply_print(register const u_char *bp, int length, int32_t opcode)
 	 * from ubik/ubik_int.xg
 	 */
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," ubik reply %s", tok2str(ubik_req, "op#%d", opcode));
+	ARGUSBUF_APPEND(" ubik reply %s", tok2str(ubik_req, "op#%d", opcode));
 
 	bp += sizeof(struct rx_header);
 
@@ -2166,10 +2166,10 @@ ubik_reply_print(register const u_char *bp, int length, int32_t opcode)
 	if (rxh->type == RX_PACKET_TYPE_DATA)
 		switch (opcode) {
 		case 10000:		/* Beacon */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," vote no");
+			ARGUSBUF_APPEND(" vote no");
 			break;
 		case 20004:		/* Get version */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," dbversion");
+			ARGUSBUF_APPEND(" dbversion");
 			UBIK_VERSIONOUT();
 			break;
 		default:
@@ -2185,18 +2185,18 @@ ubik_reply_print(register const u_char *bp, int length, int32_t opcode)
 	else
 		switch (opcode) {
 		case 10000:		/* Beacon */
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," vote yes until");
+			ARGUSBUF_APPEND(" vote yes until");
 			DATEOUT();
 			break;
 		default:
-			sprintf(&ArgusBuf[strlen(ArgusBuf)]," errcode");
+			ARGUSBUF_APPEND(" errcode");
 			INTOUT();
 		}
 
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|ubik]");
+	ARGUSBUF_APPEND(" [|ubik]");
 }
 
 /*
@@ -2233,12 +2233,12 @@ rx_ack_print(register const u_char *bp, int length)
 	 */
 
 	if (ArgusParser->vflag > 2)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," bufspace %d maxskew %d",
+		ARGUSBUF_APPEND(" bufspace %d maxskew %d",
 		       (int) EXTRACT_16BITS(&rxa->bufferSpace),
 		       (int) EXTRACT_16BITS(&rxa->maxSkew));
 
 	firstPacket = EXTRACT_32BITS(&rxa->firstPacket);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," first %d serial %d reason %s",
+	ARGUSBUF_APPEND(" first %d serial %d reason %s",
 	       firstPacket, EXTRACT_32BITS(&rxa->serial),
 	       tok2str(rx_ack_reasons, "#%d", (int) rxa->reason));
 
@@ -2281,7 +2281,7 @@ rx_ack_print(register const u_char *bp, int length)
 				 */
 
 				if (last == -2) {
-					sprintf(&ArgusBuf[strlen(ArgusBuf)]," acked %d",
+					ARGUSBUF_APPEND(" acked %d",
 					       firstPacket + i);
 					start = i;
 				}
@@ -2296,7 +2296,7 @@ rx_ack_print(register const u_char *bp, int length)
 				 */
 
 				else if (last != i - 1) {
-					sprintf(&ArgusBuf[strlen(ArgusBuf)],",%d", firstPacket + i);
+					ARGUSBUF_APPEND(",%d", firstPacket + i);
 					start = i;
 				}
 
@@ -2322,7 +2322,7 @@ rx_ack_print(register const u_char *bp, int length)
 				 * range.
 				 */
 			} else if (last == i - 1 && start != last)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"-%d", firstPacket + i - 1);
+				ARGUSBUF_APPEND("-%d", firstPacket + i - 1);
 
 		/*
 		 * So, what's going on here?  We ran off the end of the
@@ -2336,7 +2336,7 @@ rx_ack_print(register const u_char *bp, int length)
 		 */
 
 		if (last == i - 1 && start != last)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"-%d", firstPacket + i - 1);
+			ARGUSBUF_APPEND("-%d", firstPacket + i - 1);
 
 		/*
 		 * Same as above, just without comments
@@ -2345,19 +2345,19 @@ rx_ack_print(register const u_char *bp, int length)
 		for (i = 0, start = last = -2; i < rxa->nAcks; i++)
 			if (rxa->acks[i] == RX_ACK_TYPE_NACK) {
 				if (last == -2) {
-					sprintf(&ArgusBuf[strlen(ArgusBuf)]," nacked %d",
+					ARGUSBUF_APPEND(" nacked %d",
 					       firstPacket + i);
 					start = i;
 				} else if (last != i - 1) {
-					sprintf(&ArgusBuf[strlen(ArgusBuf)],",%d", firstPacket + i);
+					ARGUSBUF_APPEND(",%d", firstPacket + i);
 					start = i;
 				}
 				last = i;
 			} else if (last == i - 1 && start != last)
-				sprintf(&ArgusBuf[strlen(ArgusBuf)],"-%d", firstPacket + i - 1);
+				ARGUSBUF_APPEND("-%d", firstPacket + i - 1);
 
 		if (last == i - 1 && start != last)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"-%d", firstPacket + i - 1);
+			ARGUSBUF_APPEND("-%d", firstPacket + i - 1);
 
 		bp += rxa->nAcks;
 	}
@@ -2372,25 +2372,25 @@ rx_ack_print(register const u_char *bp, int length)
 
 	if (ArgusParser->vflag > 1) {
 		TRUNCRET(4);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," ifmtu");
+		ARGUSBUF_APPEND(" ifmtu");
 		INTOUT();
 
 		TRUNCRET(4);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," maxmtu");
+		ARGUSBUF_APPEND(" maxmtu");
 		INTOUT();
 
 		TRUNCRET(4);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," rwind");
+		ARGUSBUF_APPEND(" rwind");
 		INTOUT();
 
 		TRUNCRET(4);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," maxpackets");
+		ARGUSBUF_APPEND(" maxpackets");
 		INTOUT();
 	}
 
 	return;
 
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|ack]");
+	ARGUSBUF_APPEND(" [|ack]");
 }
 #undef TRUNCRET

--- a/examples/radump/print-smb.c
+++ b/examples/radump/print-smb.c
@@ -107,7 +107,7 @@ trans2_findfirst(const u_char *param, const u_char *data, int pcnt, int dcnt)
 
     smb_fdata(param, fmt, param + pcnt, unicodestr);
     if (dcnt) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"data:\n");
+	ARGUSBUF_APPEND("data:\n");
 	print_data(data, dcnt);
     }
 }
@@ -141,12 +141,12 @@ trans2_qfsinfo(const u_char *param, const u_char *data, int pcnt, int dcnt)
 	smb_fdata(data, fmt, data + dcnt, unicodestr);
     }
     if (dcnt) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"data:\n");
+	ARGUSBUF_APPEND("data:\n");
 	print_data(data, dcnt);
     }
     return;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|SMB]");
+    ARGUSBUF_APPEND("[|SMB]");
     return;
 }
 
@@ -195,8 +195,8 @@ print_trans2(const u_char *words, const u_char *dat, const u_char *buf, const u_
 	fn = smbfindint(EXTRACT_LE_16BITS(w + 14 * 2), trans2_fns);
     } else {
 	if (words[0] == 0) {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s\n", fn->name);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Trans2Interim\n");
+	    ARGUSBUF_APPEND("%s\n", fn->name);
+	    ARGUSBUF_APPEND("Trans2Interim\n");
 	    return;
 	}
 	TCHECK2(w[7 * 2], 2);
@@ -206,7 +206,7 @@ print_trans2(const u_char *words, const u_char *dat, const u_char *buf, const u_
 	data = buf + EXTRACT_LE_16BITS(w + 7 * 2);
     }
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s param_length=%d data_length=%d\n", fn->name, pcnt, dcnt);
+    ARGUSBUF_APPEND("%s param_length=%d data_length=%d\n", fn->name, pcnt, dcnt);
 
     if (request) {
 	if (words[0] == 8) {
@@ -231,7 +231,7 @@ print_trans2(const u_char *words, const u_char *dat, const u_char *buf, const u_
 
     TCHECK2(*dat, 2);
     bcc = EXTRACT_LE_16BITS(dat);
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"smb_bcc=%u\n", bcc);
+    ARGUSBUF_APPEND("smb_bcc=%u\n", bcc);
     if (fn->descript.fn)
 	(*fn->descript.fn)(param, data, pcnt, dcnt);
     else {
@@ -240,7 +240,7 @@ print_trans2(const u_char *words, const u_char *dat, const u_char *buf, const u_
     }
     return;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|SMB]");
+    ARGUSBUF_APPEND("[|SMB]");
     return;
 }
 
@@ -322,7 +322,7 @@ print_browse(const u_char *param, int paramlen, const u_char *data, int datalen)
     }
     return;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|SMB]");
+    ARGUSBUF_APPEND("[|SMB]");
     return;
 }
 
@@ -374,7 +374,7 @@ print_trans(const u_char *words, const u_char *data1, const u_char *buf, const u
 
     TCHECK2(*data1, 2);
     bcc = EXTRACT_LE_16BITS(data1);
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"smb_bcc=%u\n", bcc);
+    ARGUSBUF_APPEND("smb_bcc=%u\n", bcc);
     if (bcc > 0) {
 	smb_fdata(data1 + 2, f2, maxbuf - (paramlen + datalen), unicodestr);
 
@@ -395,7 +395,7 @@ print_trans(const u_char *words, const u_char *data1, const u_char *buf, const u
     }
     return;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|SMB]");
+    ARGUSBUF_APPEND("[|SMB]");
     return;
 }
 
@@ -427,7 +427,7 @@ print_negprot(const u_char *words, const u_char *data, const u_char *buf, const 
 
     TCHECK2(*data, 2);
     bcc = EXTRACT_LE_16BITS(data);
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"smb_bcc=%u\n", bcc);
+    ARGUSBUF_APPEND("smb_bcc=%u\n", bcc);
     if (bcc > 0) {
 	if (f2)
 	    smb_fdata(data + 2, f2, SMBMIN(data + 2 + EXTRACT_LE_16BITS(data),
@@ -437,7 +437,7 @@ print_negprot(const u_char *words, const u_char *data, const u_char *buf, const 
     }
     return;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|SMB]");
+    ARGUSBUF_APPEND("[|SMB]");
     return;
 }
 
@@ -471,7 +471,7 @@ print_sesssetup(const u_char *words, const u_char *data, const u_char *buf, cons
 
     TCHECK2(*data, 2);
     bcc = EXTRACT_LE_16BITS(data);
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"smb_bcc=%u\n", bcc);
+    ARGUSBUF_APPEND("smb_bcc=%u\n", bcc);
     if (bcc > 0) {
 	if (f2)
 	    smb_fdata(data + 2, f2, SMBMIN(data + 2 + EXTRACT_LE_16BITS(data),
@@ -481,7 +481,7 @@ print_sesssetup(const u_char *words, const u_char *data, const u_char *buf, cons
     }
     return;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|SMB]");
+    ARGUSBUF_APPEND("[|SMB]");
     return;
 }
 
@@ -511,7 +511,7 @@ print_lockingandx(const u_char *words, const u_char *data, const u_char *buf, co
 
     TCHECK2(*data, 2);
     bcc = EXTRACT_LE_16BITS(data);
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"smb_bcc=%u\n", bcc);
+    ARGUSBUF_APPEND("smb_bcc=%u\n", bcc);
     if (bcc > 0) {
 	if (f2)
 	    smb_fdata(data + 2, f2, SMBMIN(data + 2 + EXTRACT_LE_16BITS(data),
@@ -521,7 +521,7 @@ print_lockingandx(const u_char *words, const u_char *data, const u_char *buf, co
     }
     return;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|SMB]");
+    ARGUSBUF_APPEND("[|SMB]");
     return;
 }
 
@@ -822,9 +822,9 @@ print_smb(const u_char *buf, const u_char *maxbuf)
     fn = smbfind(command, smb_fns);
 
     if (ArgusParser->vflag > 1)
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+	ARGUSBUF_APPEND("\n");
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"SMB PACKET: %s (%s)\n", fn->name, request ? "REQUEST" : "REPLY");
+    ARGUSBUF_APPEND("SMB PACKET: %s (%s)\n", fn->name, request ? "REQUEST" : "REPLY");
 
     if (ArgusParser->vflag < 2)
         return;
@@ -835,10 +835,10 @@ print_smb(const u_char *buf, const u_char *maxbuf)
     if (nterrcodes) {
     	nterror = EXTRACT_LE_32BITS(&buf[5]);
 	if (nterror)
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"NTError = %s\n", nt_errstr(nterror));
+	    ARGUSBUF_APPEND("NTError = %s\n", nt_errstr(nterror));
     } else {
 	if (buf[5])
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"SMBError = %s\n", smb_errstr(buf[5], EXTRACT_LE_16BITS(&buf[7])));
+	    ARGUSBUF_APPEND("SMBError = %s\n", smb_errstr(buf[5], EXTRACT_LE_16BITS(&buf[7])));
     }
 
     smboffset = 32;
@@ -876,20 +876,20 @@ print_smb(const u_char *buf, const u_char *maxbuf)
 		    for (i = 0; &words[1 + 2 * i] < maxwords; i++) {
 			TCHECK2(words[1 + 2 * i], 2);
 			v = EXTRACT_LE_16BITS(words + 1 + 2 * i);
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"smb_vwv[%d]=%d (0x%X)\n", i, v, v);
+			ARGUSBUF_APPEND("smb_vwv[%d]=%d (0x%X)\n", i, v, v);
 		    }
 		}
 	    }
 
 	    TCHECK2(*data, 2);
 	    bcc = EXTRACT_LE_16BITS(data);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"smb_bcc=%u\n", bcc);
+	    ARGUSBUF_APPEND("smb_bcc=%u\n", bcc);
 	    if (f2) {
 		if (bcc > 0)
 		    smb_fdata(data + 2, f2, data + 2 + bcc, unicodestr);
 	    } else {
 		if (bcc > 0) {
-		    sprintf(&ArgusBuf[strlen(ArgusBuf)],"smb_buf[]=\n");
+		    ARGUSBUF_APPEND("smb_buf[]=\n");
 		    print_data(data + 2, SMBMIN(bcc, PTR_DIFF(maxbuf, data + 2)));
 		}
 	    }
@@ -908,19 +908,19 @@ print_smb(const u_char *buf, const u_char *maxbuf)
 
 	fn = smbfind(command, smb_fns);
 
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\nSMB PACKET: %s (%s) (CHAINED)\n",
+	ARGUSBUF_APPEND("\nSMB PACKET: %s (%s) (CHAINED)\n",
 	    fn->name, request ? "REQUEST" : "REPLY");
 	if (newsmboffset < smboffset) {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Bad andX offset: %u < %u\n", newsmboffset, smboffset);
+	    ARGUSBUF_APPEND("Bad andX offset: %u < %u\n", newsmboffset, smboffset);
 	    break;
 	}
 	smboffset = newsmboffset;
     }
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+    ARGUSBUF_APPEND("\n");
     return;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|SMB]");
+    ARGUSBUF_APPEND("[|SMB]");
     return;
 }
 
@@ -952,20 +952,20 @@ smb_tcp_print(const u_char *data, int length)
     if (smb_len >= 4 && caplen >= 4 && (memcmp(data,"\377SMB",4) || (memcmp(data,"\376SMB",4) == 0))) {
 	if ((int)smb_len > caplen) {
 	    if ((int)smb_len > length)
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"WARNING: Packet is continued in later TCP segments\n");
+                ARGUSBUF_APPEND("WARNING: Packet is continued in later TCP segments\n");
 	    else
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"WARNING: Short packet. Try increasing the snap length by %d\n",
+                ARGUSBUF_APPEND("WARNING: Short packet. Try increasing the snap length by %d\n",
 		    smb_len - caplen);
 	} else
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)], " ");
+	    ARGUSBUF_APPEND(" ");
 
 	print_smb(data, maxbuf > data + smb_len ? data + smb_len : maxbuf);
     } else
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"SMB-over-TCP packet:(raw data or continuation?)\n");
+       ARGUSBUF_APPEND("SMB-over-TCP packet:(raw data or continuation?)\n");
 
     return ArgusBuf;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|SMB]");
+    ARGUSBUF_APPEND("[|SMB]");
     return ArgusBuf;
 }
 
@@ -997,18 +997,18 @@ nbt_tcp_print(const u_char *data, int length)
     startbuf = data;
 
     if (ArgusParser->vflag < 2) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," NBT Session Packet: ");
+	ARGUSBUF_APPEND(" NBT Session Packet: ");
 	switch (type) {
 	case 0x00:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Session Message");
+	    ARGUSBUF_APPEND("Session Message");
 	    break;
 
 	case 0x81:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Session Request");
+	    ARGUSBUF_APPEND("Session Request");
 	    break;
 
 	case 0x82:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Session Granted");
+	    ARGUSBUF_APPEND("Session Granted");
 	    break;
 
 	case 0x83:
@@ -1023,29 +1023,29 @@ nbt_tcp_print(const u_char *data, int length)
 		goto trunc;
 	    ecode = data[4];
 
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Session Reject, ");
+	    ARGUSBUF_APPEND("Session Reject, ");
 	    switch (ecode) {
 	    case 0x80:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"Not listening on called name");
+		ARGUSBUF_APPEND("Not listening on called name");
 		break;
 	    case 0x81:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"Not listening for calling name");
+		ARGUSBUF_APPEND("Not listening for calling name");
 		break;
 	    case 0x82:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"Called name not present");
+		ARGUSBUF_APPEND("Called name not present");
 		break;
 	    case 0x83:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"Called name present, but insufficient resources");
+		ARGUSBUF_APPEND("Called name present, but insufficient resources");
 		break;
 	    default:
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"Unspecified error 0x%X", ecode);
+		ARGUSBUF_APPEND("Unspecified error 0x%X", ecode);
 		break;
 	    }
 	  }
 	    break;
 
 	case 0x85:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Session Keepalive");
+	    ARGUSBUF_APPEND("Session Keepalive");
 	    break;
 
 	default:
@@ -1063,14 +1063,14 @@ nbt_tcp_print(const u_char *data, int length)
 	    if (nbt_len >= 4 && caplen >= 4 && memcmp(data,"\377SMB",4) == 0) {
 		if ((int)nbt_len > caplen) {
 		    if ((int)nbt_len > length)
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"WARNING: Packet is continued in later TCP segments\n");
+			ARGUSBUF_APPEND("WARNING: Packet is continued in later TCP segments\n");
 		    else
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"WARNING: Short packet. Try increasing the snap length by %d\n",
+			ARGUSBUF_APPEND("WARNING: Short packet. Try increasing the snap length by %d\n",
 			    nbt_len - caplen);
 		}
 		print_smb(data, maxbuf > data + nbt_len ? data + nbt_len : maxbuf);
 	    } else
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"Session packet:(raw data or continuation?)\n");
+		ARGUSBUF_APPEND("Session packet:(raw data or continuation?)\n");
 	    break;
 
 	case 0x81:
@@ -1097,19 +1097,19 @@ nbt_tcp_print(const u_char *data, int length)
 		ecode = origdata[4];
 		switch (ecode) {
 		case 0x80:
-		    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Not listening on called name\n");
+		    ARGUSBUF_APPEND("Not listening on called name\n");
 		    break;
 		case 0x81:
-		    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Not listening for calling name\n");
+		    ARGUSBUF_APPEND("Not listening for calling name\n");
 		    break;
 		case 0x82:
-		    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Called name not present\n");
+		    ARGUSBUF_APPEND("Called name not present\n");
 		    break;
 		case 0x83:
-		    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Called name present, but insufficient resources\n");
+		    ARGUSBUF_APPEND("Called name present, but insufficient resources\n");
 		    break;
 		default:
-		    sprintf(&ArgusBuf[strlen(ArgusBuf)],"Unspecified error 0x%X\n", ecode);
+		    ARGUSBUF_APPEND("Unspecified error 0x%X\n", ecode);
 		    break;
 		}
 	    }
@@ -1124,11 +1124,11 @@ nbt_tcp_print(const u_char *data, int length)
 	    data = smb_fdata(data, "NBT - Unknown packet type\nType=[B]\n", maxbuf, 0);
 	    break;
 	}
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+	ARGUSBUF_APPEND("\n");
     }
     return ArgusBuf;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|SMB]");
+    ARGUSBUF_APPEND("[|SMB]");
     return ArgusBuf;
 }
 
@@ -1162,9 +1162,9 @@ nbt_udp137_print(const u_char *data, int length)
         return ArgusBuf;
 
     if (ArgusParser->vflag > 1)
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n>>> ");
+	ARGUSBUF_APPEND("\n>>> ");
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"NBT UDP PACKET(137): ");
+    ARGUSBUF_APPEND("NBT UDP PACKET(137): ");
 
     switch (opcode) {
     case 0: opcodestr = "QUERY"; break;
@@ -1176,28 +1176,28 @@ nbt_udp137_print(const u_char *data, int length)
     case 15: opcodestr = "MULTIHOMED REGISTRATION"; break;
     default: opcodestr = "OPUNKNOWN"; break;
     }
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", opcodestr);
+    ARGUSBUF_APPEND("%s", opcodestr);
     if (response) {
 	if (rcode)
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"; NEGATIVE");
+	    ARGUSBUF_APPEND("; NEGATIVE");
 	else
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"; POSITIVE");
+	    ARGUSBUF_APPEND("; POSITIVE");
     }
 
     if (response)
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"; RESPONSE");
+	ARGUSBUF_APPEND("; RESPONSE");
     else
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"; REQUEST");
+	ARGUSBUF_APPEND("; REQUEST");
 
     if (nm_flags & 1)
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"; BROADCAST");
+	ARGUSBUF_APPEND("; BROADCAST");
     else
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"; UNICAST");
+	ARGUSBUF_APPEND("; UNICAST");
 
     if (ArgusParser->vflag < 2)
         return ArgusBuf;
 
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\nTrnID=0x%X\nOpCode=%d\nNmFlags=0x%X\nRcode=%d\nQueryCount=%d\nAnswerCount=%d\nAuthorityCount=%d\nAddressRecCount=%d\n",
+    ARGUSBUF_APPEND("\nTrnID=0x%X\nOpCode=%d\nNmFlags=0x%X\nRcode=%d\nQueryCount=%d\nAnswerCount=%d\nAuthorityCount=%d\nAddressRecCount=%d\n",
 	name_trn_id, opcode, nm_flags, rcode, qdcount, ancount, nscount,
 	arcount);
 
@@ -1206,12 +1206,12 @@ nbt_udp137_print(const u_char *data, int length)
     total = ancount + nscount + arcount;
 
     if (qdcount > 100 || total > 100) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"Corrupt packet??\n");
+	ARGUSBUF_APPEND("Corrupt packet??\n");
         return ArgusBuf;
     }
 
     if (qdcount) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"QuestionRecords:\n");
+	ARGUSBUF_APPEND("QuestionRecords:\n");
 	for (i = 0; i < qdcount; i++) {
 	    p = smb_fdata(p,
 		"|Name=[n1]\nQuestionType=[rw]\nQuestionClass=[rw]\n#",
@@ -1222,7 +1222,7 @@ nbt_udp137_print(const u_char *data, int length)
     }
 
     if (total) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\nResourceRecords:\n");
+	ARGUSBUF_APPEND("\nResourceRecords:\n");
 	for (i = 0; i < total; i++) {
 	    int rdlen;
 	    int restype;
@@ -1235,7 +1235,7 @@ nbt_udp137_print(const u_char *data, int length)
 	    if (p == NULL)
 		goto out;
 	    rdlen = EXTRACT_16BITS(p);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"ResourceLength=%d\nResourceData=\n", rdlen);
+	    ARGUSBUF_APPEND("ResourceLength=%d\nResourceData=\n", rdlen);
 	    p += 2;
 	    if (rdlen == 6) {
 		p = smb_fdata(p, "AddrType=[rw]\nAddress=[b.b.b.b]\n", p + rdlen, 0);
@@ -1256,22 +1256,22 @@ nbt_udp137_print(const u_char *data, int length)
 			    goto out;
 			TCHECK(*p);
 			if (p[0] & 0x80)
-			    sprintf(&ArgusBuf[strlen(ArgusBuf)],"<GROUP> ");
+			    ARGUSBUF_APPEND("<GROUP> ");
 			switch (p[0] & 0x60) {
-			case 0x00: sprintf(&ArgusBuf[strlen(ArgusBuf)],"B "); break;
-			case 0x20: sprintf(&ArgusBuf[strlen(ArgusBuf)],"P "); break;
-			case 0x40: sprintf(&ArgusBuf[strlen(ArgusBuf)],"M "); break;
-			case 0x60: sprintf(&ArgusBuf[strlen(ArgusBuf)],"_ "); break;
+			case 0x00: ARGUSBUF_APPEND("B "); break;
+			case 0x20: ARGUSBUF_APPEND("P "); break;
+			case 0x40: ARGUSBUF_APPEND("M "); break;
+			case 0x60: ARGUSBUF_APPEND("_ "); break;
 			}
 			if (p[0] & 0x10)
-			    sprintf(&ArgusBuf[strlen(ArgusBuf)],"<DEREGISTERING> ");
+			    ARGUSBUF_APPEND("<DEREGISTERING> ");
 			if (p[0] & 0x08)
-			    sprintf(&ArgusBuf[strlen(ArgusBuf)],"<CONFLICT> ");
+			    ARGUSBUF_APPEND("<CONFLICT> ");
 			if (p[0] & 0x04)
-			    sprintf(&ArgusBuf[strlen(ArgusBuf)],"<ACTIVE> ");
+			    ARGUSBUF_APPEND("<ACTIVE> ");
 			if (p[0] & 0x02)
-			    sprintf(&ArgusBuf[strlen(ArgusBuf)],"<PERMANENT> ");
-			sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+			    ARGUSBUF_APPEND("<PERMANENT> ");
+			ARGUSBUF_APPEND("\n");
 			p += 2;
 		    }
 		} else {
@@ -1286,10 +1286,10 @@ nbt_udp137_print(const u_char *data, int length)
 	smb_fdata(p, "AdditionalData:\n", maxbuf, 0);
 
 out:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+    ARGUSBUF_APPEND("\n");
     return ArgusBuf;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|SMB]");
+    ARGUSBUF_APPEND("[|SMB]");
     return ArgusBuf;
 }
 
@@ -1310,7 +1310,7 @@ nbt_udp138_print(const u_char *data, int length)
     startbuf = data;
 
     if (ArgusParser->vflag < 2) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"NBT UDP PACKET(138)");
+	ARGUSBUF_APPEND("NBT UDP PACKET(138)");
         return ArgusBuf;
     }
 
@@ -1327,7 +1327,7 @@ nbt_udp138_print(const u_char *data, int length)
 	    print_smb(data, maxbuf);
     }
 out:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+    ARGUSBUF_APPEND("\n");
    return ArgusBuf;
 }
 
@@ -1413,10 +1413,10 @@ netbeui_print(u_short control, const u_char *data, int length)
     startbuf = data;
 
     if (ArgusParser->vflag < 2) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"NBF Packet: ");
+	ARGUSBUF_APPEND("NBF Packet: ");
 	data = smb_fdata(data, "[P5]#", maxbuf, 0);
     } else {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n>>> NBF Packet\nType=0x%X ", control);
+	ARGUSBUF_APPEND("\n>>> NBF Packet\nType=0x%X ", control);
 	data = smb_fdata(data, "Length=[d] Signature=[w] Command=[B]\n#", maxbuf, 0);
     }
     if (data == NULL)
@@ -1429,15 +1429,15 @@ netbeui_print(u_short control, const u_char *data, int length)
 	    data = smb_fdata(data, "Unknown NBF Command\n", data2, 0);
     } else {
 	if (ArgusParser->vflag < 2) {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", nbf_strings[command].name);
+	    ARGUSBUF_APPEND("%s", nbf_strings[command].name);
 	    if (nbf_strings[command].nonverbose != NULL)
 		data = smb_fdata(data, nbf_strings[command].nonverbose, data2, 0);
 	} else {
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s:\n", nbf_strings[command].name);
+	    ARGUSBUF_APPEND("%s:\n", nbf_strings[command].name);
 	    if (nbf_strings[command].verbose != NULL)
 		data = smb_fdata(data, nbf_strings[command].verbose, data2, 0);
 	    else
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+		ARGUSBUF_APPEND("\n");
 	}
     }
 
@@ -1469,7 +1469,7 @@ netbeui_print(u_short control, const u_char *data, int length)
 	    if (&data2[i + 3] >= maxbuf)
 		break;
 	    if (memcmp(&data2[i], "\377SMB", 4) == 0) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"found SMB packet at %d\n", i);
+		ARGUSBUF_APPEND("found SMB packet at %d\n", i);
 		print_smb(&data2[i], maxbuf);
 		break;
 	    }
@@ -1477,10 +1477,10 @@ netbeui_print(u_short control, const u_char *data, int length)
     }
 
 out:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+    ARGUSBUF_APPEND("\n");
     return;
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|SMB]");
+    ARGUSBUF_APPEND("[|SMB]");
     return;
 }
 
@@ -1510,7 +1510,7 @@ ipx_netbios_print(const u_char *data, u_int length)
 	    smb_fdata(data, "\n>>> IPX transport ", &data[i], 0);
 	    if (data != NULL)
 		print_smb(&data[i], maxbuf);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+	    ARGUSBUF_APPEND("\n");
 	    break;
 	}
     }

--- a/examples/radump/print-snmp.c
+++ b/examples/radump/print-snmp.c
@@ -316,10 +316,10 @@ struct obj_abrev {
       } while ((objp = objp->next) != NULL); \
    } \
    if (objp) { \
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],suppressdot?"%s":".%s", objp->desc); \
+      ARGUSBUF_APPEND(suppressdot?"%s":".%s", objp->desc); \
       objp = objp->child; \
    } else \
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],suppressdot?"%u":".%u", (o)); \
+      ARGUSBUF_APPEND(suppressdot?"%u":".%u", (o)); \
 }
 
 /*
@@ -412,7 +412,7 @@ asn1_parse(register const u_char *p, u_int len, struct be *elem)
    elem->asnlen = 0;
    elem->type = BE_ANY;
    if (len < 1) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "[nothing to parse]");
+      ARGUSBUF_APPEND("[nothing to parse]");
       return -1;
    }
    TCHECK(*p);
@@ -451,14 +451,14 @@ asn1_parse(register const u_char *p, u_int len, struct be *elem)
        */
       for (id = 0; *p & ASN_BIT8; len--, hdr++, p++) {
          if (len < 1) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "[Xtagfield?]");
+            ARGUSBUF_APPEND("[Xtagfield?]");
             return -1;
          }
          TCHECK(*p);
          id = (id << 7) | (*p & ~ASN_BIT8);
       }
       if (len < 1) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "[Xtagfield?]");
+         ARGUSBUF_APPEND("[Xtagfield?]");
          return -1;
       }
       TCHECK(*p);
@@ -468,7 +468,7 @@ asn1_parse(register const u_char *p, u_int len, struct be *elem)
       ++p;
    }
    if (len < 1) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "[no asnlen]");
+      ARGUSBUF_APPEND("[no asnlen]");
       return -1;
    }
    TCHECK(*p);
@@ -478,7 +478,7 @@ asn1_parse(register const u_char *p, u_int len, struct be *elem)
       u_int32_t noct = elem->asnlen % ASN_BIT8;
       elem->asnlen = 0;
       if (len < noct) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"[asnlen? %d<%d]", len, noct);
+         ARGUSBUF_APPEND("[asnlen? %d<%d]", len, noct);
          return -1;
       }
       TCHECK2(*p, noct);
@@ -486,19 +486,19 @@ asn1_parse(register const u_char *p, u_int len, struct be *elem)
          elem->asnlen = (elem->asnlen << ASN_SHIFT8) | *p++;
    }
    if (len < elem->asnlen) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[len%d<asnlen%u]", len, elem->asnlen);
+      ARGUSBUF_APPEND("[len%d<asnlen%u]", len, elem->asnlen);
       return -1;
    }
    if (form >= sizeof(Form)/sizeof(Form[0])) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[form?%d]", form);
+      ARGUSBUF_APPEND("[form?%d]", form);
       return -1;
    }
    if (class >= sizeof(Class)/sizeof(Class[0])) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[class?%c/%d]", *Form[form], class);
+      ARGUSBUF_APPEND("[class?%c/%d]", *Form[form], class);
       return -1;
    }
    if ((int)id >= Class[class].numIDs) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[id?%c/%s/%d]", *Form[form], Class[class].name, id);
+      ARGUSBUF_APPEND("[id?%c/%s/%d]", *Form[form], Class[class].name, id);
       return -1;
    }
 
@@ -539,7 +539,7 @@ asn1_parse(register const u_char *p, u_int len, struct be *elem)
          default:
             elem->type = BE_OCTET;
             elem->data.raw = (caddr_t)p;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"[P/U/%s]",
+            ARGUSBUF_APPEND("[P/U/%s]",
                Class[class].Id[id]);
             break;
          }
@@ -583,7 +583,7 @@ asn1_parse(register const u_char *p, u_int len, struct be *elem)
          default:
             elem->type = BE_OCTET;
             elem->data.raw = (caddr_t)p;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"[P/A/%s]",
+            ARGUSBUF_APPEND("[P/A/%s]",
                Class[class].Id[id]);
             break;
          }
@@ -609,7 +609,7 @@ asn1_parse(register const u_char *p, u_int len, struct be *elem)
          break;
 
       default:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"[P/%s/%s]",
+         ARGUSBUF_APPEND("[P/%s/%s]",
             Class[class].name, Class[class].Id[id]);
          TCHECK2(*p, elem->asnlen);
          elem->type = BE_OCTET;
@@ -630,7 +630,7 @@ asn1_parse(register const u_char *p, u_int len, struct be *elem)
          default:
             elem->type = BE_OCTET;
             elem->data.raw = (caddr_t)p;
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"C/U/%s", Class[class].Id[id]);
+            ARGUSBUF_APPEND("C/U/%s", Class[class].Id[id]);
             break;
          }
          break;
@@ -643,7 +643,7 @@ asn1_parse(register const u_char *p, u_int len, struct be *elem)
       default:
          elem->type = BE_OCTET;
          elem->data.raw = (caddr_t)p;
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"C/%s/%s",
+         ARGUSBUF_APPEND("C/%s/%s",
             Class[class].name, Class[class].Id[id]);
          break;
       }
@@ -654,7 +654,7 @@ asn1_parse(register const u_char *p, u_int len, struct be *elem)
    return elem->asnlen + hdr;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "[|snmp]");
+   ARGUSBUF_APPEND("[|snmp]");
    return -1;
 }
 
@@ -675,7 +675,7 @@ asn1_print(struct be *elem)
    case BE_OCTET:
       TCHECK2(*p, asnlen);
       for (i = asnlen; i-- > 0; p++)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"_%.2x", *p);
+         ARGUSBUF_APPEND("_%.2x", *p);
       break;
 
    case BE_NULL:
@@ -693,7 +693,7 @@ asn1_print(struct be *elem)
                objp = a->node->child;
                i -= strlen(a->oid);
                p += strlen(a->oid);
-               sprintf("%s", &ArgusBuf[strlen(ArgusBuf)],a->prefix);
+                ARGUSBUF_APPEND("%s", a->prefix);
                first = 1;
                break;
             }
@@ -729,11 +729,11 @@ asn1_print(struct be *elem)
    }
 
    case BE_INT:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d", elem->data.integer);
+      ARGUSBUF_APPEND("%d", elem->data.integer);
       break;
 
    case BE_UNS:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", elem->data.uns);
+      ARGUSBUF_APPEND("%u", elem->data.uns);
       break;
 
    case BE_UNS64: {   /* idea borrowed from by Marshall Rose */
@@ -741,16 +741,16 @@ asn1_print(struct be *elem)
       int j, carry;
       char *cpf, *cpl, last[6], first[30];
       if (elem->data.uns64.high == 0) {
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", elem->data.uns64.low);
+              ARGUSBUF_APPEND("%u", elem->data.uns64.low);
               break;
       }
       d = elem->data.uns64.high * 4294967296.0;   /* 2^32 */
       if (elem->data.uns64.high <= 0x1fffff) {
               d += elem->data.uns64.low;
 #if 0 /*is looks illegal, but what is the intention?*/
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"%.f", d);
+         ARGUSBUF_APPEND("%.f", d);
 #else
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"%f", d);
+         ARGUSBUF_APPEND("%f", d);
 #endif
          break;
       }
@@ -774,7 +774,7 @@ asn1_print(struct be *elem)
               }
          *cpf = j + '0';
       }
-      sprintf("%s", &ArgusBuf[strlen(ArgusBuf)],first);
+      ARGUSBUF_APPEND("%s", first);
       break;
    }
 
@@ -786,56 +786,56 @@ asn1_print(struct be *elem)
          printable = isprint(*p) || isspace(*p);
       p = elem->data.str;
       if (printable) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
-         if (fn_printn(p, asnlen, snapend, &ArgusBuf[strlen(ArgusBuf)]) == NULL) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+         ARGUSBUF_APPEND("%c", '"');
+         if (fn_printn(p, asnlen, snapend, &ArgusBuf[strlen(ArgusBuf)], MAXSTRLEN - strlen(ArgusBuf)) == NULL) {
+            ARGUSBUF_APPEND("%c", '"');
             goto trunc;
          }
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", '"');
+         ARGUSBUF_APPEND("%c", '"');
       } else
          for (i = asnlen; i-- > 0; p++) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],first ? "%.2x" : "_%.2x", *p);
+            ARGUSBUF_APPEND(first ? "%.2x" : "_%.2x", *p);
             first = 0;
          }
       break;
    }
 
    case BE_SEQ:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"Seq(%u)", elem->asnlen);
+      ARGUSBUF_APPEND("Seq(%u)", elem->asnlen);
       break;
 
    case BE_INETADDR:
       if (asnlen != ASNLEN_INETADDR)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"[inetaddr len!=%d]", ASNLEN_INETADDR);
+         ARGUSBUF_APPEND("[inetaddr len!=%d]", ASNLEN_INETADDR);
       TCHECK2(*p, asnlen);
       for (i = asnlen; i-- != 0; p++) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],(i == asnlen-1) ? "%u" : ".%u", *p);
+         ARGUSBUF_APPEND((i == asnlen-1) ? "%u" : ".%u", *p);
       }
       break;
 
    case BE_NOSUCHOBJECT:
    case BE_NOSUCHINST:
    case BE_ENDOFMIBVIEW:
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],"[%s]", Class[EXCEPTIONS].Id[elem->id]);
+           ARGUSBUF_APPEND("[%s]", Class[EXCEPTIONS].Id[elem->id]);
       break;
 
    case BE_PDU:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s(%u)",
+      ARGUSBUF_APPEND("%s(%u)",
          Class[CONTEXT].Id[elem->id], elem->asnlen);
       break;
 
    case BE_ANY:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[BE_ANY!?]");
+      ARGUSBUF_APPEND("[BE_ANY!?]");
       break;
 
    default:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[be!?]");
+      ARGUSBUF_APPEND("[be!?]");
       break;
    }
    return 0;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|snmp]");
+   ARGUSBUF_APPEND("[|snmp]");
    return -1;
 }
 
@@ -858,13 +858,13 @@ asn1_decode(u_char *p, u_int length)
    while (i >= 0 && length > 0) {
       i = asn1_parse(p, length, &elem);
       if (i >= 0) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+         ARGUSBUF_APPEND(" ");
          if (asn1_print(&elem) < 0)
             return;
          if (elem.type == BE_SEQ || elem.type == BE_PDU) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," {");
+            ARGUSBUF_APPEND(" {");
             asn1_decode(elem.data.raw, elem.asnlen);
-            sprintf(&ArgusBuf[strlen(ArgusBuf)]," }");
+            ARGUSBUF_APPEND(" }");
          }
          length -= i;
          p += i;
@@ -931,7 +931,7 @@ smi_decode_oid(struct be *elem, unsigned int *oid,
    return 0;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|snmp]");
+   ARGUSBUF_APPEND("[|snmp]");
    return -1;
 }
 
@@ -1041,13 +1041,13 @@ static SmiNode *smi_print_variable(struct be *elem, int *status)
       return NULL;
    }
    if (ArgusParser->vflag) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],smiGetNodeModule(smiNode)->name);
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"::");
+      ARGUSBUF_APPEND(smiGetNodeModule(smiNode)->name);
+      ARGUSBUF_APPEND("::");
    }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],smiNode->name);
+   ARGUSBUF_APPEND(smiNode->name);
    if (smiNode->oidlen < oidlen) {
            for (i = smiNode->oidlen; i < oidlen; i++) {
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],".%u", oid[i]);
+              ARGUSBUF_APPEND(".%u", oid[i]);
       }
    }
    *status = 0;
@@ -1074,20 +1074,20 @@ smi_print_value(SmiNode *smiNode, u_char pduid, struct be *elem)
    }
 
    if (NOTIFY_CLASS(pduid) && smiNode->access < SMI_ACCESS_NOTIFY) {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"[notNotifyable]");
+       ARGUSBUF_APPEND("[notNotifyable]");
    }
 
    if (READ_CLASS(pduid) && smiNode->access < SMI_ACCESS_READ_ONLY) {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"[notReadable]");
+       ARGUSBUF_APPEND("[notReadable]");
    }
 
    if (WRITE_CLASS(pduid) && smiNode->access < SMI_ACCESS_READ_WRITE) {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"[notWritable]");
+       ARGUSBUF_APPEND("[notWritable]");
    }
 
    if (RESPONSE_CLASS(pduid)
        && smiNode->access == SMI_ACCESS_NOT_ACCESSIBLE) {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"[noAccess]");
+       ARGUSBUF_APPEND("[noAccess]");
    }
 
    smiType = smiGetNodeType(smiNode);
@@ -1096,11 +1096,11 @@ smi_print_value(SmiNode *smiNode, u_char pduid, struct be *elem)
    }
 
    if (! smi_check_type(smiType->basetype, elem->type)) {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"[wrongType]");
+       ARGUSBUF_APPEND("[wrongType]");
    }
 
    if (! smi_check_range(smiType, elem)) {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"[outOfRange]");
+       ARGUSBUF_APPEND("[outOfRange]");
    }
 
    /* resolve bits to named bits */
@@ -1122,14 +1122,14 @@ smi_print_value(SmiNode *smiNode, u_char pduid, struct be *elem)
          smiNode = smiGetNodeByOID(oidlen, oid);
          if (smiNode) {
                  if (ArgusParser->vflag) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],smiGetNodeModule(smiNode)->name);
-               sprintf(&ArgusBuf[strlen(ArgusBuf)],"::");
+               ARGUSBUF_APPEND(smiGetNodeModule(smiNode)->name);
+               ARGUSBUF_APPEND("::");
             }
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],smiNode->name);
+            ARGUSBUF_APPEND(smiNode->name);
             if (smiNode->oidlen < oidlen) {
                     for (i = smiNode->oidlen;
                     i < oidlen; i++) {
-                       sprintf(&ArgusBuf[strlen(ArgusBuf)],".%u", oid[i]);
+                       ARGUSBUF_APPEND(".%u", oid[i]);
                }
             }
             done++;
@@ -1144,8 +1144,8 @@ smi_print_value(SmiNode *smiNode, u_char pduid, struct be *elem)
               nn = smiGetNextNamedNumber(nn)) {
                   if (nn->value.value.integer32
                  == elem->data.integer) {
-                     sprintf(&ArgusBuf[strlen(ArgusBuf)],nn->name);
-                sprintf(&ArgusBuf[strlen(ArgusBuf)],"(%d)", elem->data.integer);
+                     ARGUSBUF_APPEND(nn->name);
+                ARGUSBUF_APPEND("(%d)", elem->data.integer);
                 done++;
                 break;
             }
@@ -1211,12 +1211,12 @@ varbind_print(u_char pduid, const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_SEQ) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[!SEQ of varbind]");
+      ARGUSBUF_APPEND("[!SEQ of varbind]");
       asn1_print(&elem);
       return;
    }
    if ((u_int)count < length)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[%d extra after SEQ of varbind]", length - count);
+      ARGUSBUF_APPEND("[%d extra after SEQ of varbind]", length - count);
    /* descend */
    length = elem.asnlen;
    np = (u_char *)elem.data.raw;
@@ -1225,13 +1225,13 @@ varbind_print(u_char pduid, const u_char *np, u_int length)
       const u_char *vbend;
       u_int vblength;
 
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+      ARGUSBUF_APPEND(" ");
 
       /* Sequence */
       if ((count = asn1_parse(np, length, &elem)) < 0)
          return;
       if (elem.type != BE_SEQ) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"[!varbind]");
+         ARGUSBUF_APPEND("[!varbind]");
          asn1_print(&elem);
          return;
       }
@@ -1245,7 +1245,7 @@ varbind_print(u_char pduid, const u_char *np, u_int length)
       if ((count = asn1_parse(np, length, &elem)) < 0)
          return;
       if (elem.type != BE_OID) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"[objName!=OID]");
+         ARGUSBUF_APPEND("[objName!=OID]");
          asn1_print(&elem);
          return;
       }
@@ -1261,7 +1261,7 @@ varbind_print(u_char pduid, const u_char *np, u_int length)
 
       if (pduid != GETREQ && pduid != GETNEXTREQ
           && pduid != GETBULKREQ)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"=");
+         ARGUSBUF_APPEND("=");
 
       /* objVal (ANY) */
       if ((count = asn1_parse(np, length, &elem)) < 0)
@@ -1269,7 +1269,7 @@ varbind_print(u_char pduid, const u_char *np, u_int length)
       if (pduid == GETREQ || pduid == GETNEXTREQ
           || pduid == GETBULKREQ) {
          if (elem.type != BE_NULL) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"[objVal!=NULL]");
+            ARGUSBUF_APPEND("[objVal!=NULL]");
             if (asn1_print(&elem) < 0)
                return;
          }
@@ -1303,12 +1303,12 @@ snmppdu_print(u_short pduid, const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_INT) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[reqId!=INT]");
+      ARGUSBUF_APPEND("[reqId!=INT]");
       asn1_print(&elem);
       return;
    }
    if (ArgusParser->vflag)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"R=%d ", elem.data.integer);
+      ARGUSBUF_APPEND("R=%d ", elem.data.integer);
    length -= count;
    np += count;
 
@@ -1316,7 +1316,7 @@ snmppdu_print(u_short pduid, const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_INT) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[errorStatus!=INT]");
+      ARGUSBUF_APPEND("[errorStatus!=INT]");
       asn1_print(&elem);
       return;
    }
@@ -1325,13 +1325,13 @@ snmppdu_print(u_short pduid, const u_char *np, u_int length)
        || pduid == INFORMREQ || pduid == V2TRAP || pduid == REPORT)
        && elem.data.integer != 0) {
       char errbuf[20];
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[errorStatus(%s)!=0]",
+      ARGUSBUF_APPEND("[errorStatus(%s)!=0]",
          DECODE_ErrorStatus(elem.data.integer));
    } else if (pduid == GETBULKREQ) {
-           sprintf(&ArgusBuf[strlen(ArgusBuf)]," N=%d", elem.data.integer);
+           ARGUSBUF_APPEND(" N=%d", elem.data.integer);
    } else if (elem.data.integer != 0) {
       char errbuf[20];
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", DECODE_ErrorStatus(elem.data.integer));
+      ARGUSBUF_APPEND(" %s", DECODE_ErrorStatus(elem.data.integer));
       error = elem.data.integer;
    }
    length -= count;
@@ -1341,26 +1341,26 @@ snmppdu_print(u_short pduid, const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_INT) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[errorIndex!=INT]");
+      ARGUSBUF_APPEND("[errorIndex!=INT]");
       asn1_print(&elem);
       return;
    }
    if ((pduid == GETREQ || pduid == GETNEXTREQ || pduid == SETREQ
        || pduid == INFORMREQ || pduid == V2TRAP || pduid == REPORT)
        && elem.data.integer != 0)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[errorIndex(%d)!=0]", elem.data.integer);
+      ARGUSBUF_APPEND("[errorIndex(%d)!=0]", elem.data.integer);
    else if (pduid == GETBULKREQ)
-           sprintf(&ArgusBuf[strlen(ArgusBuf)]," M=%d", elem.data.integer);
+           ARGUSBUF_APPEND(" M=%d", elem.data.integer);
    else if (elem.data.integer != 0) {
       if (!error)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"[errorIndex(%d) w/o errorStatus]",
+         ARGUSBUF_APPEND("[errorIndex(%d) w/o errorStatus]",
             elem.data.integer);
       else {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"@%d", elem.data.integer);
+         ARGUSBUF_APPEND("@%d", elem.data.integer);
          error = elem.data.integer;
       }
    } else if (error) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[errorIndex==0]");
+      ARGUSBUF_APPEND("[errorIndex==0]");
       error = 0;
    }
    length -= count;
@@ -1379,13 +1379,13 @@ trappdu_print(const u_char *np, u_int length)
    struct be elem;
    int count = 0, generic;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+   ARGUSBUF_APPEND("%c", ' ');
 
    /* enterprise (oid) */
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_OID) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[enterprise!=OID]");
+      ARGUSBUF_APPEND("[enterprise!=OID]");
       asn1_print(&elem);
       return;
    }
@@ -1394,13 +1394,13 @@ trappdu_print(const u_char *np, u_int length)
    length -= count;
    np += count;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+   ARGUSBUF_APPEND("%c", ' ');
 
    /* agent-addr (inetaddr) */
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_INETADDR) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[agent-addr!=INETADDR]");
+      ARGUSBUF_APPEND("[agent-addr!=INETADDR]");
       asn1_print(&elem);
       return;
    }
@@ -1413,14 +1413,14 @@ trappdu_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_INT) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[generic-trap!=INT]");
+      ARGUSBUF_APPEND("[generic-trap!=INT]");
       asn1_print(&elem);
       return;
    }
    generic = elem.data.integer;
    {
       char buf[20];
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", DECODE_GenericTrap(generic));
+      ARGUSBUF_APPEND(" %s", DECODE_GenericTrap(generic));
    }
    length -= count;
    np += count;
@@ -1429,25 +1429,25 @@ trappdu_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_INT) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[specific-trap!=INT]");
+      ARGUSBUF_APPEND("[specific-trap!=INT]");
       asn1_print(&elem);
       return;
    }
    if (generic != GT_ENTERPRISE) {
       if (elem.data.integer != 0)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"[specific-trap(%d)!=0]", elem.data.integer);
+         ARGUSBUF_APPEND("[specific-trap(%d)!=0]", elem.data.integer);
    } else
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," s=%d", elem.data.integer);
+      ARGUSBUF_APPEND(" s=%d", elem.data.integer);
    length -= count;
    np += count;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+   ARGUSBUF_APPEND("%c", ' ');
 
    /* time-stamp (TimeTicks) */
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_UNS) {         /* XXX */
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[time-stamp!=TIMETICKS]");
+      ARGUSBUF_APPEND("[time-stamp!=TIMETICKS]");
       asn1_print(&elem);
       return;
    }
@@ -1473,17 +1473,17 @@ pdu_print(const u_char *np, u_int length, int version)
    if ((count = asn1_parse(np, length, &pdu)) < 0)
       return;
    if (pdu.type != BE_PDU) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[no PDU]");
+      ARGUSBUF_APPEND("[no PDU]");
       return;
    }
    if ((u_int)count < length)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[%d extra after PDU]", length - count);
+      ARGUSBUF_APPEND("[%d extra after PDU]", length - count);
    if (ArgusParser->vflag) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"{ ");
+      ARGUSBUF_APPEND("{ ");
    }
    if (asn1_print(&pdu) < 0)
       return;
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+   ARGUSBUF_APPEND(" ");
    /* descend into PDU */
    length = pdu.asnlen;
    np = (u_char *)pdu.data.raw;
@@ -1491,12 +1491,12 @@ pdu_print(const u_char *np, u_int length, int version)
    if (version == SNMP_VERSION_1 &&
        (pdu.id == GETBULKREQ || pdu.id == INFORMREQ ||
         pdu.id == V2TRAP || pdu.id == REPORT)) {
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],"[v2 PDU in v1 message]");
+           ARGUSBUF_APPEND("[v2 PDU in v1 message]");
       return;
    }
 
    if (version == SNMP_VERSION_2 && pdu.id == TRAP) {
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],"[v1 PDU in v2 message]");
+           ARGUSBUF_APPEND("[v1 PDU in v2 message]");
       return;
    }
 
@@ -1517,7 +1517,7 @@ pdu_print(const u_char *np, u_int length, int version)
    }
 
    if (ArgusParser->vflag) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," } ");
+      ARGUSBUF_APPEND(" } ");
    }
 }
 
@@ -1534,7 +1534,7 @@ scopedpdu_print(const u_char *np, u_int length, int version)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_SEQ) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[!scoped PDU]");
+      ARGUSBUF_APPEND("[!scoped PDU]");
       asn1_print(&elem);
       return;
    }
@@ -1545,31 +1545,31 @@ scopedpdu_print(const u_char *np, u_int length, int version)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_STR) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[contextEngineID!=STR]");
+      ARGUSBUF_APPEND("[contextEngineID!=STR]");
       asn1_print(&elem);
       return;
    }
    length -= count;
    np += count;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"E= ");
+   ARGUSBUF_APPEND("E= ");
    for (i = 0; i < (int)elem.asnlen; i++) {
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"0x%02X", elem.data.str[i]);
+            ARGUSBUF_APPEND("0x%02X", elem.data.str[i]);
         }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+   ARGUSBUF_APPEND(" ");
 
    /* contextName (OCTET STRING) */
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_STR) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[contextName!=STR]");
+      ARGUSBUF_APPEND("[contextName!=STR]");
       asn1_print(&elem);
       return;
    }
    length -= count;
    np += count;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"C=%.*s ", (int)elem.asnlen, elem.data.str);
+   ARGUSBUF_APPEND("C=%.*s ", (int)elem.asnlen, elem.data.str);
 
    pdu_print(np, length, version);
 }
@@ -1587,7 +1587,7 @@ community_print(const u_char *np, u_int length, int version)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_STR) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[comm!=STR]");
+      ARGUSBUF_APPEND("[comm!=STR]");
       asn1_print(&elem);
       return;
    }
@@ -1596,7 +1596,7 @@ community_print(const u_char *np, u_int length, int version)
        strncmp((char *)elem.data.str, DEF_COMMUNITY,
                sizeof(DEF_COMMUNITY) - 1) == 0))
       /* ! "public" */
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"C=%.*s ", (int)elem.asnlen, elem.data.str);
+      ARGUSBUF_APPEND("C=%.*s ", (int)elem.asnlen, elem.data.str);
    length -= count;
    np += count;
 
@@ -1616,7 +1616,7 @@ usm_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_SEQ) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[!usm]");
+      ARGUSBUF_APPEND("[!usm]");
       asn1_print(&elem);
       return;
    }
@@ -1627,7 +1627,7 @@ usm_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_STR) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgAuthoritativeEngineID!=STR]");
+      ARGUSBUF_APPEND("[msgAuthoritativeEngineID!=STR]");
       asn1_print(&elem);
       return;
    }
@@ -1638,12 +1638,12 @@ usm_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_INT) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgAuthoritativeEngineBoots!=INT]");
+      ARGUSBUF_APPEND("[msgAuthoritativeEngineBoots!=INT]");
       asn1_print(&elem);
       return;
    }
    if (ArgusParser->vflag)
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],"B=%d ", elem.data.integer);
+           ARGUSBUF_APPEND("B=%d ", elem.data.integer);
    length -= count;
    np += count;
 
@@ -1651,12 +1651,12 @@ usm_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_INT) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgAuthoritativeEngineTime!=INT]");
+      ARGUSBUF_APPEND("[msgAuthoritativeEngineTime!=INT]");
       asn1_print(&elem);
       return;
    }
    if (ArgusParser->vflag)
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],"T=%d ", elem.data.integer);
+           ARGUSBUF_APPEND("T=%d ", elem.data.integer);
    length -= count;
    np += count;
 
@@ -1664,20 +1664,20 @@ usm_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_STR) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgUserName!=STR]");
+      ARGUSBUF_APPEND("[msgUserName!=STR]");
       asn1_print(&elem);
       return;
    }
    length -= count;
         np += count;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"U=%.*s ", (int)elem.asnlen, elem.data.str);
+   ARGUSBUF_APPEND("U=%.*s ", (int)elem.asnlen, elem.data.str);
 
    /* msgAuthenticationParameters (OCTET STRING) */
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_STR) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgAuthenticationParameters!=STR]");
+      ARGUSBUF_APPEND("[msgAuthenticationParameters!=STR]");
       asn1_print(&elem);
       return;
    }
@@ -1688,7 +1688,7 @@ usm_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_STR) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgPrivacyParameters!=STR]");
+      ARGUSBUF_APPEND("[msgPrivacyParameters!=STR]");
       asn1_print(&elem);
       return;
    }
@@ -1696,7 +1696,7 @@ usm_print(const u_char *np, u_int length)
         np += count;
 
    if ((u_int)count < length)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[%d extra after usm SEQ]", length - count);
+      ARGUSBUF_APPEND("[%d extra after usm SEQ]", length - count);
 }
 
 /*
@@ -1716,7 +1716,7 @@ v3msg_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_SEQ) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[!message]");
+      ARGUSBUF_APPEND("[!message]");
       asn1_print(&elem);
       return;
    }
@@ -1724,14 +1724,14 @@ v3msg_print(const u_char *np, u_int length)
    np = (u_char *)elem.data.raw;
 
    if (ArgusParser->vflag) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"{ ");
+      ARGUSBUF_APPEND("{ ");
    }
 
    /* msgID (INTEGER) */
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_INT) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgID!=INT]");
+      ARGUSBUF_APPEND("[msgID!=INT]");
       asn1_print(&elem);
       return;
    }
@@ -1742,7 +1742,7 @@ v3msg_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_INT) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgMaxSize!=INT]");
+      ARGUSBUF_APPEND("[msgMaxSize!=INT]");
       asn1_print(&elem);
       return;
    }
@@ -1753,34 +1753,34 @@ v3msg_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_STR) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgFlags!=STR]");
+      ARGUSBUF_APPEND("[msgFlags!=STR]");
       asn1_print(&elem);
       return;
    }
    if (elem.asnlen != 1) {
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgFlags size %d]", elem.asnlen);
+           ARGUSBUF_APPEND("[msgFlags size %d]", elem.asnlen);
       return;
    }
    flags = elem.data.str[0];
    if (flags != 0x00 && flags != 0x01 && flags != 0x03
        && flags != 0x04 && flags != 0x05 && flags != 0x07) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgFlags=0x%02X]", flags);
+      ARGUSBUF_APPEND("[msgFlags=0x%02X]", flags);
       return;
    }
    length -= count;
    np += count;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"F=");
-   if (flags & 0x01) sprintf(&ArgusBuf[strlen(ArgusBuf)],"a");
-   if (flags & 0x02) sprintf(&ArgusBuf[strlen(ArgusBuf)],"p");
-   if (flags & 0x04) sprintf(&ArgusBuf[strlen(ArgusBuf)],"r");
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+   ARGUSBUF_APPEND("F=");
+   if (flags & 0x01) ARGUSBUF_APPEND("a");
+   if (flags & 0x02) ARGUSBUF_APPEND("p");
+   if (flags & 0x04) ARGUSBUF_APPEND("r");
+   ARGUSBUF_APPEND(" ");
 
    /* msgSecurityModel (INTEGER) */
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_INT) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgSecurityModel!=INT]");
+      ARGUSBUF_APPEND("[msgSecurityModel!=INT]");
       asn1_print(&elem);
       return;
    }
@@ -1789,18 +1789,18 @@ v3msg_print(const u_char *np, u_int length)
    np += count;
 
    if ((u_int)count < length)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[%d extra after message SEQ]", length - count);
+      ARGUSBUF_APPEND("[%d extra after message SEQ]", length - count);
 
    if (ArgusParser->vflag) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"} ");
+      ARGUSBUF_APPEND("} ");
    }
 
    if (model == 3) {
        if (ArgusParser->vflag) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"{ USM ");
+      ARGUSBUF_APPEND("{ USM ");
        }
    } else {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"[security model %d]", model);
+       ARGUSBUF_APPEND("[security model %d]", model);
             return;
    }
 
@@ -1811,7 +1811,7 @@ v3msg_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return;
    if (elem.type != BE_STR) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[msgSecurityParameters!=STR]");
+      ARGUSBUF_APPEND("[msgSecurityParameters!=STR]");
       asn1_print(&elem);
       return;
    }
@@ -1821,18 +1821,18 @@ v3msg_print(const u_char *np, u_int length)
    if (model == 3) {
        usm_print(elem.data.str, elem.asnlen);
        if (ArgusParser->vflag) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"} ");
+      ARGUSBUF_APPEND("} ");
        }
    }
 
    if (ArgusParser->vflag) {
-       sprintf(&ArgusBuf[strlen(ArgusBuf)],"{ ScopedPDU ");
+       ARGUSBUF_APPEND("{ ScopedPDU ");
    }
 
    scopedpdu_print(np, length, 3);
 
    if (ArgusParser->vflag) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"} ");
+      ARGUSBUF_APPEND("} ");
    }
 }
 
@@ -1846,18 +1846,18 @@ snmp_print(const u_char *np, u_int length)
    int count = 0;
    int version = 0;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", ' ');
+   ARGUSBUF_APPEND("%c", ' ');
 
    /* initial Sequence */
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return ArgusBuf;
    if (elem.type != BE_SEQ) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[!init SEQ]");
+      ARGUSBUF_APPEND("[!init SEQ]");
       asn1_print(&elem);
       return ArgusBuf;
    }
    if ((u_int)count < length)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[%d extra after iSEQ]", length - count);
+      ARGUSBUF_APPEND("[%d extra after iSEQ]", length - count);
    /* descend */
    length = elem.asnlen;
    np = (u_char *)elem.data.raw;
@@ -1866,7 +1866,7 @@ snmp_print(const u_char *np, u_int length)
    if ((count = asn1_parse(np, length, &elem)) < 0)
       return ArgusBuf;
    if (elem.type != BE_INT) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[version!=INT]");
+      ARGUSBUF_APPEND("[version!=INT]");
       asn1_print(&elem);
       return ArgusBuf;
    }
@@ -1876,10 +1876,10 @@ snmp_print(const u_char *np, u_int length)
    case SNMP_VERSION_2:
    case SNMP_VERSION_3:
            if (ArgusParser->vflag)
-              sprintf(&ArgusBuf[strlen(ArgusBuf)],"{ %s ", SnmpVersion[elem.data.integer]);
+              ARGUSBUF_APPEND("{ %s ", SnmpVersion[elem.data.integer]);
       break;
    default:
-           sprintf(&ArgusBuf[strlen(ArgusBuf)],"[version = %d]", elem.data.integer);
+           ARGUSBUF_APPEND("[version = %d]", elem.data.integer);
       return ArgusBuf;
    }
    version = elem.data.integer;
@@ -1895,12 +1895,12 @@ snmp_print(const u_char *np, u_int length)
       v3msg_print(np, length);
       break;
    default:
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[version = %d]", elem.data.integer);
+      ARGUSBUF_APPEND("[version = %d]", elem.data.integer);
       break;
    }
 
    if (ArgusParser->vflag) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"} ");
+      ARGUSBUF_APPEND("} ");
    }
 
    return ArgusBuf;

--- a/examples/radump/print-stp.c
+++ b/examples/radump/print-stp.c
@@ -36,37 +36,37 @@ extern char ArgusBuf[];
 static void
 stp_print_bridge_id(const u_char *p)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "%.2x%.2x.%.2x:%.2x:%.2x:%.2x:%.2x:%.2x",
+   ARGUSBUF_APPEND("%.2x%.2x.%.2x:%.2x:%.2x:%.2x:%.2x:%.2x",
           p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
 }
 
 static void
 stp_print_config_bpdu(const u_char *p)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "config ");
+   ARGUSBUF_APPEND("config ");
    if (p[4] & 1)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "TOP_CHANGE ");
+      ARGUSBUF_APPEND("TOP_CHANGE ");
    if (p[4] & 0x80)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "TOP_CHANGE_ACK ");
+      ARGUSBUF_APPEND("TOP_CHANGE_ACK ");
 
    stp_print_bridge_id(p+17);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], ".%.2x%.2x ", p[25], p[26]);
+   ARGUSBUF_APPEND(".%.2x%.2x ", p[25], p[26]);
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "root ");
+   ARGUSBUF_APPEND("root ");
    stp_print_bridge_id(p+5);
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], " pathcost %i ", (p[13] << 24) | (p[14] << 16) | (p[15] << 8) | p[16]);
+   ARGUSBUF_APPEND(" pathcost %i ", (p[13] << 24) | (p[14] << 16) | (p[15] << 8) | p[16]);
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "age %i ", p[27]);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "max %i ", p[29]);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "hello %i ", p[31]);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "fdelay %i", p[33]);
+   ARGUSBUF_APPEND("age %i ", p[27]);
+   ARGUSBUF_APPEND("max %i ", p[29]);
+   ARGUSBUF_APPEND("hello %i ", p[31]);
+   ARGUSBUF_APPEND("fdelay %i", p[33]);
 }
 
 static void
 stp_print_tcn_bpdu(void)
 {
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "tcn");
+   ARGUSBUF_APPEND("tcn");
 }
 
 #define BPDU_TOPOLOGY_CHANGE 	0
@@ -81,61 +81,61 @@ static void
 stp_print_rapid_bpdu(const u_char *p, u_int length)
 {
    int i;
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "rapid ");
+   ARGUSBUF_APPEND("rapid ");
 
    for (i = 0; i < 8; i++) {
       switch (i) {
          case BPDU_TOPOLOGY_CHANGE:
             if (p[4] & (0x01 << i)) 
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "top_change ");
+               ARGUSBUF_APPEND("top_change ");
             break;
          case BPDU_PROPOSAL:
             if (p[4] & (0x01 << i)) 
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "prop ");
+               ARGUSBUF_APPEND("prop ");
             break;
          case BPDU_PORT_ROLE:
             if (p[4] & 0x0B) {
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "role:");
+               ARGUSBUF_APPEND("role:");
                switch (p[4] & 0x0C) {
-                  case 0x04: sprintf(&ArgusBuf[strlen(ArgusBuf)], "back "); break;
-                  case 0x08: sprintf(&ArgusBuf[strlen(ArgusBuf)], "root "); break;
-                  case 0x0C: sprintf(&ArgusBuf[strlen(ArgusBuf)], "desg "); break;
+                  case 0x04: ARGUSBUF_APPEND("back "); break;
+                  case 0x08: ARGUSBUF_APPEND("root "); break;
+                  case 0x0C: ARGUSBUF_APPEND("desg "); break;
                }
             }
             break;
          case BPDU_LEARNING:
             if (p[4] & (0x01 << i)) 
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "learn ");
+               ARGUSBUF_APPEND("learn ");
             break;
          case BPDU_FORWARDING:
             if (p[4] & (0x01 << i)) 
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "forward ");
+               ARGUSBUF_APPEND("forward ");
             break;
          case BPDU_AGREEMENT:
             if (p[4] & (0x01 << i)) 
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "agree ");
+               ARGUSBUF_APPEND("agree ");
             break;
          case BPDU_TOPOLOGY_ACK:
             if (p[4] & (0x01 << i)) 
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "top_change_ack ");
+               ARGUSBUF_APPEND("top_change_ack ");
             break;
       }
    }
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "root ");
+   ARGUSBUF_APPEND("root ");
    stp_print_bridge_id(p+5);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], " cost %i ", (p[13] << 24) | (p[14] << 16) | (p[15] << 8) | p[16]);
+   ARGUSBUF_APPEND(" cost %i ", (p[13] << 24) | (p[14] << 16) | (p[15] << 8) | p[16]);
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "bridge ");
+   ARGUSBUF_APPEND("bridge ");
    stp_print_bridge_id(p+17);
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], " port ");
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "0x%.2x%.2x ", p[25], p[26]);
+   ARGUSBUF_APPEND(" port ");
+   ARGUSBUF_APPEND("0x%.2x%.2x ", p[25], p[26]);
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "age %i ", p[27]);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "max %i ", p[29]);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "hello %i ", p[31]);
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "fdelay %i", p[33]);
+   ARGUSBUF_APPEND("age %i ", p[27]);
+   ARGUSBUF_APPEND("max %i ", p[29]);
+   ARGUSBUF_APPEND("hello %i ", p[31]);
+   ARGUSBUF_APPEND("fdelay %i", p[33]);
 }
 
 /*
@@ -149,9 +149,9 @@ stp_print(const u_char *p, u_int length)
    if (length < 4)
       goto trunc;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "802.1d ");
+   ARGUSBUF_APPEND("802.1d ");
    if (p[0] || p[1]) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], "unknown protocol");
+      ARGUSBUF_APPEND("unknown protocol");
       return (ArgusBuf);
    }
 
@@ -174,18 +174,18 @@ stp_print(const u_char *p, u_int length)
                break;
 
             default:
-               sprintf(&ArgusBuf[strlen(ArgusBuf)], "unknown type %i", p[3]);
+               ARGUSBUF_APPEND("unknown type %i", p[3]);
                break;
          }
          break;
       }
       default:
-         sprintf(&ArgusBuf[strlen(ArgusBuf)], "unknown version");
+         ARGUSBUF_APPEND("unknown version");
          break;
    }
    return (ArgusBuf);
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)], "[|stp %d]", length);
+   ARGUSBUF_APPEND("[|stp %d]", length);
 
    return (ArgusBuf);
 }

--- a/examples/radump/print-syslog.c
+++ b/examples/radump/print-syslog.c
@@ -125,7 +125,7 @@ syslog_print(register const u_char *pptr, register u_int len)
             msg_off++;
         }
     } else {
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|syslog]");
+        ARGUSBUF_APPEND("[|syslog]");
         return ArgusBuf;
     }
 
@@ -134,14 +134,14 @@ syslog_print(register const u_char *pptr, register u_int len)
 
     
     if (ArgusParser->vflag < 1 ) {
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"SYSLOG %s.%s, length: %u",
+        ARGUSBUF_APPEND("SYSLOG %s.%s, length: %u",
                tok2str(syslog_facility_values, "unknown (%u)", facility),
                tok2str(syslog_severity_values, "unknown (%u)", severity),
                len);
         return ArgusBuf;
     }
        
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"SYSLOG, length: %u\n\tFacility %s (%u), Severity %s (%u)\n\tMsg: ",
+    ARGUSBUF_APPEND("SYSLOG, length: %u\n\tFacility %s (%u), Severity %s (%u)\n\tMsg: ",
            len,
            tok2str(syslog_facility_values, "unknown (%u)", facility),
            facility,
@@ -152,7 +152,7 @@ syslog_print(register const u_char *pptr, register u_int len)
     for (; msg_off < len; msg_off++) {
         if (!TTEST2(*(pptr+msg_off), 1))
             goto trunc;
-        sprintf(&ArgusBuf[strlen(ArgusBuf)],"%c", *(pptr+msg_off));
+        ARGUSBUF_APPEND("%c", *(pptr+msg_off));
     }
 
    if (ArgusParser->vflag > 1) {
@@ -163,6 +163,6 @@ syslog_print(register const u_char *pptr, register u_int len)
    return ArgusBuf;
 
 trunc:
-   sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|syslog]");
+   ARGUSBUF_APPEND("[|syslog]");
    return ArgusBuf;
 }

--- a/examples/radump/print-telnet.c
+++ b/examples/radump/print-telnet.c
@@ -134,7 +134,7 @@ telnet_parse(const u_char *sp, u_int length, int print)
    FETCH(c, sp, length);
    if (c == IAC) {      /* <IAC><IAC>! */
       if (print)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"IAC IAC");
+         ARGUSBUF_APPEND("IAC IAC");
       goto done;
    }
 
@@ -152,10 +152,10 @@ telnet_parse(const u_char *sp, u_int length, int print)
       FETCH(x, sp, length);
       if (x >= 0 && x < NTELOPTS) {
          if (print)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s %s", telcmds[i], telopts[x]);
+            ARGUSBUF_APPEND("%s %s", telcmds[i], telopts[x]);
       } else {
          if (print)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s %#x", telcmds[i], x);
+            ARGUSBUF_APPEND("%s %#x", telcmds[i], x);
       }
       if (c != SB)
          break;
@@ -175,47 +175,47 @@ telnet_parse(const u_char *sp, u_int length, int print)
             break;
          FETCH(c, sp, length);
          if (print)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", STR_OR_ID(c, authcmd));
+            ARGUSBUF_APPEND(" %s", STR_OR_ID(c, authcmd));
          if (p <= sp)
             break;
          FETCH(c, sp, length);
          if (print)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", STR_OR_ID(c, authtype));
+            ARGUSBUF_APPEND(" %s", STR_OR_ID(c, authtype));
          break;
       case TELOPT_ENCRYPT:
          if (p <= sp)
             break;
          FETCH(c, sp, length);
          if (print)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", STR_OR_ID(c, enccmd));
+            ARGUSBUF_APPEND(" %s", STR_OR_ID(c, enccmd));
          if (p <= sp)
             break;
          FETCH(c, sp, length);
          if (print)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", STR_OR_ID(c, enctype));
+            ARGUSBUF_APPEND(" %s", STR_OR_ID(c, enctype));
          break;
       default:
          if (p <= sp)
             break;
          FETCH(c, sp, length);
          if (print)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", STR_OR_ID(c, cmds));
+            ARGUSBUF_APPEND(" %s", STR_OR_ID(c, cmds));
          break;
       }
       while (p > sp) {
          FETCH(x, sp, length);
          if (print)
-            (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," %#x", x);
+            ARGUSBUF_APPEND(" %#x", x);
       }
       /* terminating IAC SE */
       if (print)
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)]," SE");
+         ARGUSBUF_APPEND(" SE");
       sp += 2;
       length -= 2;
       break;
    default:
       if (print)
-         (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", telcmds[i]);
+         ARGUSBUF_APPEND("%s", telcmds[i]);
       goto done;
    }
 
@@ -223,7 +223,7 @@ done:
    return sp - osp;
 
 trunc:
-   (void)sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|telnet]");
+   ARGUSBUF_APPEND("[|telnet]");
 pktend:
    return -1;
 #undef FETCH
@@ -248,14 +248,14 @@ telnet_print(const u_char *sp, u_int length)
        */
       if (ArgusParser->Xflag && 2 < ArgusParser->vflag) {
          if (first)
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"Telnet:");
+            ARGUSBUF_APPEND("Telnet:");
          hex_print_with_offset(" ", sp, l, sp - osp);
          if (l > 8)
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n\t\t\t\t");
+            ARGUSBUF_APPEND("\n\t\t\t\t");
          else
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"%*s\t", (8 - l) * 3, "");
+            ARGUSBUF_APPEND("%*s\t", (8 - l) * 3, "");
       } else
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", (first) ? " [telnet " : ", ");
+         ARGUSBUF_APPEND("%s", (first) ? " [telnet " : ", ");
 
       (void)telnet_parse(sp, length, 1);
       first = 0;
@@ -265,9 +265,9 @@ telnet_print(const u_char *sp, u_int length)
    }
    if (!first) {
       if (ArgusParser->Xflag && 2 < ArgusParser->vflag)
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+         ARGUSBUF_APPEND("\n");
       else
-         sprintf(&ArgusBuf[strlen(ArgusBuf)],"]");
+         ARGUSBUF_APPEND("]");
    }
 
    return ArgusBuf;

--- a/examples/radump/print-tftp.c
+++ b/examples/radump/print-tftp.c
@@ -87,13 +87,13 @@ tftp_print(register const u_char *bp, u_int length)
 	tp = (const struct tftphdr *)bp;
 
 	/* Print length */
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," %d", length);
+	ARGUSBUF_APPEND(" %d", length);
 
 	/* Print tftp request type */
 	TCHECK(tp->th_opcode);
 	opcode = EXTRACT_16BITS(&tp->th_opcode);
 	cp = tok2str(op2str, "tftp-#%d", opcode);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s", cp);
+	ARGUSBUF_APPEND(" %s", cp);
 	/* Bail if bogus opcode */
 	if (*cp == 't')
 		return ArgusBuf;
@@ -111,9 +111,9 @@ tftp_print(register const u_char *bp, u_int length)
 #else
 		p = (u_char *)&tp->th_block;
 #endif
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," \"");
-		i = fn_print(p, snapend, ArgusBuf);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\"");
+		ARGUSBUF_APPEND(" \"");
+		i = fn_print(p, snapend, ArgusBuf, MAXSTRLEN - strlen(ArgusBuf));
+		ARGUSBUF_APPEND("\"");
 
 		/* Print the mode and any options */
 		while ((p = (const u_char *)strchr((const char *)p, '\0')) != NULL) {
@@ -121,8 +121,8 @@ tftp_print(register const u_char *bp, u_int length)
 				break;
 			p++;
 			if (*p != '\0') {
-		           sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
-				fn_print(p, snapend, ArgusBuf);
+		           ARGUSBUF_APPEND(" ");
+				fn_print(p, snapend, ArgusBuf, MAXSTRLEN - strlen(ArgusBuf));
 			}
 		}
 		
@@ -133,28 +133,28 @@ tftp_print(register const u_char *bp, u_int length)
 	case ACK:
 	case DATA:
 		TCHECK(tp->th_block);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," block %d", EXTRACT_16BITS(&tp->th_block));
+		ARGUSBUF_APPEND(" block %d", EXTRACT_16BITS(&tp->th_block));
 		break;
 
 	case ERROR:
 		/* Print error code string */
 		TCHECK(tp->th_code);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)]," %s ", tok2str(err2str, "tftp-err-#%d \"",
+		ARGUSBUF_APPEND(" %s ", tok2str(err2str, "tftp-err-#%d \"",
 				       EXTRACT_16BITS(&tp->th_code)));
 		/* Print error message string */
-		i = fn_print((const u_char *)tp->th_data, snapend, ArgusBuf);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"\"");
+		i = fn_print((const u_char *)tp->th_data, snapend, ArgusBuf, MAXSTRLEN - strlen(ArgusBuf));
+		ARGUSBUF_APPEND("\"");
 		if (i)
 			goto trunc;
 		break;
 
 	default:
 		/* We shouldn't get here */
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"(unknown #%d)", opcode);
+		ARGUSBUF_APPEND("(unknown #%d)", opcode);
 		break;
 	}
 	return ArgusBuf;
 trunc:
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstr);
+	ARGUSBUF_APPEND("%s", tstr);
 	return ArgusBuf;
 }

--- a/examples/radump/print-timed.c
+++ b/examples/radump/print-timed.c
@@ -58,38 +58,38 @@ timed_print(register const u_char *bp, u_int len)
    const u_char *end;
 
    if (endof(tsp->tsp_type) > snapend) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"[|timed]");
+      ARGUSBUF_APPEND("[|timed]");
       return ArgusBuf;
    }
    if (tsp->tsp_type < TSPTYPENUMBER)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"TSP_%s", tsptype[tsp->tsp_type]);
+      ARGUSBUF_APPEND("TSP_%s", tsptype[tsp->tsp_type]);
    else
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"(tsp_type %#x)", tsp->tsp_type);
+      ARGUSBUF_APPEND("(tsp_type %#x)", tsp->tsp_type);
 
    if (endof(tsp->tsp_vers) > snapend) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|timed]");
+      ARGUSBUF_APPEND(" [|timed]");
       return ArgusBuf;
    }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," vers %d", tsp->tsp_vers);
+   ARGUSBUF_APPEND(" vers %d", tsp->tsp_vers);
 
    if (endof(tsp->tsp_seq) > snapend) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|timed]");
+      ARGUSBUF_APPEND(" [|timed]");
       return ArgusBuf;
    }
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," seq %d", tsp->tsp_seq);
+   ARGUSBUF_APPEND(" seq %d", tsp->tsp_seq);
 
    if (tsp->tsp_type == TSP_LOOP) {
       if (endof(tsp->tsp_hopcnt) > snapend) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|timed]");
+         ARGUSBUF_APPEND(" [|timed]");
          return ArgusBuf;
       }
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," hopcnt %d", tsp->tsp_hopcnt);
+      ARGUSBUF_APPEND(" hopcnt %d", tsp->tsp_hopcnt);
    } else if (tsp->tsp_type == TSP_SETTIME ||
      tsp->tsp_type == TSP_ADJTIME ||
      tsp->tsp_type == TSP_SETDATE ||
      tsp->tsp_type == TSP_SETDATEREQ) {
       if (endof(tsp->tsp_time) > snapend) {
-         sprintf(&ArgusBuf[strlen(ArgusBuf)]," [|timed]");
+         ARGUSBUF_APPEND(" [|timed]");
          return ArgusBuf;
       }
       sec = EXTRACT_32BITS(&tsp->tsp_time.tv_sec);
@@ -97,21 +97,21 @@ timed_print(register const u_char *bp, u_int len)
       if (usec < 0)
          /* corrupt, skip the rest of the packet */
          return ArgusBuf;
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," time ");
+      ARGUSBUF_APPEND(" time ");
       if (sec < 0 && usec != 0) {
          sec++;
          if (sec == 0)
-            sprintf(&ArgusBuf[strlen(ArgusBuf)],"-");
+            ARGUSBUF_APPEND("-");
          usec = 1000000 - usec;
       }
-      sprintf(&ArgusBuf[strlen(ArgusBuf)],"%ld.%06ld", sec, usec);
+      ARGUSBUF_APPEND("%ld.%06ld", sec, usec);
    }
 
    end = memchr(tsp->tsp_name, '\0', snapend - (u_char *)tsp->tsp_name);
    if (end == NULL)
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], " [|timed]");
+      ARGUSBUF_APPEND(" [|timed]");
    else {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)], " name");
+      ARGUSBUF_APPEND(" name");
       snprintf(&ArgusBuf[strlen(ArgusBuf)], end - (u_char *)tsp->tsp_name, "%s", tsp->tsp_name);
    }
 

--- a/examples/radump/print-wol.c
+++ b/examples/radump/print-wol.c
@@ -58,7 +58,7 @@ wol_print(const u_char *dat, u_int length)
    const u_char *ptr = dat;
    int i, match = 0;
 
-   sprintf(&ArgusBuf[strlen(ArgusBuf)]," wol:");
+   ARGUSBUF_APPEND(" wol:");
 
    for (i = 0; i < length; i++) {
       if (ptr[i] != 0xff)
@@ -71,8 +71,8 @@ wol_print(const u_char *dat, u_int length)
    }
 
    if (match == 6) {
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," tagged: ");
-      sprintf(&ArgusBuf[strlen(ArgusBuf)]," wake-on-lan eaddr %s", etheraddr_string(ArgusParser, (u_char *)&dat[i]));
+      ARGUSBUF_APPEND(" tagged: ");
+      ARGUSBUF_APPEND(" wake-on-lan eaddr %s", etheraddr_string(ArgusParser, (u_char *)&dat[i]));
    }
 
    return ArgusBuf;

--- a/examples/radump/radump.c
+++ b/examples/radump/radump.c
@@ -549,13 +549,20 @@ void ArgusWindowClose(void) {
 /*
  * Print out a null-terminated filename (or other ascii string).
  * If ep is NULL, assume no truncation check is needed.
- * Return true if truncated.
+ * "buflen" is the number of bytes remaining in "buf" (not including a
+ * terminating NUL) that this call is allowed to write, so a caller
+ * appending to a shared buffer (e.g. &ArgusBuf[strlen(ArgusBuf)]) can pass
+ * the buffer's actual remaining capacity and this function will never
+ * write past it, regardless of how many bytes the record being decoded
+ * claims to contain.
+ * Return true if truncated (either by "ep" or by running out of "buflen").
  */
 int
-fn_print(register const u_char *s, register const u_char *ep, char *buf)
+fn_print(register const u_char *s, register const u_char *ep, char *buf, size_t buflen)
 {
    register int ret;
    register u_char c;
+   char *lim = buf + buflen;
 
    ret = 1;                        /* assume truncated */
    while (ep == NULL || s < ep) {
@@ -564,6 +571,8 @@ fn_print(register const u_char *s, register const u_char *ep, char *buf)
          ret = 0;
          break;
       }
+      if ((buf + strlen(buf) + 4) >= lim)
+         break;                    /* out of room; report truncated */
       if (!isascii(c)) {
          c = toascii(c);
          sprintf(&buf[strlen(buf)], "%c", 'M');
@@ -581,18 +590,24 @@ fn_print(register const u_char *s, register const u_char *ep, char *buf)
 /*                      
  * Print out a counted filename (or other ascii string).
  * If ep is NULL, assume no truncation check is needed.
- * Return true if truncated.
+ * "buflen" is the number of bytes remaining in "buf" (not including a
+ * terminating NUL); see fn_print() above for why this matters.
+ * Returns a pointer to the NUL terminator on success, or NULL if
+ * truncated by "ep" or by running out of "buflen".
  */                     
 
 char *
 fn_printn(register const u_char *s, register u_int n,
-          register const u_char *ep, char *buf)
+          register const u_char *ep, char *buf, size_t buflen)
 {
    register u_char c;
    int len = strlen(buf);
    char *ebuf = &buf[len];
+   char *lim = buf + buflen;
 
    while ((n > 0) && (ep == NULL || s < ep)) {
+      if ((ebuf + 4) >= lim)
+         return (NULL);            /* out of room */
       n--;
       c = *s++;
       if (!isascii(c)) {
@@ -606,6 +621,7 @@ fn_printn(register const u_char *s, register u_int n,
       }
       *ebuf++ = c;
    }
+   *ebuf = '\0';
    return (n == 0) ? ebuf : NULL;
 }
 

--- a/examples/radump/smbutil.c
+++ b/examples/radump/smbutil.c
@@ -259,7 +259,7 @@ print_asc(const unsigned char *buf, int len)
     extern char ArgusBuf[];
     int i;
     for (i = 0; i < len; i++)
-        sprintf(&ArgusBuf[strlen(ArgusBuf)], "%c", buf[i]);
+        ARGUSBUF_APPEND("%c", buf[i]);
 }
 
 static const char *
@@ -286,38 +286,38 @@ print_data(const unsigned char *buf, int len)
 
     if (len <= 0)
 	return;
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"[%03X] ", i);
+    ARGUSBUF_APPEND("[%03X] ", i);
     for (i = 0; i < len; /*nothing*/) {
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02X ", buf[i] & 0xff);
+	ARGUSBUF_APPEND("%02X ", buf[i] & 0xff);
 	i++;
 	if (i%8 == 0)
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+	    ARGUSBUF_APPEND(" ");
 	if (i % 16 == 0) {
 	    print_asc(&buf[i - 16], 8);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+	    ARGUSBUF_APPEND(" ");
 	    print_asc(&buf[i - 8], 8);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+	    ARGUSBUF_APPEND("\n");
 	    if (i < len)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"[%03X] ", i);
+		ARGUSBUF_APPEND("[%03X] ", i);
 	}
     }
     if (i % 16) {
 	int n;
 
 	n = 16 - (i % 16);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+	ARGUSBUF_APPEND(" ");
 	if (n>8)
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+	    ARGUSBUF_APPEND(" ");
 	while (n--)
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"   ");
+	    ARGUSBUF_APPEND("   ");
 
 	n = SMBMIN(8, i % 16);
 	print_asc(&buf[i - (i % 16)], n);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)]," ");
+	ARGUSBUF_APPEND(" ");
 	n = (i % 16) - n;
 	if (n > 0)
 	    print_asc(&buf[i - n], n);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
+	ARGUSBUF_APPEND("\n");
     }
 }
 
@@ -331,7 +331,7 @@ write_bits(unsigned int val, const char *fmt)
     while ((p = strchr(fmt, '|'))) {
 	size_t l = PTR_DIFF(p, fmt);
 	if (l && (val & (1 << i)))
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%.*s ", (int)l, fmt);
+	    ARGUSBUF_APPEND("%.*s ", (int)l, fmt);
 	fmt = p + 1;
 	i++;
     }
@@ -494,7 +494,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    unsigned int x;
 	    TCHECK(buf[0]);
 	    x = buf[0];
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u (0x%x)", x, x);
+	    ARGUSBUF_APPEND("%u (0x%x)", x, x);
 	    buf += 1;
 	    fmt++;
 	    break;
@@ -505,7 +505,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    TCHECK2(buf[0], 2);
 	    x = reverse ? EXTRACT_16BITS(buf) :
 			  EXTRACT_LE_16BITS(buf);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d (0x%x)", x, x);
+	    ARGUSBUF_APPEND("%d (0x%x)", x, x);
 	    buf += 2;
 	    fmt++;
 	    break;
@@ -516,7 +516,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    TCHECK2(buf[0], 4);
 	    x = reverse ? EXTRACT_32BITS(buf) :
 			  EXTRACT_LE_32BITS(buf);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%d (0x%x)", x, x);
+	    ARGUSBUF_APPEND("%d (0x%x)", x, x);
 	    buf += 4;
 	    fmt++;
 	    break;
@@ -527,7 +527,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    TCHECK2(buf[0], 8);
 	    x = reverse ? EXTRACT_64BITS(buf) :
 			  EXTRACT_LE_64BITS(buf);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%" PRIu64 " (0x%" PRIx64 ")", x, x);
+	    ARGUSBUF_APPEND("%" PRIu64 " (0x%" PRIx64 ")", x, x);
 	    buf += 8;
 	    fmt++;
 	    break;
@@ -543,7 +543,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    x2 = reverse ? EXTRACT_32BITS(buf + 4) :
 			   EXTRACT_LE_32BITS(buf + 4);
 	    x = (((u_int64_t)x1) << 32) | x2;
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%" PRIu64 " (0x%" PRIx64 ")", x, x);
+	    ARGUSBUF_APPEND("%" PRIu64 " (0x%" PRIx64 ")", x, x);
 	    buf += 8;
 	    fmt++;
 	    break;
@@ -553,7 +553,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    unsigned int x;
 	    TCHECK(buf[0]);
 	    x = buf[0];
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"0x%X", x);
+	    ARGUSBUF_APPEND("0x%X", x);
 	    buf += 1;
 	    fmt++;
 	    break;
@@ -564,7 +564,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    TCHECK2(buf[0], 2);
 	    x = reverse ? EXTRACT_16BITS(buf) :
 			  EXTRACT_LE_16BITS(buf);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"0x%X", x);
+	    ARGUSBUF_APPEND("0x%X", x);
 	    buf += 2;
 	    fmt++;
 	    break;
@@ -575,7 +575,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    TCHECK2(buf[0], 4);
 	    x = reverse ? EXTRACT_32BITS(buf) :
 			  EXTRACT_LE_32BITS(buf);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"0x%X", x);
+	    ARGUSBUF_APPEND("0x%X", x);
 	    buf += 4;
 	    fmt++;
 	    break;
@@ -588,7 +588,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    case 'b':
 		TCHECK(buf[0]);
 		stringlen = buf[0];
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", stringlen);
+		ARGUSBUF_APPEND("%u", stringlen);
 		buf += 1;
 		break;
 
@@ -596,7 +596,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 		TCHECK2(buf[0], 2);
 		stringlen = reverse ? EXTRACT_16BITS(buf) :
 				      EXTRACT_LE_16BITS(buf);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", stringlen);
+		ARGUSBUF_APPEND("%u", stringlen);
 		buf += 2;
 		break;
 
@@ -604,7 +604,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 		TCHECK2(buf[0], 4);
 		stringlen = reverse ? EXTRACT_32BITS(buf) :
 				      EXTRACT_LE_32BITS(buf);
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%u", stringlen);
+		ARGUSBUF_APPEND("%u", stringlen);
 		buf += 4;
 		break;
 	    }
@@ -622,7 +622,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    s = unistr(buf, &len, (*fmt == 'R') ? 0 : unicodestr);
 	    if (s == NULL)
 		goto trunc;
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", s);
+	    ARGUSBUF_APPEND("%s", s);
 	    buf += len;
 	    fmt++;
 	    break;
@@ -635,14 +635,14 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 
 	    TCHECK(*buf);
 	    if (*buf != 4 && *buf != 2) {
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"Error! ASCIIZ buffer of type %u", *buf);
+		ARGUSBUF_APPEND("Error! ASCIIZ buffer of type %u", *buf);
 		return maxbuf;	/* give up */
 	    }
 	    len = 0;
 	    s = unistr(buf + 1, &len, (*fmt == 'Y') ? 0 : unicodestr);
 	    if (s == NULL)
 		goto trunc;
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", s);
+	    ARGUSBUF_APPEND("%s", s);
 	    buf += len + 1;
 	    fmt++;
 	    break;
@@ -651,7 +651,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	  {
 	    int l = atoi(fmt + 1);
 	    TCHECK2(*buf, l);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%-*.*s", l, l, buf);
+	    ARGUSBUF_APPEND("%-*.*s", l, l, buf);
 	    buf += l;
 	    fmt++;
 	    while (isdigit((unsigned char)*fmt))
@@ -661,7 +661,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	case 'c':
 	  {
 	    TCHECK2(*buf, stringlen);
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%-*.*s", (int)stringlen, (int)stringlen, buf);
+	    ARGUSBUF_APPEND("%-*.*s", (int)stringlen, (int)stringlen, buf);
 	    buf += stringlen;
 	    fmt++;
 	    while (isdigit((unsigned char)*fmt))
@@ -674,7 +674,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    s = unistr(buf, &stringlen, unicodestr);
 	    if (s == NULL)
 		goto trunc;
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", s);
+	    ARGUSBUF_APPEND("%s", s);
 	    buf += stringlen;
 	    fmt++;
 	    break;
@@ -684,7 +684,7 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    int l = atoi(fmt + 1);
 	    TCHECK2(*buf, l);
 	    while (l--)
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%02x", *buf++);
+		ARGUSBUF_APPEND("%02x", *buf++);
 	    fmt++;
 	    while (isdigit((unsigned char)*fmt))
 		fmt++;
@@ -707,13 +707,13 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 		if (len < 0)
 		    goto trunc;
 		buf += len;
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%-15.15s NameType=0x%02X (%s)", nbuf, name_type,
+		ARGUSBUF_APPEND("%-15.15s NameType=0x%02X (%s)", nbuf, name_type,
 		    name_type_str(name_type));
 		break;
 	    case 2:
 		TCHECK(buf[15]);
 		name_type = buf[15];
-		sprintf(&ArgusBuf[strlen(ArgusBuf)],"%-15.15s NameType=0x%02X (%s)", buf, name_type,
+		ARGUSBUF_APPEND("%-15.15s NameType=0x%02X (%s)", buf, name_type,
 		    name_type_str(name_type));
 		buf += 16;
 		break;
@@ -763,27 +763,27 @@ smb_fdata1(const u_char *buf, const char *fmt, const u_char *maxbuf,
 		    tstring = "(Can't convert time)\n";
 	    } else
 		tstring = "NULL\n";
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%s", tstring);
+	    ARGUSBUF_APPEND("%s", tstring);
 	    fmt++;
 	    while (isdigit((unsigned char)*fmt))
 		fmt++;
 	    break;
 	  }
 	default:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%c", *fmt);
+	    ARGUSBUF_APPEND("%c", *fmt);
 	    fmt++;
 	    break;
 	}
     }
 
     if (buf >= maxbuf && *fmt)
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"END OF BUFFER\n");
+	ARGUSBUF_APPEND("END OF BUFFER\n");
 
     return(buf);
 
 trunc:
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"\n");
-    sprintf(&ArgusBuf[strlen(ArgusBuf)],"WARNING: Short packet. Try increasing the snap length\n");
+    ARGUSBUF_APPEND("\n");
+    ARGUSBUF_APPEND("WARNING: Short packet. Try increasing the snap length\n");
     return(NULL);
 }
 
@@ -847,14 +847,14 @@ smb_fdata(const u_char *buf, const char *fmt, const u_char *maxbuf,
 	    break;
 
 	default:
-	    sprintf(&ArgusBuf[strlen(ArgusBuf)],"%c", *fmt);
+	    ARGUSBUF_APPEND("%c", *fmt);
 	    fmt++;
 	    break;
 	}
     }
     if (!depth && buf < maxbuf) {
 	size_t len = PTR_DIFF(maxbuf, buf);
-	sprintf(&ArgusBuf[strlen(ArgusBuf)],"Data: (%lu bytes)\n", (unsigned long)len);
+	ARGUSBUF_APPEND("Data: (%lu bytes)\n", (unsigned long)len);
 	print_data(buf, len);
 	return(buf + len);
     }

--- a/examples/ramysql/raclient.c
+++ b/examples/ramysql/raclient.c
@@ -226,7 +226,7 @@ ArgusProcessData (void *arg)
 
          if ((!(parser->status & ARGUS_FILE_LIST_PROCESSED)) && ((file = parser->ArgusInputFileList) != NULL)) {
             while (file && parser->eNflag) {
-               if ((input = ArgusMalloc(sizeof(*input))) == NULL)
+               if ((input = ArgusCalloc(1, sizeof(*input))) == NULL)
                   ArgusLog(LOG_ERR, "unable to allocate input structure\n");
 
                ArgusInputFromFile(input, file);

--- a/examples/ramysql/rasqltimeindex.c
+++ b/examples/ramysql/rasqltimeindex.c
@@ -967,7 +967,7 @@ ArgusClientInit (struct ArgusParserStruct *parser)
          struct ArgusFileInput *nxtfile;
          struct ArgusFileInput *file;
 
-         input = ArgusMalloc(sizeof(*input));
+         input = ArgusCalloc(1, sizeof(*input));
          if (input == NULL)
             ArgusLog(LOG_ERR, "unable to allocate input structure\n");
 

--- a/examples/raqsort/raqsort.c
+++ b/examples/raqsort/raqsort.c
@@ -321,7 +321,7 @@ RaParseComplete (int sig)
       file = ArgusParser->ArgusInputFileList;
 
       if (file) {
-         input = ArgusMalloc(sizeof(*input));
+         input = ArgusCalloc(1, sizeof(*input));
          if (input == NULL)
             ArgusLog(LOG_ERR, "unable to allocate input structure\n");
 

--- a/examples/ratop/raclient.c
+++ b/examples/ratop/raclient.c
@@ -394,7 +394,7 @@ ArgusProcessData (void *arg)
 
          if ((!(parser->status & ARGUS_FILE_LIST_PROCESSED)) && ((file = parser->ArgusInputFileList) != NULL)) {
             while (file && parser->eNflag) {
-               if ((input = ArgusMalloc(sizeof(*input))) == NULL)
+               if ((input = ArgusCalloc(1, sizeof(*input))) == NULL)
                   ArgusLog(LOG_ERR, "unable to allocate input structure\n");
 
                switch (file->type) {

--- a/include/argus_int.h
+++ b/include/argus_int.h
@@ -105,8 +105,8 @@ extern char timestamp_fmt[];
 extern long timestamp_scale;
 extern void timestampinit(void);
 
-extern int fn_print(const u_char *, const u_char *, char *);
-extern char *fn_printn(const u_char *, u_int, const u_char *, char *);
+extern int fn_print(const u_char *, const u_char *, char *, size_t);
+extern char *fn_printn(const u_char *, u_int, const u_char *, char *, size_t);
 extern char *dnaddr_string(u_short);
 extern char *savestr(const char *);
 

--- a/pythonlib/argusPython.c
+++ b/pythonlib/argusPython.c
@@ -1257,7 +1257,7 @@ ArgusLoadDataFiles (struct ArgusParserStruct *parser, int type)
 #ifdef ARGUSDEBUG
       ArgusDebug (1, "ArgusLoadDataFiles (%p, %d) allocating input struct", parser, type);
 #endif
-      input = ArgusMalloc(sizeof(*input));
+      input = ArgusCalloc(1, sizeof(*input));
       if (input == NULL)
          ArgusLog(LOG_ERR, "unable to allocate input structure\n");
 


### PR DESCRIPTION
F-CL-29: swapped sprintf() arguments in print-snmp.c's snmp_print() (two sites) — a read-only string literal was used as the destination buffer and attacker-influenced SNMP data was used as the format string. Corrected argument order at both sites.

F-CL-30: unbounded sprintf-append to the fixed-size global ArgusBuf scratch buffer across radump's protocol printers and radns/radomain.c, plus unbounded raw-pointer writes in the shared fn_print()/fn_printn() helpers. Added a bounded ARGUSBUF_APPEND() macro and mechanically converted 2092 call sites in 32 radump/*.c files and 81 in radomain.c; added a buflen parameter to fn_print()/fn_printn() with explicit bounds checks and NUL-termination; manually hardened radomain.c's ns_nprint()/ns_cprint(), which had additional unbounded raw writes.

F-CL-31: the -s +suser:N/+duser:N CLI field-length option was never clamped against the fixed-size internal buffers it feeds downstream (MAXSTRLEN-sized label buffers, the 65536-byte ArgusPrintTempBuf). Clamped RaNewLength to MAXSTRLEN at the point it is parsed in ArgusProcessSOptions(), plus added defensive snprintf/bounds clamps in ArgusPrintSrcUserDataLabel()/ArgusPrintDstUserDataLabel().

F-CL-32: struct ArgusInput was allocated via ArgusMalloc() (plain malloc, not zeroed) but ArgusInputFromFile() immediately checks input->ArgusReadBuffer != NULL before calling ArgusFree() on it — a free() on uninitialized/garbage memory. Fixed all 7 independent copies of this allocation pattern (common/argus_main.c plus 6 other files) by switching to ArgusCalloc(1, sizeof(*input)).

F-CL-31 and F-CL-32 were found via AddressSanitizer verification of the F-CL-29/F-CL-30 fixes against real captured traffic, and confirmed to reproduce identically on unmodified main.

Verified via: full clean rebuild (production and ASan-instrumented, zero errors in both); functional smoke-testing of ra/radump/radns against a real capture file (DNS/SMB/RDP traffic) across multiple flag combinations including all 5 -M printer= encoding modes and -s lengths up to 1,000,000 — all clean exits, zero ASan errors, decode output matching the pre-fix baseline byte-for-byte at previously-working flag combinations.