### PR TITLE
Remove false 'make check' claim from ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -345,9 +345,13 @@ clients/
 ```bash
 ./configure              # Detect system capabilities
 make                     # Build all components
-make check               # Run tests
 sudo make install        # Install to system
 ```
+
+There is no `make check` target — this project does not have an automated test suite runnable via
+the standard Autotools `check:` convention. Changes are verified via functional smoke testing against
+real capture data (e.g. `ra`/`radump`/`radns` against a known-good `.argus` file) and, for the
+`common/` record-parsing code, the fuzz-regression corpus under `security-review/fuzz/`.
 
 ---
 


### PR DESCRIPTION
ARCHITECTURE.md's Build Process section instructed contributors to run 'make check' as a normal build/test step. No such target exists anywhere in this project's build system (confirmed: zero 'check:' target definitions across every Makefile.in in the tree, including common/, clients/, examples/*, and pkg/), and this project uses raw autoconf with hand-written Makefiles, not automake, so there is no implicit expectation of an automake-generated check: target either. Running 'make check' fails with 'No rule to make target `check''.

This was raised by a follow-up review pass as a suspected build-system gap, but on inspection this project never had an automated test suite behind that target -- there's no evidence one was ever built or removed. Reclassified from 'missing build feature' to 'documentation accuracy issue' and fixed accordingly: the false claim is corrected rather than manufacturing a check: target retroactively to match documentation that was never accurate.

The doc now points readers at the actual verification method used throughout this project: functional smoke testing against real capture data via ra/radump/radns, and the fuzz-regression corpus under security-review/fuzz/ for common/ record-parsing changes.