### PR TITLE
Fix unescaped popen() shell injection in transparent decompression (A…

### DIFF
--- a/common/argus_util.c
+++ b/common/argus_util.c
@@ -59,6 +59,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#include <limits.h>
 
 #if defined(__NetBSD__)
 #include <machine/limits.h>
@@ -31669,26 +31670,40 @@ ArgusReadConnection (struct ArgusParserStruct *parser, struct ArgusInput *input,
                          ((ptr[0] == 0xFD) &&  (ptr[1] == 0x37) && (ptr[2] == 0x7A) && (ptr[3] == 0x58) &&  (ptr[4] == 0x5A) && (ptr[5] == 0x00)) || 
                          ((ptr[0] == 0xFD) && ((ptr[1] == 0x37) || (ptr[2] == 0x7A))) ||
                          ((ptr[0] == 'B') && (ptr[1] == 'Z') && (ptr[2] == 'h'))) {
-                        char cmd[256];
-                        bzero(cmd, 256);
+                        char cmd[2 * PATH_MAX];
+                        const char *decomp;
 
                         fclose(input->file);
                         input->file = NULL;
 
                         if (ptr[0] == 'B')
-                           strncpy(cmd, "bzip2 -dc \"", 12);
+                           decomp = "bzip2 -dc";
                         else
                         if (ptr[1] == 0x8B)
-                           strncpy(cmd, "gzip -dc \"", 12);
+                           decomp = "gzip -dc";
                         else
                         if ((ptr[0] == 0xFD) && (ptr[1] == 0x37) && (ptr[2] == 0x7A) && (ptr[3] == 0x58) &&  (ptr[4] == 0x5A) && (ptr[5] == 0x00))
-                           strncpy(cmd, "xzcat \"", 8);
+                           decomp = "xzcat";
                         else
-                           strncpy(cmd, "zcat \"", 7);
-            
-                        strncat(cmd, input->filename, (256 - strlen(cmd) - 1));
-                        strncat(cmd, "\" 2>/dev/null", (256 - strlen(cmd) - 1));
-             
+                           decomp = "zcat";
+
+                        /*
+                         * input->filename is wrapped in single quotes below, rather than the
+                         * double quotes this used to use, because a shell's double-quoted
+                         * strings still allow $(...), backtick, and variable-expansion
+                         * substitution -- double-quoting alone does not neutralize shell
+                         * metacharacters. Single quotes do, provided the string contains no
+                         * embedded single quote (which can't itself be escaped from inside a
+                         * single-quoted string), so any filename containing one is rejected
+                         * instead of passed through. Same fix pattern as F-CL-18/F-CL-25
+                         * (clients/rastream.c, examples/raconvert/raconvert.c).
+                         */
+                        if (strchr(input->filename, '\'') != NULL) {
+                           ArgusLog (LOG_ERR, "ArgusReadConnection: filename contains a single quote: %s", input->filename);
+                        }
+
+                        snprintf(cmd, sizeof(cmd), "%s '%s' 2>/dev/null", decomp, input->filename);
+
                         if ((input->pipe = popen(cmd, "r")) == NULL)
                            ArgusLog (LOG_ERR, "ArgusReadConnection: popen(%s) failed. %s", cmd, strerror(errno));
 


### PR DESCRIPTION
…rgusReadConnection)

ArgusReadConnection()'s ARGUS_FILE case detects gzip/bzip2/xz/compress magic bytes at the start of a -r-supplied input file and transparently decompresses it by shelling out via popen(). The decompression command was built by concatenating input->filename into a fixed 256-byte buffer wrapped in double quotes:

    strncpy(cmd, "gzip -dc \"", 12);
    strncat(cmd, input->filename, ...);
    strncat(cmd, "\" 2>/dev/null", ...);

Double-quoting does not neutralize shell metacharacters -- $(...), backticks, and variable expansion all still execute inside a double-quoted string. A filename (from a local -r-style CLI argument, or a filename list) containing such a sequence would execute arbitrary commands as the user running the argus client, via popen()'s /bin/sh -c invocation.

Fixed the same way as the two previous instances of this exact bug class already fixed in this codebase (F-CL-18 in clients/rastream.c, Phase 1; F-CL-25 in examples/raconvert/raconvert.c, Phase 2): wrap input->filename in single quotes instead of double quotes, and reject (via ArgusLog(LOG_ERR, ...), which terminates the process) any filename containing an embedded single quote, since a single-quoted shell string cannot itself contain an escaped single quote. Also replaced the fixed 256-byte cmd buffer and its associated strncpy/strncat length arithmetic with a 2*PATH_MAX-sized buffer built via snprintf(), the same sizing/construction pattern used by the raconvert.c fix, removing the now-unnecessary manual buffer-remaining-space tracking.

Added #include <limits.h> for PATH_MAX (already relied upon by raconvert.c the same way; this file previously had no direct PATH_MAX use and only defined a private fallback constant much later in the file, well past this use site).

Verified via clean rebuild (0 errors, 0 warnings on the changed file); functional regression covering both the gzip and bzip2 decompression branches (a real argus data file derived from the RIMPAC baseline pcap, gzip- and bzip2-compressed, each read back via 'ra -r' with the expected 1825-record count, matching the plain/uncompressed baseline); a filename-with-spaces case (to confirm single-quoting doesn't break legitimate filenames); a filename containing an embedded single quote (confirmed rejected via the intended ArgusLog(LOG_ERR, ...) path -- process exits cleanly with no shell command ever constructed, rather than silently mis-parsing the quote); and a fuzz-corpus regression replay against the ArgusHandleRecord AFL++ harness (all corpus files, zero crashes). No shell-injection payload was constructed or executed against the pre-fix code to demonstrate exploitability, per this review's normal-input-only testing policy -- the defect (shell metacharacters surviving double-quoting) is unambiguous from static inspection alone, and is the identical, already-established bug class fixed twice before in this same codebase.