### PR TITLE
Fix remaining CodeQL alerts: snprintf overflow, format-string type

### DIFF
--- a/common/argus_util.c
+++ b/common/argus_util.c
@@ -1168,7 +1168,7 @@ ArgusMainInit (struct ArgusParserStruct *parser, int argc, char **argv)
             strncat (parser->ArgusProgramArgs, " ", (len - strlen(parser->ArgusProgramArgs) - 1)); 
          }
       } else             
-         ArgusLog (LOG_ERR, "ArgusCalloc(%d, %d) failed %s", len, sizeof(char), strerror(errno));
+         ArgusLog (LOG_ERR, "ArgusCalloc(%d, %zu) failed %s", len, sizeof(char), strerror(errno));
    } 
 
    if (gettimeofday(&parser->ArgusRealTime, &tz) < 0)
@@ -6209,7 +6209,7 @@ ArgusPrintRecord (struct ArgusParserStruct *parser, char *buf, struct ArgusRecor
                               if (parser->ArgusPrintJson) {
                                  if (parser->ArgusPrintD3 && ((parser->RaPrintAlgorithm->print == ArgusPrintStartDate ) ||
                                                            (parser->RaPrintAlgorithm->print == ArgusPrintLastDate ))) {
-                                    slen = snprintf(&buf[blen], (len - blen), "%c%s%c:%s%c", 
+                                    slen = snprintf(&buf[blen], (blen < len) ? (len - blen) : 0, "%c%s%c:%s%c", 
                                        parser->RaFieldQuoted, parser->RaPrintAlgorithm->field, parser->RaFieldQuoted,
                                        tmpbuf, parser->RaFieldDelimiter);
 				    
@@ -6267,11 +6267,11 @@ ArgusPrintRecord (struct ArgusParserStruct *parser, char *buf, struct ArgusRecor
                            }
 
                         } else {
-                           slen = snprintf(&buf[blen], (len - blen), "%s%c", tmpbuf, parser->RaFieldDelimiter);
+                           slen = snprintf(&buf[blen], (blen < len) ? (len - blen) : 0, "%s%c", tmpbuf, parser->RaFieldDelimiter);
                         }
 
                      } else {
-                        dlen = len - blen;
+                        dlen = (blen < len) ? (len - blen) : 0;
                         slen = snprintf(&buf[blen], dlen, "%s", tmpbuf);
                      }
 
@@ -6332,7 +6332,7 @@ ArgusPrintRecord (struct ArgusParserStruct *parser, char *buf, struct ArgusRecor
                               break;
 		        }
                      } else
-                        slen = snprintf(&buf[blen], (len - blen), "%c%s%c%c", 
+                        slen = snprintf(&buf[blen], (blen < len) ? (len - blen) : 0, "%c%s%c%c", 
 			         parser->RaFieldQuoted, tmpbuf, parser->RaFieldQuoted, parser->RaFieldDelimiter);
                   }
                   parser->RaPrintAlgorithm->offset = blen;
@@ -32040,7 +32040,7 @@ ArgusReadConnection (struct ArgusParserStruct *parser, struct ArgusInput *input,
 #endif
 
                default:
-                  ArgusLog (LOG_ERR, "ArgusReadConnection(0x%x) unknown source type", input);
+                  ArgusLog (LOG_ERR, "ArgusReadConnection(%p) unknown source type", (void *)input);
                   break;
             }
 
@@ -32353,13 +32353,28 @@ ArgusReadConnection (struct ArgusParserStruct *parser, struct ArgusInput *input,
                               }
                            }
 
-                           if (input->major_version >= MAJOR_VERSION_3) {
-                              if (!parser->RaPollMode) {
-                                 char *cmd = parser->ArgusProgramName;
-                                 struct passwd *pw = getpwuid(parser->uid);
-                                 pid_t pid = parser->pid;
+                            if (input->major_version >= MAJOR_VERSION_3) {
+                               if (!parser->RaPollMode) {
+                                  char *cmd = parser->ArgusProgramName;
+                                  struct passwd *pw = getpwuid(parser->uid);
+                                  pid_t pid = parser->pid;
 
-                                 snprintf ((char *) buf, ARGUS_RINGBUFFER_MAX, "START: user='%s',cmd='%s[%d]'", pw->pw_name, cmd, pid);
+                                  /* CodeQL: cpp/cleartext-transmission of system data.
+                                   * This intentionally sends the local user name, program
+                                   * name and pid to the remote argus/radium server as a
+                                   * client session-identification string. The server only
+                                   * ever uses this value (client->clientid, see
+                                   * ArgusCheckClientMessage()/RADIUM_START in
+                                   * argus_output.c) for human-readable log/diagnostic
+                                   * messages -- it is never used for authentication,
+                                   * authorization, or any other access-control decision.
+                                   * Treated as an accepted risk of the existing wire
+                                   * protocol rather than an accidental data leak; operators
+                                   * who consider this sensitive on untrusted networks
+                                   * should run argus/radium connections over an encrypted
+                                   * transport (e.g. TLS or an SSH tunnel).
+                                   */
+                                  snprintf ((char *) buf, ARGUS_RINGBUFFER_MAX, "START: user='%s',cmd='%s[%d]'", pw->pw_name, cmd, pid);
 
                                  len = strlen((char *) buf);
                                  if (ArgusWriteConnection (parser, input, (u_char *) buf, len) < 0) {
@@ -32530,14 +32545,14 @@ ArgusReadConnection (struct ArgusParserStruct *parser, struct ArgusInput *input,
                break;
 
             default:
-               ArgusLog (LOG_ERR, "ArgusReadConnection(0x%x) unknown source type", input);
+               ArgusLog (LOG_ERR, "ArgusReadConnection(%p) unknown source type", (void *)input);
                break;
          }
          break;
       }
 
       default:
-         ArgusLog (LOG_ERR, "ArgusReadConnection(0x%x) unknown stream type", input);
+         ArgusLog (LOG_ERR, "ArgusReadConnection(%p) unknown stream type", (void *)input);
          break;
    }
 
@@ -33592,7 +33607,7 @@ ArgusWriteNewLogfile (struct ArgusParserStruct *parser, struct ArgusInput *input
             if ((stat (file, &wfile->statbuf) < 0)) {
                if (wfile->fd != NULL) {
                   if (fflush (wfile->fd) != 0)
-                     ArgusLog (LOG_ERR, "ArgusWriteNewLogfile(%s, 0x%x) fflush error %s", file, argus, strerror(errno));
+                     ArgusLog (LOG_ERR, "ArgusWriteNewLogfile(%s, %p) fflush error %s", file, (void *)argus, strerror(errno));
                   fclose (wfile->fd);
                   wfile->fd = NULL;
                }
@@ -33603,15 +33618,28 @@ ArgusWriteNewLogfile (struct ArgusParserStruct *parser, struct ArgusInput *input
             }
             wfile->laststat = parser->ArgusRealTime;
             if (fflush (wfile->fd) != 0)
-               ArgusLog (LOG_ERR, "ArgusWriteNewLogfile(%s, 0x%x) fflush error %s", file, argus, strerror(errno));
+               ArgusLog (LOG_ERR, "ArgusWriteNewLogfile(%s, %p) fflush error %s", file, (void *)argus, strerror(errno));
          }
       }
 
       if (wfile->fd == NULL) {
          ArgusMkdirPath(file);
 
-         if ((wfile->fd = fopen (file, "a+")) == NULL)
-            ArgusLog (LOG_ERR, "ArgusWriteNewLogfile(%s, 0x%x) fopen %s", file, argus, strerror(errno));
+         {
+            /* Open with O_NOFOLLOW so that if an attacker has swapped
+             * this path for a symlink in the window since the stat()
+             * above, we fail closed rather than transparently writing
+             * through the symlink (TOCTOU hardening).
+             */
+            int rawfd = open(file, O_CREAT|O_APPEND|O_WRONLY|O_NOFOLLOW, 0644);
+            if (rawfd < 0)
+               wfile->fd = NULL;
+            else
+               wfile->fd = fdopen(rawfd, "a");
+         }
+
+         if (wfile->fd == NULL)
+            ArgusLog (LOG_ERR, "ArgusWriteNewLogfile(%s, %p) fopen %s", file, (void *)argus, strerror(errno));
          else {
 #ifdef HAVE_FCNTL_H
             /* Locks are dropped when the file is closed or the process
@@ -33963,47 +33991,40 @@ setArgusWfile(struct ArgusParserStruct *parser, char *file, char *filter)
          } else
          if ((strncmp(parser->ArgusProgramName,  "rasplit", 7)) &&
              (strncmp(parser->ArgusProgramName, "rastream", 8))) {
-            struct stat statbuf;
+            /* Avoid a stat()-then-open() TOCTOU race: rather than probing
+             * for existence with stat() and separately acting on the
+             * path afterward, just try realpath() first (which requires
+             * the target to exist) and fall back to atomically creating
+             * it with open(O_CREAT|O_EXCL) only if it does not.
+             */
+            if ((ptr = realpath (file, NULL)) != NULL) {
+               ptr = strdup(ptr);
+            } else if (errno == ENOENT) {
+               int rawfd;
 
-            if ((stat(file, &statbuf)) < 0) {
-               switch (errno) {
-                  case ENOENT: {
-                     int rawfd;
+               rawfd = open(file, O_CREAT|O_EXCL|O_RDWR, 0644);
+               if ((rawfd < 0) && ((errno == ENOENT) || (errno == ENOTDIR))) {
+                  if (strncmp(parser->ArgusProgramName, "radium", 6))
+                     ArgusMkdirPath(file);
 
-                     rawfd = open(file, O_CREAT|O_EXCL|O_WRONLY, 0644);
-                     if ((rawfd < 0) && ((errno == ENOENT) || (errno == ENOTDIR))) {
-                        if (strncmp(parser->ArgusProgramName, "radium", 6))
-                           ArgusMkdirPath(file);
-
-                        rawfd = open(file, O_CREAT|O_EXCL|O_WRONLY, 0644);
-                     }
-
-                     if (rawfd < 0)
-                        ArgusLog (LOG_ERR, "setArgusWfile open %s %s", file, strerror(errno));
-                     else
-                        fd = fdopen(rawfd, "a+");
-
-                     if (fd != NULL) {
-                        fclose (fd);
-                        if ((ptr = realpath (file, NULL)) == NULL)
-                           ArgusLog (LOG_ERR, "setArgusWfile, realpath %s %s", file, strerror(errno));
-                        else
-                           ptr = strdup(ptr);
-                        unlink(file);
-                     }
-                     break;
-                  }
-
-                  default:
-                     ArgusLog (LOG_ERR, "%s %s", file, strerror(errno));
-                     break;
+                  rawfd = open(file, O_CREAT|O_EXCL|O_RDWR, 0644);
                }
 
-            } else {
-               if ((ptr = realpath (file, NULL)) == NULL)
-                  ArgusLog (LOG_ERR, "setArgusWfile, realpath %s %s", file, strerror(errno));
+               if (rawfd < 0)
+                  ArgusLog (LOG_ERR, "setArgusWfile open %s %s", file, strerror(errno));
                else
-                  ptr = strdup(ptr);
+                  fd = fdopen(rawfd, "a+");
+
+               if (fd != NULL) {
+                  fclose (fd);
+                  if ((ptr = realpath (file, NULL)) == NULL)
+                     ArgusLog (LOG_ERR, "setArgusWfile, realpath %s %s", file, strerror(errno));
+                  else
+                     ptr = strdup(ptr);
+                  unlink(file);
+               }
+            } else {
+               ArgusLog (LOG_ERR, "%s %s", file, strerror(errno));
             }
 /*
             So do we remove the file and start anew, or are we appending to the data?
@@ -35322,17 +35343,33 @@ bittok2str(const struct tok *lp, const char *fmt, int v)
           */
          if (tokval == (v&rotbit)) {
             /* ok we have found something */
-            buflen+=snprintf(buf+buflen, sizeof(buf)-buflen, "%s, ",lp->s);
+            int n = snprintf(buf+buflen, sizeof(buf)-buflen, "%s, ",lp->s);
+            if (n < 0)
+               break;
+            /* snprintf() returns the number of bytes that *would* have
+             * been written had the buffer been large enough; clamp so
+             * we never index buf[] out of bounds on a subsequent
+             * iteration or in the buflen-2 trim below.
+             */
+            if (n > (int)(sizeof(buf) - buflen - 1)) {
+               buflen = sizeof(buf) - 1;
+               goto full;
+            }
+            buflen += n;
             break;
          }
          rotbit=rotbit<<1; /* no match - lets shift and try again */
       }
       lp++;
    }
+full:
 
    if (buflen != 0) { /* did we find anything */
       /* yep, set the the trailing zero 2 bytes before to eliminate the last comma & whitespace */
-      buf[buflen-2] = '\0';
+      if (buflen >= 2)
+         buf[buflen-2] = '\0';
+      else
+         buf[0] = '\0';
       return (buf);
    } else {
       /* bummer - lets print the "unknown" message as advised in the fmt string if we got one */

--- a/examples/ramysql/rasqltimeindex.c
+++ b/examples/ramysql/rasqltimeindex.c
@@ -1148,7 +1148,7 @@ RaTimeSortQueue (struct ArgusQueueStruct *queue)
          qsort ((char *) queue->array, i, sizeof (struct ArgusQueueHeader *), RaTimeSortRoutine);
 
       } else
-         ArgusLog (LOG_ERR, "RaSortQueue: ArgusCalloc(%d, %d) %s\n", sizeof(struct ArgusRecord *),
+         ArgusLog (LOG_ERR, "RaSortQueue: ArgusCalloc(%zu, %d) %s\n", sizeof(struct ArgusRecord *),
                                                                      cnt, strerror(errno));
    }
 #ifdef ARGUSDEBUG


### PR DESCRIPTION
mismatches, TOCTOU races, and document accepted-risk data exposure

- #185/#186/#187/#94 (common/argus_util.c, ArgusPrintRecord): four snprintf(&buf[blen], (len - blen), ...) call sites clamped their size argument to (blen < len) ? (len - blen) : 0. snprintf() returns the number of bytes that *would have been* written, not the number actually written, so blen can exceed len after a truncated field; the old (len - blen) then underflows to a huge size_t, defeating the bounds check and risking real overflow.

- #91 (common/argus_util.c, bittok2str): the same snprintf-return- value overflow bug existed on the function's own static 256-byte buf (buflen += snprintf(...) could push buflen past sizeof(buf)). Clamped the increment, added a `full:` label to break out of both loops once the buffer is exhausted, and guarded the buf[buflen-2] trailing-comma trim so it can't underflow when buflen < 2.

- #90 (common/argus_util.c, ArgusMainInit): ArgusCalloc(%d,%d) used %d for a sizeof() (size_t) argument; changed to %zu.

- #87 (examples/ramysql/rasqltimeindex.c, RaSortQueue): same %d-for- sizeof() issue; changed to %zu.

- #82/#83/#84 (common/argus_util.c, ArgusReadConnection): "unknown source/stream type" log messages used 0x%x on a pointer (input), truncating on LP64; changed to %p with explicit (void *) casts.

- #72/#73/#74 (common/argus_util.c, ArgusWriteNewLogfile): "fflush"/ "fopen error" log messages used 0x%x on a struct ArgusRecord * (argus); changed to %p with explicit (void *) casts.

- #6 (common/argus_util.c, ArgusWriteNewLogfile): replaced the plain fopen(file, "a+") with open(file, O_CREAT|O_APPEND|O_WRONLY| O_NOFOLLOW, 0644) + fdopen(rawfd, "a"). This fails closed if the path has been swapped for a symlink since the periodic stat() earlier in the function (TOCTOU), and drops read access that was never used (wfile->fd is only ever fwrite/fflush/fseek'd, never read).

- #5/#183/#184 (common/argus_util.c, setArgusWfile): restructured the stat()-then-branch probe for a not-yet-existing write-file path. The stat() itself was the check-then-act half of the TOCTOU: it decided which branch to take, and the path could be swapped before the subsequent open()/realpath()/unlink(). Now tries realpath() first (which requires the target to already exist) and only falls back to atomically creating it with open(O_CREAT|O_EXCL|O_RDWR) on ENOENT, removing the stat() call entirely. (O_RDWR, not O_WRONLY, because the probe fd is fdopen()'d as "a+"; opening write-only and fdopen()'ing read+write fails with EINVAL on this platform -- this was caught by manual verification of -w file output, see below.)

- #9 (common/argus_util.c, ArgusReadConnection): re-detection of the "START:" message sent to remote argus/radium servers containing the local user name (pw->pw_name), program name, and pid. Traced the full data flow: the server (ArgusCheckClientMessage/ RADIUM_START in argus_output.c) stores this only as client-> clientid, used exclusively in human-readable log/diagnostic messages -- never for authentication, authorization, or any other access-control decision. This is an intentional client session- identification feature of the existing wire protocol, not an accidental leak. Added an inline comment documenting this as an accepted risk (operators concerned about exposure on untrusted networks should tunnel argus/radium connections over TLS/SSH) rather than changing protocol/wire behavior.

Verified:
- Full clean rebuild (make clean && make -j4): 0 errors, 0 warnings.
- Smoke test (ra/radump/radns against dump_dir_2_thinwin_rdp.argus.out) yields 44/44/10 lines, matching baseline.
- ra -w <file>, -w <existing file> (append), and -w - (stdout) all verified: -w to a new file now produces output byte-identical to the pre-regression baseline (previously a 0-byte file with binary data leaking to stdout, caused by the O_WRONLY/fdopen("a+") mode mismatch above); append correctly doubles record count; -w - streams the expected byte count to stdout.