### PR TITLE
Fix top-level Makefile.in install: target masking sub-make failures

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -81,7 +81,7 @@ examples: common
 include: common
 
 install: install-perl force installdirs
-	@for i in  $(INSTDIRS) ; do \
+	@set -e ; for i in  $(INSTDIRS) ; do \
 		if [ -d $$i ] ; then \
 		echo "making in $$i"; \
 		(cd $$i > /dev/null; $(MAKE) install); \


### PR DESCRIPTION
The all: target already correctly uses "@set -e ; for i in $(DIRS) ..." to propagate build failures from subdirectories. The install: target's loop over $(INSTDIRS) was missing that "set -e", so a failure while installing one subdirectory (e.g. a stale/missing build artifact, or a compile error triggered by installs' "force all" dependency) was silently ignored and the loop continued installing every remaining directory, with "make install" ultimately reporting exit code 0.

Fix: add "set -e" to the install: loop, matching the existing correct
pattern already used by all: in this same file.

Verified:
- Reproduced the bug on unmodified main: injected a deliberate syntax error into common/argus_code.c and ran "make install" with a scratch DESTDIR. common/ failed to compile, but the loop continued into ./include, ./clients, ./examples and every example subdirectory, and "make install" exited 0 -- a broken install reported as success.
- With the fix, the same injected error now causes "make install" to stop immediately after common/ fails, with exit code 2.
- Reverted the injected error, confirmed clean rebuild (make clean && make -j4): 0 errors, 0 warnings.
- Standard pcap smoke test (dump_dir_2_thinwin_rdp.pcap -> ra -c ',', radump -s +suser,duser -v, radns -v): 44/44/10 lines, matches baseline.
- Confirmed the fix does not break the normal successful install path: "make install DESTDIR=..." with no injected failure still exits 0 and installs ra/radump/etc. as expected.