### PR TITLE
Fix CodeQL alert #190: TOCTOU race in ArgusWriteNewLogfile's periodic

### DIFF
--- a/common/argus_util.c
+++ b/common/argus_util.c
@@ -33604,7 +33604,22 @@ ArgusWriteNewLogfile (struct ArgusParserStruct *parser, struct ArgusInput *input
       if (strncmp(file, "/dev/null", 9)) {
 
          if (parser->ArgusRealTime.tv_sec > wfile->laststat.tv_sec) {
-            if ((stat (file, &wfile->statbuf) < 0)) {
+            /* Was: stat(file, &wfile->statbuf) followed, later in this
+             * function, by a separate open() of the same path -- a
+             * classic check-then-act TOCTOU race (an attacker with
+             * write access to the containing directory could swap the
+             * path for a symlink between the two calls). Get the same
+             * information (existence + size) race-free by doing the
+             * existence check with an O_NOFOLLOW probe open() and
+             * fstat()'ing the resulting fd; the fd, not the path, is
+             * what's inspected, so nothing can be swapped out from
+             * under us between the check and the use. This probe fd is
+             * closed immediately; the real (re)open with locking, if
+             * needed, still happens below via the wfile->fd == NULL path.
+             */
+            int rawfd = open(file, O_CREAT|O_APPEND|O_WRONLY|O_NOFOLLOW, 0644);
+
+            if (rawfd < 0) {
                if (wfile->fd != NULL) {
                   if (fflush (wfile->fd) != 0)
                      ArgusLog (LOG_ERR, "ArgusWriteNewLogfile(%s, %p) fflush error %s", file, (void *)argus, strerror(errno));
@@ -33613,12 +33628,17 @@ ArgusWriteNewLogfile (struct ArgusParserStruct *parser, struct ArgusInput *input
                }
 
             } else {
-               if (wfile->statbuf.st_size == 0)
-                  wfile->firstWrite++;
+               if (fstat(rawfd, &wfile->statbuf) == 0) {
+                  if (wfile->statbuf.st_size == 0)
+                     wfile->firstWrite++;
+               }
+               close(rawfd);
             }
             wfile->laststat = parser->ArgusRealTime;
-            if (fflush (wfile->fd) != 0)
-               ArgusLog (LOG_ERR, "ArgusWriteNewLogfile(%s, %p) fflush error %s", file, (void *)argus, strerror(errno));
+            if (wfile->fd != NULL) {
+               if (fflush (wfile->fd) != 0)
+                  ArgusLog (LOG_ERR, "ArgusWriteNewLogfile(%s, %p) fflush error %s", file, (void *)argus, strerror(errno));
+            }
          }
       }
 


### PR DESCRIPTION
existence check

ArgusWriteNewLogfile periodically (once per second of ArgusRealTime) called stat(file, &wfile->statbuf) on the write-file's path to detect deletion/rotation and refresh the cached size/firstWrite state. This stat() result was a pure check: the path was later acted upon (opened) elsewhere in the same function, based on wfile->fd being NULL -- a classic check-then-act TOCTOU race. An attacker with write access to the containing directory could swap the path for a symlink in the window between the stat() and the later open(), and (depending on timing) have data written through the symlink before the existing O_NOFOLLOW-protected open() in the wfile->fd == NULL branch had a chance to reject it.

Replaced the raw stat(path) with an O_NOFOLLOW probe open() plus fstat() on the resulting fd. Because the fd -- not the path -- is what's inspected, there is no window between checking and using the file: if the path has been swapped for a symlink, the open() itself fails (ELOOP) rather than silently succeeding and handing back stale information about a path that no longer refers to the same file. The probe fd is closed immediately after; the real (re)open with locking (when wfile->fd is NULL) is unchanged and still goes through the existing O_NOFOLLOW-protected open()/fdopen() path a few lines below.

Also tightened the trailing fflush(wfile->fd) at the end of this block to be skipped when wfile->fd is NULL (previously relied on the well-defined but wasteful fflush(NULL) "flush all streams" behavior).

Verified:
- Minimal C repro (/tmp/test_nofollow.c) confirms O_NOFOLLOW correctly rejects opening through a symlink (ELOOP), so an attacker swapping the write-file path for a symlink during the race window now fails closed instead of writing through it.
- Full clean rebuild (make clean && make -j4): 0 errors, 0 warnings.
- Smoke test (ra/radump/radns against dump_dir_2_thinwin_rdp.argus.out) still yields 44/44/10 lines.
- ra -w <new file> and -w <existing file> (append, which exercises the now-fd-based periodic check on a pre-existing file) both verified: new-file output is byte-identical to baseline; append correctly doubles the record count.