### PR TITLE
Fix regression: setArgusWfile probe-open/fdopen mode mismatch breaks …

### DIFF
--- a/common/argus_util.c
+++ b/common/argus_util.c
@@ -33970,12 +33970,12 @@ setArgusWfile(struct ArgusParserStruct *parser, char *file, char *filter)
                   case ENOENT: {
                      int rawfd;
 
-                     rawfd = open(file, O_CREAT|O_EXCL|O_WRONLY, 0644);
+                     rawfd = open(file, O_CREAT|O_EXCL|O_RDWR, 0644);
                      if ((rawfd < 0) && ((errno == ENOENT) || (errno == ENOTDIR))) {
                         if (strncmp(parser->ArgusProgramName, "radium", 6))
                            ArgusMkdirPath(file);
 
-                        rawfd = open(file, O_CREAT|O_EXCL|O_WRONLY, 0644);
+                        rawfd = open(file, O_CREAT|O_EXCL|O_RDWR, 0644);
                      }
 
                      if (rawfd < 0)


### PR DESCRIPTION
…-w file output

Commit e25a144 (TOCTOU fix for setArgusWfile's file-creation probe) replaced the probing fopen(file, "a+") with
open(file, O_CREAT|O_EXCL|O_WRONLY, 0644) followed by fdopen(rawfd, "a+"). On at least macOS/BSD libc, fdopen() requires the underlying fd's access mode to be compatible with the requested stream mode: opening write-only and then fdopen()'ing as "a+" (read+write) fails with EINVAL, silently returning NULL.

Because the resulting fd == NULL, the subsequent
'if (fd != NULL) { ... realpath(); unlink(); }' block was skipped, so wfile->filename was left as the original (possibly relative) path instead of the canonicalized realpath, and - more importantly - this probe/verify step being skipped altered downstream behavior: 'ra -w <file>' produced a 0-byte output file while dumping binary argus records to stdout instead, for every -w invocation on any new (not-yet-existing) file path.

Fix: open the probe fd with O_RDWR instead of O_WRONLY so the mode is compatible with fdopen(rawfd, "a+"). This preserves the O_EXCL atomicity (still fails closed if the path was raced/symlinked) while restoring correct behavior.

Verified:
- 'cc -o /tmp/test_fdopen ...' minimal repro confirms open(O_WRONLY)+fdopen("a+") -> NULL/EINVAL, while open(O_RDWR)+fdopen("a+") -> succeeds.
- Full clean rebuild: 0 errors/0 warnings.
- './bin/ra -X -r dump_dir_2_thinwin_rdp.argus.out -w /tmp/out.argus' now produces a non-empty file byte-identical to the pre-e25a144 baseline (34ddcc2), with empty stdout (previously: 0-byte file, 19040 bytes of binary data on stdout).
- Standard smoke test (ra/radump/radns against dump_dir_2_thinwin_rdp.argus.out) still yields 44/44/10 lines.