### PR TITLE
Fix typo in configure.ac: with_pythonllib -> with_pythonlib

### DIFF
--- a/configure
+++ b/configure
@@ -12631,7 +12631,7 @@ if test "x$HAVE_SWIG" = "xyes" ; then
         ;;
   *)
 if test "x$HAVE_PYTHON_NUMPY" = "xyes"; then
-   if test "x$with_pythonllib" = "xyes"; then
+   if test "x$with_pythonlib" = "xyes"; then
         DIRS="$DIRS ./pythonlib"
    fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -537,7 +537,7 @@ if test "x$HAVE_SWIG" = "xyes" ; then
         ;;
   *)
 if test "x$HAVE_PYTHON_NUMPY" = "xyes"; then
-   if test "x$with_pythonllib" = "xyes"; then
+   if test "x$with_pythonlib" = "xyes"; then
         DIRS="$DIRS ./pythonlib"
    fi
 fi


### PR DESCRIPTION
The SWIG-conditional block that decides whether to add ./pythonlib to DIRS (non-Darwin, HAVE_SWIG=yes, HAVE_PYTHON_NUMPY=yes) checked the misspelled shell variable $with_pythonllib (double "l") instead of $with_pythonlib. Since acsite.m4's AC_ARG_WITH(pythonlib, ...) never sets that misspelled name, the check was always false, making this branch permanently dead code -- it could never add ./pythonlib to DIRS regardless of --with-pythonlib being passed or numpy/swig being present.

Practical impact was limited: the earlier, unconditional 'if test "$with_pythonlib" != no; then DIRS="$DIRS ./pythonlib"; fi' block (added in dfca903, "make perllib and pythonlib optional") still correctly adds ./pythonlib whenever --with-pythonlib is passed on the command line, on any platform. The typo only affected this specific, narrower SWIG+numpy-gated code path.

Investigated whether to instead port over an alternate restructuring from the old, now-deleted 'carter/perlPythonlib' branch (which also touched this logic, among other unrelated pre-CodeQL-era history) but that branch had diverged 140+ commits behind main and its version of this block was otherwise equivalent for the cases exercised here, so a minimal, targeted typo fix was preferable to reintroducing stale history.

Regenerating configure via 'autoconf' (2.73) instead of hand-editing produces ~8400 lines of unrelated boilerplate churn, because this repo's configure was last generated with autoconf 2.71 and the two versions differ in their generated shell-portability shims/comments/ copyright years. Hand-edited configure identically to the one-line configure.ac change instead, to keep the diff minimal and scoped to this fix; the two files remain consistent for this change.

Verified:
- ./configure (no flags): 0 errors, DIRS unaffected (as expected, since --with-pythonlib wasn't passed).
- ./configure --with-perllib --with-pythonlib: DIRS correctly includes both ./perllib and ./pythonlib (via the pre-existing unconditional block); a swig.stamp/distutils build failure seen in that configuration is a pre-existing environment issue (missing Python 'distutils' module), reproduced identically on unmodified main via git stash, confirming it's not a regression from this fix.
- Full clean rebuild with default (no perl/python) configuration: 0 errors, 0 warnings.
- Smoke test (ra/radump/radns against dump_dir_2_thinwin_rdp.argus.out) still yields 44/44/10 lines.