### PR TITLE
Fix GeoIP labeling bugs and a general ENCAPS record-generation overflow

### DIFF
--- a/common/argus_label_geoip.c
+++ b/common/argus_label_geoip.c
@@ -303,7 +303,8 @@ ArgusLabelRecordGeoIP(struct ArgusParserStruct *parser,
                         if (labeler->RaLabelGeoIPCity & ARGUS_SRC_ADDR)
                            if ((gir = GeoIP_record_by_ipnum (labeler->RaGeoIPv4CityObject, flow->ip_flow.ip_src)) != NULL) {
                               if ((geo = (struct ArgusGeoLocationStruct *)argus->dsrs[ARGUS_GEO_INDEX]) == NULL) {
-                                 geo = (struct ArgusGeoLocationStruct *) ArgusCalloc(1, sizeof(*geo));
+                                 if ((geo = (struct ArgusGeoLocationStruct *) ArgusCalloc(1, sizeof(*geo))) == NULL)
+                                    ArgusLog (LOG_ERR, "%s: ArgusCalloc error %s", __func__, strerror(errno));
                                  geo->hdr.type = ARGUS_GEO_DSR;
                                  geo->hdr.argus_dsrvl8.len = (sizeof(*geo) + 3) / 4;
 
@@ -322,7 +323,8 @@ ArgusLabelRecordGeoIP(struct ArgusParserStruct *parser,
                         if (labeler->RaLabelGeoIPCity & ARGUS_DST_ADDR)
                            if ((gir = GeoIP_record_by_ipnum (labeler->RaGeoIPv4CityObject, flow->ip_flow.ip_dst)) != NULL) {
                               if ((geo = (struct ArgusGeoLocationStruct *)argus->dsrs[ARGUS_GEO_INDEX]) == NULL) {
-                                 geo = (struct ArgusGeoLocationStruct *) ArgusCalloc(1, sizeof(*geo));
+                                 if ((geo = (struct ArgusGeoLocationStruct *) ArgusCalloc(1, sizeof(*geo))) == NULL)
+                                    ArgusLog (LOG_ERR, "%s: ArgusCalloc error %s", __func__, strerror(errno));
                                  geo->hdr.type = ARGUS_GEO_DSR;
                                  geo->hdr.argus_dsrvl8.len = (sizeof(*geo) + 3) / 4;
                                  argus->dsrs[ARGUS_GEO_INDEX] = &geo->hdr;
@@ -352,7 +354,8 @@ ArgusLabelRecordGeoIP(struct ArgusParserStruct *parser,
                                              case ARGUS_TYPE_IPV4:
                                                 if ((gir = GeoIP_record_by_ipnum (labeler->RaGeoIPv4CityObject, icmp->osrcaddr)) != NULL) {
                                                    if ((geo = (struct ArgusGeoLocationStruct *)argus->dsrs[ARGUS_GEO_INDEX]) == NULL) {
-                                                      geo = (struct ArgusGeoLocationStruct *) ArgusCalloc(1, sizeof(*geo));
+                                                      if ((geo = (struct ArgusGeoLocationStruct *) ArgusCalloc(1, sizeof(*geo))) == NULL)
+                                                         ArgusLog (LOG_ERR, "%s: ArgusCalloc error %s", __func__, strerror(errno));
                                                       geo->hdr.type = ARGUS_GEO_DSR;
                                                       geo->hdr.argus_dsrvl8.len = (sizeof(*geo) + 3) / 4;
                                                       argus->dsrs[ARGUS_GEO_INDEX] = &geo->hdr;
@@ -441,14 +444,20 @@ ArgusFormatDSR_GEO(struct ArgusParserStruct *parser,
 
    geo = (struct ArgusGeoLocationStruct *)argus->dsrs[ARGUS_GEO_INDEX];
    if (geo == NULL) {
-      geo = (struct ArgusGeoLocationStruct *) ArgusCalloc(1, sizeof(*geo));
+      if ((geo = (struct ArgusGeoLocationStruct *) ArgusCalloc(1, sizeof(*geo))) == NULL)
+         ArgusLog (LOG_ERR, "%s: ArgusCalloc error %s", __func__, strerror(errno));
       geo->hdr.type = ARGUS_GEO_DSR;
       geo->hdr.argus_dsrvl8.len = (sizeof(*geo) + 3) / 4;
       argus->dsrs[ARGUS_GEO_INDEX] = &geo->hdr;
       argus->dsrindex |= (0x1 << ARGUS_GEO_INDEX);
    }
 
-   geo->hdr.argus_dsrvl8.qual |= ARGUS_DST_GEO;
+   if (dir & ARGUS_SRC_ADDR)
+      geo->hdr.argus_dsrvl8.qual |= ARGUS_SRC_GEO;
+   else if (dir & ARGUS_DST_ADDR)
+      geo->hdr.argus_dsrvl8.qual |= ARGUS_DST_GEO;
+   else if (dir & ARGUS_INODE_ADDR)
+      geo->hdr.argus_dsrvl8.qual |= ARGUS_INODE_GEO;
    if (!strcmp(user, "latitude")) {
       if (dir & ARGUS_DST_ADDR)
          geo->dst.lat = (float)value->entry_data.double_value;
@@ -699,7 +708,7 @@ dump_entry_data_list(
    /* Check if Argus knows anything about the current datum */
    gkey.geoip2_path = strdup(path);
    if (gkey.geoip2_path == NULL)
-      ArgusLog(LOG_ERR, "%s: unable to duplicate path string");
+      ArgusLog(LOG_ERR, "%s: unable to duplicate path string", __func__);
 
 #ifdef ARGUSDEBUG
    ArgusDebug(4, "looking for \"%s\"\n", path);
@@ -1014,7 +1023,7 @@ ArgusLabelRecordGeoIP2(struct ArgusParserStruct *parser,
                         label, &str_offset, &str_remain, ARGUS_SRC_ADDR);
 
          }
-         if (labeler->RaLabelGeoIPAsn & ARGUS_DST_ADDR) {
+         if (labeler->RaLabelGeoIPAsn & ARGUS_SRC_ADDR) {
             addr.sin_addr.s_addr = htonl(flow->ip_flow.ip_src);
             lookup_asn(parser, argus, "", (struct sockaddr *)&addr,
                        label, &str_offset, &str_remain, ARGUS_SRC_ADDR);

--- a/common/argus_output.c
+++ b/common/argus_output.c
@@ -2159,6 +2159,43 @@ ArgusGenerateV3Record (struct ArgusRecordStruct *rec, unsigned char state, char 
                            len = 0;
                         break;
                      }
+
+
+                     case ARGUS_ENCAPS_INDEX: {
+                        struct ArgusEncapsStruct *encaps = (struct ArgusEncapsStruct *) dsr;
+                        int slen = 0, dlen = 0;
+
+                        *dsrptr++ = *(unsigned int *)&encaps->hdr;
+                        *dsrptr++ = encaps->src;
+                        *dsrptr++ = encaps->dst;
+                        len = 3;
+
+                        if ((encaps->slen > 0) || (encaps->dlen > 0)) {
+                           slen = (encaps->slen + 3) / 4;
+                           dlen = (encaps->dlen + 3) / 4;
+
+                           *dsrptr++ = ((unsigned int *)&encaps->slen)[0];
+                           len++;
+
+                           if (slen > 0) {
+                              if (encaps->sbuf != NULL)
+                                 bcopy((char *)encaps->sbuf, (char *)dsrptr, encaps->slen);
+                              if ((slen * 4) > encaps->slen)
+                                 bzero(&((char *)dsrptr)[encaps->slen], (slen * 4) - encaps->slen);
+                              dsrptr += slen;
+                              len += slen;
+                           }
+                           if (dlen > 0) {
+                              if (encaps->dbuf != NULL)
+                                 bcopy((char *)encaps->dbuf, (char *)dsrptr, encaps->dlen);
+                              if ((dlen * 4) > encaps->dlen)
+                                 bzero(&((char *)dsrptr)[encaps->dlen], (dlen * 4) - encaps->dlen);
+                              dsrptr += dlen;
+                              len += dlen;
+                           }
+                        }
+                        break;
+                     }
                   }
 
                   dsrlen += len;
@@ -3043,6 +3080,43 @@ ArgusGenerateV5Record (struct ArgusRecordStruct *rec, unsigned char state, char 
                            len = 1 + ((labelen + 3)/4);
                         } else
                            len = 0;
+                        break;
+                     }
+
+
+                     case ARGUS_ENCAPS_INDEX: {
+                        struct ArgusEncapsStruct *encaps = (struct ArgusEncapsStruct *) dsr;
+                        int slen = 0, dlen = 0;
+
+                        *dsrptr++ = *(unsigned int *)&encaps->hdr;
+                        *dsrptr++ = encaps->src;
+                        *dsrptr++ = encaps->dst;
+                        len = 3;
+
+                        if ((encaps->slen > 0) || (encaps->dlen > 0)) {
+                           slen = (encaps->slen + 3) / 4;
+                           dlen = (encaps->dlen + 3) / 4;
+
+                           *dsrptr++ = ((unsigned int *)&encaps->slen)[0];
+                           len++;
+
+                           if (slen > 0) {
+                              if (encaps->sbuf != NULL)
+                                 bcopy((char *)encaps->sbuf, (char *)dsrptr, encaps->slen);
+                              if ((slen * 4) > encaps->slen)
+                                 bzero(&((char *)dsrptr)[encaps->slen], (slen * 4) - encaps->slen);
+                              dsrptr += slen;
+                              len += slen;
+                           }
+                           if (dlen > 0) {
+                              if (encaps->dbuf != NULL)
+                                 bcopy((char *)encaps->dbuf, (char *)dsrptr, encaps->dlen);
+                              if ((dlen * 4) > encaps->dlen)
+                                 bzero(&((char *)dsrptr)[encaps->dlen], (dlen * 4) - encaps->dlen);
+                              dsrptr += dlen;
+                              len += dlen;
+                           }
+                        }
                         break;
                      }
 


### PR DESCRIPTION
This closes out the Phase 2 security review's GeoIP subsystem, the last remaining item, by rebuilding with --with-libmaxminddb so common/argus_label_geoip.c is compiled and exercised for the first time (it was previously dead code with respect to build/test coverage), then fixing 4 bugs found via functional testing against real GeoLite2 databases and real argus data, 3 with AddressSanitizer.

F-CL-33: ArgusLabelRecordGeoIP2()'s IPv4 source-address ASN lookup was gated on RaLabelGeoIPAsn & ARGUS_DST_ADDR instead of ARGUS_SRC_ADDR, so RALABEL_GEOIP_ASN="saddr:asn" silently produced no output while "daddr:asn" produced both sasn and dasn. Corrected the guard.

F-CL-34: dump_entry_data_list()'s ArgusLog() call for a failed strdup() was missing the %s argument for the "%s: ..." format string, reading garbage from an uninitialized va_arg slot. Added the missing __func__ argument.

F-CL-35: four call sites (two in the never-built legacy GeoIP1 path gated by #ifdef ARGUS_GEOIP, two in the compiled GEOIP2/libmaxminddb path) left ArgusCalloc()'s return value unchecked before dereferencing it. Added NULL checks with ArgusLog(LOG_ERR, ...) on failure, matching the codebase convention used elsewhere in this file. Also corrected ArgusFormatDSR_GEO() (the compiled GEOIP2 city-coordinate formatter), which unconditionally set qual |= ARGUS_DST_GEO regardless of the actual dir parameter; it now sets ARGUS_SRC_GEO/ARGUS_DST_GEO/ ARGUS_INODE_GEO based on dir, matching the pattern already used by the legacy path and by the qual-bit consumers in argus_output.c and argus_client.c.

F-CL-36: ArgusGenerateV5Record() and ArgusGenerateV3Record() (the general FAR-record serializers in common/argus_output.c, unrelated to GeoIP) have no case for ARGUS_ENCAPS_INDEX in their DSR-copy switch, so any record carrying an ARGUS_ENCAPS DSR (GRE/VXLAN/GENEVE-tunneled traffic) fell through to the generic default: case. That default copies len 32-bit words directly from the wire-format DSR header's length field, but ArgusCopyRecordStruct() allocates only the fixed 32-byte struct ArgusEncapsStruct for this DSR type — the on-wire length (header + variable-length encapsulation payload) is larger, producing a heap-buffer-overflow read confirmed under AddressSanitizer and reproducible on unmodified main with no GeoIP labeling configured at all (real bin/ralabel -f <any config, even empty> -w ... run). The existing default: path is also semantically wrong for this DSR type, since it would serialize the sbuf/dbuf heap pointer values onto the wire instead of the encapsulated packet bytes they reference. Added a dedicated ARGUS_ENCAPS_INDEX case to both serializers that copies the fixed header/src/dst fields and, when present, the variable-length sbuf/dbuf capture buffers (word-aligned with zero-padding), mirroring the equivalent serialization logic in the already-reviewed argus sensor's ArgusModeler.c.

Verified via: full clean rebuild (production and ASan-instrumented, zero errors in both, 36 baseline linker alignment warnings unchanged); functional smoke-testing of ra/radump/radns against a real capture file (unchanged 44/44/10 line baseline); GeoIP city+ASN+coordinate labeling against real GeoLite2-City/GeoLite2-ASN databases and real public-IP argus data (1825 IP records, 1384 ICMP/inode-address records), with and without -w (exercising ArgusCopyRecordStruct/ArgusGenerateV5Record); saddr-only/daddr-only ASN regression tests for F-CL-33; the F-CL-36 ENCAPS heap-overflow repro clean under ASan after the fix, with output record counts and content matching the pre-fix (crashing) baseline behavior exactly once the crash is removed.