### PR TITLE
Disable unauthenticated remote FILE: read command in radium/argus out…

### DIFF
--- a/common/argus_output.c
+++ b/common/argus_output.c
@@ -4154,7 +4154,15 @@ char *ArgusClientCommands[ARGUSMAXCLIENTCOMMANDS] =
    "FILTER:",
    "MODEL:",
    "PROJECT:",
-   "FILE:",
+   /*
+    * "FILE:" (RADIUM_FILE) intentionally disabled -- see the commented-out
+    * case RADIUM_FILE block below for detail. Setting this entry to NULL
+    * means the command-matching loop's "ArgusClientCommands[i] != NULL"
+    * guard skips it entirely, so a client sending "FILE:..." now just falls
+    * through to the generic "unrecognized command" log path instead of
+    * ever reaching ArgusSendFile().
+    */
+   NULL,
 };
 
 
@@ -4290,12 +4298,32 @@ ArgusCheckClientMessage (struct ArgusOutputStruct *output, struct ArgusClientDat
                                  break;
 
                               case RADIUM_FILE: {
-                                 char *file = &ptr[6];
+                                 /*
+                                  * Remote-file-read support disabled: this command let any
+                                  * connected client request that this server read an
+                                  * arbitrary local file (via ArgusSendFile() below, which
+                                  * takes the client-supplied path unvalidated into stat()
+                                  * and fopen()) and stream its contents back over the
+                                  * client connection, with no authentication or path
+                                  * restriction of any kind. Rather than build out proper
+                                  * access control (an explicit opt-in configuration option,
+                                  * path allow-listing, and/or requiring an authenticated
+                                  * session) for a feature with no currently known caller
+                                  * relying on it, this handler is disabled outright.
+                                  *
+                                  * ArgusClientCommands[RADIUM_FILE] is set to NULL above,
+                                  * so this case is not reachable via that dispatch path
+                                  * regardless; this block is also commented out so that
+                                  * restoring the NULL entry alone is not sufficient to
+                                  * re-enable this behavior.
+                                  *
+                                  * char *file = &ptr[6];
 #ifdef ARGUSDEBUG
                                  ArgusDebug (3, "ArgusCheckClientMessage: ArgusFile %s requested.\n", file);
 #endif
                                  ArgusSendFile (output, client, file, 0);
                                  retn = 5;
+                                 */
                                  break;
                               }
                            }


### PR DESCRIPTION
…put server

ArgusCheckClientMessage()'s RADIUM_FILE command handler let any client connected to a running radium (or 'argus -B') output server request an arbitrary local file by sending 'FILE:<path>' over the client connection. The path came directly from client-supplied network input ("char *file = &ptr[6];") with no validation, and was passed unmodified into ArgusSendFile(), which stat()s and fopen()s it and streams its contents back to the client -- readable by whatever user the server process runs as, with no authentication check gating this command and no restriction on which paths could be requested.

Rather than build out proper access control (an opt-in configuration option, path allow-listing, and/or requiring an authenticated session) for a feature with no currently known caller relying on it, this command is disabled outright:

- ArgusClientCommands[RADIUM_FILE] (the "FILE:" string radium matches incoming client messages against) is set to NULL, so the command- matching loop's own "ArgusClientCommands[i] != NULL" guard skips it entirely -- a client sending "FILE:..." now falls through to the generic unrecognized-command log path.
- The RADIUM_FILE case body (the call into ArgusSendFile()) is also commented out, so restoring the NULL entry alone would not be sufficient to re-enable this behavior; a deliberate code change is required.

ArgusSendFile() itself and its declaration are left in place, unused, since it is not otherwise reachable and removing it is out of scope for this fix.

Verified via clean rebuild (0 errors), and a normal radium/ra end-to-end regression test: radium serving a real argus data file (derived from the RIMPAC baseline pcap) over a local TCP listener, with an ra client connecting and successfully receiving the MAR status header, confirming the ordinary client START/connection lifecycle is unaffected by this change. The standard RIMPAC-pcap smoke test (bin/ra -r ... -c ',') also confirmed unaffected (1825 records, unchanged). No FILE: exploitation attempt was made against the pre-fix binary; the defect (unauthenticated arbitrary local file read via a documented command dispatch table) is unambiguous from static inspection alone.